### PR TITLE
Add search functionality and translations to conciliations page

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -62,7 +62,8 @@
     "colCurrency": "Currency",
     "colSender": "Sender",
     "colStatus": "Status",
-    "colCreated": "Created"
+    "colCreated": "Created",
+    "searchPlaceholder": "Search by ID, sender, amount..."
   },
   "scripts": {
     "title": "Scripts",

--- a/client/src/i18n/es.json
+++ b/client/src/i18n/es.json
@@ -62,7 +62,8 @@
     "colCurrency": "Moneda",
     "colSender": "Remitente",
     "colStatus": "Estado",
-    "colCreated": "Creada"
+    "colCreated": "Creada",
+    "searchPlaceholder": "Buscar por ID, remitente, monto..."
   },
   "scripts": {
     "title": "Scripts",

--- a/client/src/pages/Conciliations.tsx
+++ b/client/src/pages/Conciliations.tsx
@@ -1,7 +1,9 @@
+import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { api } from '@/lib/api'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useTranslation } from 'react-i18next'
@@ -77,8 +79,21 @@ function OrdersTable({ requests, accounts, showAccount }: { requests: Conciliati
   )
 }
 
+function filterRequests(requests: ConciliationRequest[], query: string, t: (key: string) => string): ConciliationRequest[] {
+  if (!query) return requests
+  const q = query.toLowerCase()
+  return requests.filter(r =>
+    r.external_id.toLowerCase().includes(q) ||
+    (r.sender_name && r.sender_name.toLowerCase().includes(q)) ||
+    String(r.expected_amount).includes(q) ||
+    r.currency.toLowerCase().includes(q) ||
+    t(`enums.conciliationStatus.${r.status}`).toLowerCase().includes(q)
+  )
+}
+
 export function Conciliations() {
   const { t } = useTranslation()
+  const [search, setSearch] = useState('')
 
   const { data: requests = [], isLoading: loadingReqs } = useQuery<ConciliationRequest[]>({
     queryKey: ['conciliations'],
@@ -91,12 +106,21 @@ export function Conciliations() {
   })
 
   const isLoading = loadingReqs || loadingAccounts
+  const filtered = filterRequests(requests, search, t)
 
   return (
     <div className="p-8 space-y-6">
-      <div>
-        <h2 className="text-2xl font-semibold">{t('conciliations.title')}</h2>
-        <p className="text-muted-foreground">{t('conciliations.subtitle')}</p>
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-semibold">{t('conciliations.title')}</h2>
+          <p className="text-muted-foreground">{t('conciliations.subtitle')}</p>
+        </div>
+        <Input
+          placeholder={t('conciliations.searchPlaceholder')}
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          className="max-w-xs"
+        />
       </div>
 
       {isLoading ? (
@@ -116,7 +140,7 @@ export function Conciliations() {
             <Card>
               <CardHeader><CardTitle>{t('conciliations.orders')}</CardTitle></CardHeader>
               <CardContent>
-                <OrdersTable requests={requests} accounts={accounts} showAccount />
+                <OrdersTable requests={filtered} accounts={accounts} showAccount />
               </CardContent>
             </Card>
           </TabsContent>
@@ -128,7 +152,7 @@ export function Conciliations() {
                   <CardTitle>{account.name || account.bank}</CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <OrdersTable requests={requests.filter(r => r.account_id === account.id)} accounts={accounts} />
+                  <OrdersTable requests={filtered.filter(r => r.account_id === account.id)} accounts={accounts} />
                 </CardContent>
               </Card>
             </TabsContent>


### PR DESCRIPTION
This pull request adds a search and filter feature to the Conciliations page, allowing users to quickly find requests by ID, sender, amount, currency, or status. It also updates the English and Spanish translations to include a search placeholder.

**Search and Filtering Functionality:**

* Added a search input to the Conciliations page UI, allowing users to filter requests in real time by ID, sender, amount, currency, or status (`Conciliations.tsx`). [[1]](diffhunk://#diff-0ed0feae3559e271512a6e6d42a5249824d9464515890d2a6bd7c412b8349458R1-R6) [[2]](diffhunk://#diff-0ed0feae3559e271512a6e6d42a5249824d9464515890d2a6bd7c412b8349458R82-R96) [[3]](diffhunk://#diff-0ed0feae3559e271512a6e6d42a5249824d9464515890d2a6bd7c412b8349458R109-R124)
* Implemented a `filterRequests` function to handle the filtering logic based on the search query (`Conciliations.tsx`).
* Updated the rendering of `OrdersTable` to use the filtered list of requests, both for the overall list and per-account tabs (`Conciliations.tsx`). [[1]](diffhunk://#diff-0ed0feae3559e271512a6e6d42a5249824d9464515890d2a6bd7c412b8349458L119-R143) [[2]](diffhunk://#diff-0ed0feae3559e271512a6e6d42a5249824d9464515890d2a6bd7c412b8349458L131-R155)

**Localization:**

* Added a `searchPlaceholder` entry to both English and Spanish translation files for the search input (`en.json`, `es.json`). [[1]](diffhunk://#diff-4ff768c3b7cbc0b99efd419ca4dbb0354dd4c09a0df1792551a2c0e7a6afb1f2L65-R66) [[2]](diffhunk://#diff-f15fde526479c9f454b4ac66327c362fed5b662075455e91061fd864d9052a44L65-R66)