### PR TITLE
feat: notify webhook on ambiguous conciliation result

### DIFF
--- a/src/contexts/conciliation/application/NotifyWebhookUseCase.ts
+++ b/src/contexts/conciliation/application/NotifyWebhookUseCase.ts
@@ -12,12 +12,14 @@ export class NotifyWebhookUseCase {
        WHERE cr.id = $1`,
       [requestId]
     )
-    if (!req?.webhook_url || req.status !== 'matched') return
+    if (!req?.webhook_url || !['matched', 'ambiguous'].includes(req.status)) return
 
-    const { rows: [match] } = await db.query(
-      `SELECT id FROM conciliated_transactions WHERE request_id = $1 AND is_primary = true`,
-      [requestId]
-    )
+    const match = req.status === 'matched'
+      ? (await db.query(
+          `SELECT id FROM conciliated_transactions WHERE request_id = $1 AND is_primary = true`,
+          [requestId]
+        )).rows[0]
+      : null
 
     const headers: Record<string, string> = { 'Content-Type': 'application/json' }
     const webhookToken = typeof req.webhook_auth_token === 'string' && req.webhook_auth_token.trim()
@@ -30,6 +32,7 @@ export class NotifyWebhookUseCase {
 
     const webhookBody = JSON.stringify({
       external_id: req.external_id,
+      status:      req.status,
       amount:      Number(req.expected_amount),
       currency:    req.currency,
       sender_name: req.sender_name ?? null,

--- a/src/contexts/conciliation/application/RunConciliationUseCase.ts
+++ b/src/contexts/conciliation/application/RunConciliationUseCase.ts
@@ -85,7 +85,7 @@ export class RunConciliationUseCase {
           accountId: request.accountId,
           requestId,
           attemptNumber,
-          status: result.status === 'ambiguous' ? 'ambiguous' : 'no_match',
+          status: result.status === 'ambiguous' ? 'ambiguous' : 'not_found',
           failureType: result.status === 'ambiguous' ? 'multiple_candidates' : 'rule_miss',
           candidateIds: result.candidateIds,
         })

--- a/src/contexts/conciliation/application/RunConciliationUseCase.ts
+++ b/src/contexts/conciliation/application/RunConciliationUseCase.ts
@@ -7,6 +7,7 @@ import { IConciliatedTransactionRepository } from '../domain/IConciliatedTransac
 import { ConciliationRequestRepository } from '../infrastructure/ConciliationRequestRepository.js'
 import { ConciliationAttemptRepository } from '../infrastructure/ConciliationAttemptRepository.js'
 import { ConciliatedTransactionRepository } from '../infrastructure/ConciliatedTransactionRepository.js'
+import { Queues } from '../../../shared/infrastructure/queues/QueueRegistry.js'
 import crypto from 'crypto'
 
 interface JobData { requestId: string }
@@ -96,5 +97,13 @@ export class RunConciliationUseCase {
 
     await EventBus.publishAll(request.domainEvents)
     request.clearDomainEvents()
+
+    if (result.status === 'ambiguous') {
+      await Queues.webhook.add(
+        'notify',
+        { requestId },
+        { jobId: `webhook_ambiguous_${requestId}`, removeOnComplete: true }
+      )
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Enqueue webhook notification when conciliation result is `ambiguous`.
- Allow `ambiguous` in webhook notifier and include `status` in payload.

## Test plan
- [ ] Produce an ambiguous conciliation (multiple candidates) and verify a webhook job is enqueued.
- [ ] Verify webhook payload includes `status: \"ambiguous\"`.

Made with [Cursor](https://cursor.com)