### PR TITLE
Extend date window to 5 days for conciliation request filtering and delete retry count

### DIFF
--- a/src/contexts/conciliation/domain/rules/DateWindowRule.ts
+++ b/src/contexts/conciliation/domain/rules/DateWindowRule.ts
@@ -1,6 +1,6 @@
 import { CandidateTransaction, RequestData } from '../ConciliationEngine.js'
 
-export function applyDateWindowRule(request: RequestData, candidates: CandidateTransaction[], windowDays = 3): CandidateTransaction[] {
+export function applyDateWindowRule(request: RequestData, candidates: CandidateTransaction[], windowDays = 5): CandidateTransaction[] {
   const from = new Date(request.createdAt)
   from.setDate(from.getDate() - windowDays)
   return candidates.filter(t => t.receivedAt >= from)

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ EventBus.subscribe<TransactionIngestedEvent>('TransactionIngested', async (event
     `SELECT id FROM conciliation_requests
      WHERE account_id = $1
        AND status IN ('pending', 'not_found')
-       AND retry_count < 3`,
+       AND created_at > now() - interval '5 days'`,
     [event.accountId]
   )
 


### PR DESCRIPTION
This pull request updates the date window logic for conciliation requests to ensure that only recent requests are considered during transaction ingestion and date-based filtering. The main focus is to expand the window for eligible requests and candidates from 3 to 5 days.

**Date window adjustments:**

* Increased the date window in the `applyDateWindowRule` function from 3 to 5 days, so candidate transactions are now filtered based on a 5-day window prior to the request's creation (`src/contexts/conciliation/domain/rules/DateWindowRule.ts`).
* Updated the SQL query in the transaction ingestion event handler to select conciliation requests created within the last 5 days, instead of limiting by retry count (`src/index.ts`).