### PR TITLE
Add 'expired' status translation for English and Spanish

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -145,7 +145,8 @@
       "processing": "Processing",
       "not_found": "Not found",
       "ambiguous": "Ambiguous",
-      "failed": "Failed"
+      "failed": "Failed",
+      "expired": "Expired"
     },
     "scriptStatus": {
       "draft": "Draft",

--- a/client/src/i18n/es.json
+++ b/client/src/i18n/es.json
@@ -145,7 +145,8 @@
       "processing": "Procesando",
       "not_found": "No encontrado",
       "ambiguous": "Ambiguo",
-      "failed": "Fallido"
+      "failed": "Fallido",
+      "expired": "Expirado"
     },
     "scriptStatus": {
       "draft": "Borrador",


### PR DESCRIPTION
This pull request adds a new status label, "Expired", to both the English and Spanish localization files. This will allow the UI to display an "Expired" status in both languages where appropriate.

Localization updates:

* Added the `"expired"` status to the `status` section in `client/src/i18n/en.json` for English translations.
* Added the `"expired"` status to the `status` section in `client/src/i18n/es.json` for Spanish translations.