### PR TITLE
Update webhook payload description for payment method inclusion

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -132,7 +132,7 @@
     "body": "Body (JSON)",
     "webhooks": "Webhooks",
     "webhookPayload": "Payload you'll receive",
-    "webhookPayloadDesc": "When an order is successfully reconciled, a POST will be sent to this URL with:",
+    "webhookPayloadDesc": "When an order is successfully reconciled, a POST will be sent to this URL. If the polling body includes payment_method_id, it will also be forwarded in the payload:",
     "webhookUrl": "Webhook URL (notifications)",
     "intervals": "Intervals and retries",
     "interval": "Interval (seconds)",

--- a/client/src/i18n/es.json
+++ b/client/src/i18n/es.json
@@ -132,7 +132,7 @@
     "body": "Body (JSON)",
     "webhooks": "Webhooks",
     "webhookPayload": "Payload que vas a recibir",
-    "webhookPayloadDesc": "Cuando una orden sea conciliada exitosamente, se enviará un POST a esta URL con:",
+    "webhookPayloadDesc": "Cuando una orden sea conciliada exitosamente, se enviará un POST a esta URL. Si el body de polling incluye payment_method_id, también se incluirá en el payload:",
     "webhookUrl": "Webhook URL (notificaciones)",
     "intervals": "Intervalos y reintentos",
     "interval": "Intervalo (segundos)",

--- a/client/src/pages/AccountConfig.tsx
+++ b/client/src/pages/AccountConfig.tsx
@@ -186,7 +186,9 @@ export function AccountConfig() {
               <pre className="text-xs bg-background rounded p-2 font-mono whitespace-pre-wrap">{`{
   "external_id": "order-123",
   "amount": 1500.00,
-  "currency": "UYU"
+  "currency": "UYU",
+  "sender_name": "Juan Pérez",
+  "payment_method_id": 33  // solo si está en el body de polling
 }`}</pre>
             </div>
           </div>


### PR DESCRIPTION
This pull request updates the webhook documentation and example payloads to clarify that the `payment_method_id` field will be included in the webhook payload only if it is present in the polling body. The changes affect both the English and Spanish translations as well as the example payload shown in the account configuration page.

**Documentation and Example Updates:**

* Updated the English webhook payload description in `en.json` to specify that `payment_method_id` will be forwarded in the payload if included in the polling body.
* Updated the Spanish webhook payload description in `es.json` with the same clarification regarding `payment_method_id`.
* Modified the example webhook payload in `AccountConfig.tsx` to include `sender_name` and conditionally include `payment_method_id` with a comment explaining its presence.