### PR TITLE
Display cancelled conciliation status with translations and styling

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -156,7 +156,8 @@
       "not_found": "Not found",
       "ambiguous": "Ambiguous",
       "failed": "Failed",
-      "expired": "Expired"
+      "expired": "Expired",
+      "cancelled": "Cancelled"
     },
     "scriptStatus": {
       "draft": "Draft",

--- a/client/src/i18n/es.json
+++ b/client/src/i18n/es.json
@@ -156,7 +156,8 @@
       "not_found": "No encontrado",
       "ambiguous": "Ambiguo",
       "failed": "Fallido",
-      "expired": "Expirado"
+      "expired": "Expirado",
+      "cancelled": "Cancelado"
     },
     "scriptStatus": {
       "draft": "Borrador",

--- a/client/src/pages/Conciliations.tsx
+++ b/client/src/pages/Conciliations.tsx
@@ -11,17 +11,19 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useTranslation } from 'react-i18next'
-import { X, SlidersHorizontal, Bell } from 'lucide-react'
+import { X, SlidersHorizontal, Bell, CheckCircle2, Clock, Loader2, SearchX, HelpCircle, XCircle, History, Ban, type LucideIcon } from 'lucide-react'
 
-const STATUS_KEYS = ['matched', 'pending', 'processing', 'not_found', 'ambiguous', 'failed', 'expired'] as const
+const STATUS_KEYS = ['matched', 'pending', 'processing', 'not_found', 'ambiguous', 'failed', 'expired', 'cancelled'] as const
 
-const statusVariant: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
-  matched:    'default',
-  pending:    'outline',
-  processing: 'secondary',
-  not_found:  'destructive',
-  ambiguous:  'destructive',
-  failed:     'destructive',
+const statusStyle: Record<string, { icon: LucideIcon; className: string }> = {
+  matched:    { icon: CheckCircle2, className: 'bg-green-500/10 text-green-700 dark:text-green-400 border-transparent' },
+  pending:    { icon: Clock,        className: 'bg-amber-500/10 text-amber-700 dark:text-amber-400 border-transparent' },
+  processing: { icon: Loader2,      className: 'bg-blue-500/10 text-blue-700 dark:text-blue-400 border-transparent [&>svg]:animate-spin' },
+  not_found:  { icon: SearchX,      className: 'bg-orange-500/10 text-orange-700 dark:text-orange-400 border-transparent' },
+  ambiguous:  { icon: HelpCircle,   className: 'bg-purple-500/10 text-purple-700 dark:text-purple-400 border-transparent' },
+  failed:     { icon: XCircle,      className: 'bg-red-500/10 text-red-700 dark:text-red-400 border-transparent' },
+  expired:    { icon: History,      className: 'bg-gray-500/10 text-gray-700 dark:text-gray-400 border-transparent' },
+  cancelled:  { icon: Ban,          className: 'bg-rose-500/10 text-rose-700 dark:text-rose-400 border-transparent' },
 }
 
 interface ConciliationRequest {
@@ -86,7 +88,16 @@ function OrdersTable({ requests, accounts, showAccount }: { requests: Conciliati
             <TableCell>{r.currency}</TableCell>
             <TableCell>{r.sender_name ?? '—'}</TableCell>
             <TableCell>
-              <Badge variant={statusVariant[r.status] ?? 'outline'}>{t(`enums.conciliationStatus.${r.status}`)}</Badge>
+              {(() => {
+                const style = statusStyle[r.status]
+                const Icon = style?.icon
+                return (
+                  <Badge className={style?.className ?? ''}>
+                    {Icon && <Icon />}
+                    {t(`enums.conciliationStatus.${r.status}`)}
+                  </Badge>
+                )
+              })()}
             </TableCell>
             <TableCell className="text-muted-foreground text-xs">
               {new Date(r.created_at).toLocaleString()}


### PR DESCRIPTION
This pull request improves the handling and presentation of conciliation request statuses by adding a new "cancelled" status, updating translations, and enhancing the UI to display status icons and colors. The changes make status distinctions clearer and more visually informative for users.

**Status Handling and UI Enhancements:**

* Added support for the new `cancelled` status throughout the codebase, including the `STATUS_KEYS` array and the `statusStyle` mapping, which defines the icon and color for each status (`Conciliations.tsx`).
* Updated the status display in the orders table to use the new `statusStyle` mapping, showing a colored badge with an appropriate icon for each status (`Conciliations.tsx`).

**Localization:**

* Added the "Cancelled" status to both English (`en.json`) and Spanish (`es.json`) translation files, ensuring the new status is properly localized. [[1]](diffhunk://#diff-4ff768c3b7cbc0b99efd419ca4dbb0354dd4c09a0df1792551a2c0e7a6afb1f2L159-R160) [[2]](diffhunk://#diff-f15fde526479c9f454b4ac66327c362fed5b662075455e91061fd864d9052a44L159-R160)