### PR TITLE
Enhance search functionality with clear button on conciliations page

### DIFF
--- a/client/src/pages/Conciliations.tsx
+++ b/client/src/pages/Conciliations.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useTranslation } from 'react-i18next'
+import { X } from 'lucide-react'
 
 const statusVariant: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
   matched:    'default',
@@ -115,12 +116,23 @@ export function Conciliations() {
           <h2 className="text-2xl font-semibold">{t('conciliations.title')}</h2>
           <p className="text-muted-foreground">{t('conciliations.subtitle')}</p>
         </div>
-        <Input
-          placeholder={t('conciliations.searchPlaceholder')}
-          value={search}
-          onChange={e => setSearch(e.target.value)}
-          className="max-w-xs"
-        />
+        <div className="relative max-w-xs w-full">
+          <Input
+            placeholder={t('conciliations.searchPlaceholder')}
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            className={search ? 'pr-8' : ''}
+          />
+          {search && (
+            <button
+              type="button"
+              onClick={() => setSearch('')}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
+        </div>
       </div>
 
       {isLoading ? (


### PR DESCRIPTION
This pull request improves the search input UX in the `Conciliations` page by adding a clear ("X") button to the search field, allowing users to easily clear their search query. The change also slightly adjusts the input styling for better alignment when the clear button is present.

**UI/UX Improvements:**

* Added a clear ("X") button inside the search input field that appears when there is text in the input, allowing users to quickly clear the search. (`client/src/pages/Conciliations.tsx`)
* Adjusted the input styling to add padding on the right when the clear button is visible, ensuring the button does not overlap the text. (`client/src/pages/Conciliations.tsx`)
* Imported the `X` icon from `lucide-react` to use as the clear button icon. (`client/src/pages/Conciliations.tsx`)