### PR TITLE
fix: use correct 'not_found' status in conciliation attempt

### DIFF
--- a/src/contexts/conciliation/application/RunConciliationUseCase.ts
+++ b/src/contexts/conciliation/application/RunConciliationUseCase.ts
@@ -85,7 +85,7 @@ export class RunConciliationUseCase {
           accountId: request.accountId,
           requestId,
           attemptNumber,
-          status: result.status === 'ambiguous' ? 'ambiguous' : 'no_match',
+          status: result.status === 'ambiguous' ? 'ambiguous' : 'not_found',
           failureType: result.status === 'ambiguous' ? 'multiple_candidates' : 'rule_miss',
           candidateIds: result.candidateIds,
         })


### PR DESCRIPTION
## Summary
- Fix typo in conciliation attempt status: `no_match` -> `not_found`.

## Test plan
- [ ] Trigger a conciliation with no matching transactions and verify attempt status is `not_found`.

Made with [Cursor](https://cursor.com)