### PR TITLE
Refactor AccountConfig by removing polling and retry options

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -134,9 +134,6 @@
     "webhookPayload": "Payload you'll receive",
     "webhookPayloadDesc": "When an order is successfully reconciled, a POST will be sent to this URL. If the polling body includes payment_method_id, it will also be forwarded in the payload:",
     "webhookUrl": "Webhook URL (notifications)",
-    "intervals": "Intervals and retries",
-    "interval": "Interval (seconds)",
-    "retryLimit": "Retry limit",
     "save": "Save configuration",
     "saving": "Saving...",
     "saved": "Saved!"

--- a/client/src/i18n/es.json
+++ b/client/src/i18n/es.json
@@ -134,9 +134,6 @@
     "webhookPayload": "Payload que vas a recibir",
     "webhookPayloadDesc": "Cuando una orden sea conciliada exitosamente, se enviará un POST a esta URL. Si el body de polling incluye payment_method_id, también se incluirá en el payload:",
     "webhookUrl": "Webhook URL (notificaciones)",
-    "intervals": "Intervalos y reintentos",
-    "interval": "Intervalo (segundos)",
-    "retryLimit": "Límite de reintentos",
     "save": "Guardar configuración",
     "saving": "Guardando...",
     "saved": "¡Guardado!"

--- a/client/src/pages/AccountConfig.tsx
+++ b/client/src/pages/AccountConfig.tsx
@@ -17,8 +17,6 @@ interface AccountConfig {
   polling_body: string
   auth_type: 'bearer' | 'api_key'
   auth_token: string
-  polling_interval_seconds: number
-  retry_limit: number
   bank_username: string
   bank_password: string
 }
@@ -34,8 +32,6 @@ export function AccountConfig() {
     polling_body: '',
     auth_type: 'bearer',
     auth_token: '',
-    polling_interval_seconds: 60,
-    retry_limit: 3,
     bank_username: '',
     bank_password: '',
   })
@@ -195,34 +191,6 @@ export function AccountConfig() {
           <div className="space-y-2">
             <Label>{t('accountConfig.webhookUrl')}</Label>
             <Input placeholder="https://..." {...field('webhook_url')} />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Polling & retries */}
-      <Card>
-        <CardHeader><CardTitle>{t('accountConfig.intervals')}</CardTitle></CardHeader>
-        <CardContent className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label>{t('accountConfig.interval')}</Label>
-              <Input
-                type="number"
-                min={10}
-                value={form.polling_interval_seconds}
-                onChange={e => setForm(f => ({ ...f, polling_interval_seconds: Number(e.target.value) }))}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label>{t('accountConfig.retryLimit')}</Label>
-              <Input
-                type="number"
-                min={0}
-                max={10}
-                value={form.retry_limit}
-                onChange={e => setForm(f => ({ ...f, retry_limit: Number(e.target.value) }))}
-              />
-            </div>
           </div>
         </CardContent>
       </Card>

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -113,8 +113,7 @@ Returns the account's reconciliation configuration.
   "pollingMethod": "GET",
   "authType": "bearer",
   "webhookAuthType": "bearer",
-  "webhookAuthToken": "...",
-  "retryLimit": 3
+  "webhookAuthToken": "..."
 }
 ```
 


### PR DESCRIPTION
This pull request removes the polling interval and retry limit configuration from the account settings in both the UI and API documentation. These options are no longer available for user configuration, simplifying the account configuration process.

**Removal of polling and retry configuration:**

* Removed `polling_interval_seconds` and `retry_limit` fields from the `AccountConfig` interface and their initialization in `client/src/pages/AccountConfig.tsx`. [[1]](diffhunk://#diff-6e6402a92bc7af66be6a556d37e1d3195c7c8290ca7949fdb3fdedd320b62d1dL20-L21) [[2]](diffhunk://#diff-6e6402a92bc7af66be6a556d37e1d3195c7c8290ca7949fdb3fdedd320b62d1dL37-L38)
* Deleted the UI section for configuring polling intervals and retry limits from the account configuration page (`AccountConfig`).
* Removed corresponding translation strings for polling intervals and retry limits from both English and Spanish localization files (`en.json`, `es.json`). [[1]](diffhunk://#diff-4ff768c3b7cbc0b99efd419ca4dbb0354dd4c09a0df1792551a2c0e7a6afb1f2L137-L139) [[2]](diffhunk://#diff-f15fde526479c9f454b4ac66327c362fed5b662075455e91061fd864d9052a44L137-L139)
* Updated the API reference documentation to remove the `retryLimit` field from the example account reconciliation configuration.