### PR TITLE
Implement transaction exclusion logic and enhance repository features

### DIFF
--- a/src/contexts/banking/domain/IBankTransactionRepository.ts
+++ b/src/contexts/banking/domain/IBankTransactionRepository.ts
@@ -1,7 +1,10 @@
 import { BankTransaction } from './BankTransaction.js'
 
 export interface IBankTransactionRepository {
+  findById(id: string, opts?: { forUpdate?: boolean }): Promise<BankTransaction | null>
   findByExternalId(accountId: string, externalId: string): Promise<BankTransaction | null>
   findLatestExternalId(accountId: string): Promise<string | null>
   save(tx: BankTransaction): Promise<void>
+  markExcluded(id: string): Promise<void>
+  isExcluded(id: string): Promise<boolean>
 }

--- a/src/contexts/banking/infrastructure/BankTransactionRepository.ts
+++ b/src/contexts/banking/infrastructure/BankTransactionRepository.ts
@@ -1,38 +1,74 @@
+import { PoolClient } from 'pg'
 import { db } from '../../../shared/infrastructure/db/client.js'
 import { BankTransaction } from '../domain/BankTransaction.js'
 import { IBankTransactionRepository } from '../domain/IBankTransactionRepository.js'
 
+function reconstitute(row: any): BankTransaction {
+  return BankTransaction.reconstitute(row.id, {
+    accountId: row.account_id,
+    externalId: row.external_id,
+    referenceHash: row.reference_hash,
+    amount: Number(row.amount),
+    currency: row.currency,
+    senderName: row.sender_name ?? undefined,
+    receivedAt: row.received_at,
+    scriptId: row.script_id,
+    ingestedAt: row.ingested_at,
+    rawPayload: row.raw_payload,
+  })
+}
+
 export class BankTransactionRepository implements IBankTransactionRepository {
+  constructor(private readonly client?: PoolClient) {}
+
+  private get executor() {
+    return this.client ?? db
+  }
+
+  async findById(id: string, opts: { forUpdate?: boolean } = {}): Promise<BankTransaction | null> {
+    const suffix = opts.forUpdate ? ' FOR UPDATE' : ''
+    const { rows } = await this.executor.query(
+      `SELECT * FROM bank_transactions WHERE id = $1${suffix}`,
+      [id]
+    )
+    if (!rows[0]) return null
+    return reconstitute(rows[0])
+  }
+
   async findByExternalId(accountId: string, externalId: string): Promise<BankTransaction | null> {
-    const { rows } = await db.query(
+    const { rows } = await this.executor.query(
       'SELECT * FROM bank_transactions WHERE account_id=$1 AND external_id=$2',
       [accountId, externalId]
     )
     if (!rows[0]) return null
-    return BankTransaction.reconstitute(rows[0].id, {
-      accountId: rows[0].account_id,
-      externalId: rows[0].external_id,
-      referenceHash: rows[0].reference_hash,
-      amount: Number(rows[0].amount),
-      currency: rows[0].currency,
-      senderName: rows[0].sender_name ?? undefined,
-      receivedAt: rows[0].received_at,
-      scriptId: rows[0].script_id,
-      ingestedAt: rows[0].ingested_at,
-      rawPayload: rows[0].raw_payload,
-    })
+    return reconstitute(rows[0])
   }
 
   async findLatestExternalId(accountId: string): Promise<string | null> {
-    const { rows } = await db.query(
+    const { rows } = await this.executor.query(
       `SELECT external_id FROM bank_transactions WHERE account_id = $1 ORDER BY received_at DESC LIMIT 1`,
       [accountId]
     )
     return rows[0]?.external_id ?? null
   }
 
+  async markExcluded(id: string): Promise<void> {
+    await this.executor.query(
+      `UPDATE bank_transactions SET excluded_at = now() WHERE id = $1 AND excluded_at IS NULL`,
+      [id]
+    )
+  }
+
+  async isExcluded(id: string): Promise<boolean> {
+    const { rows } = await this.executor.query(
+      `SELECT excluded_at FROM bank_transactions WHERE id = $1`,
+      [id]
+    )
+    return rows[0]?.excluded_at != null
+  }
+
   async save(tx: BankTransaction): Promise<void> {
-    await db.query(
+    await this.executor.query(
       `INSERT INTO bank_transactions
          (id, account_id, external_id, reference_hash, amount, currency, sender_name, received_at, script_id, ingested_at, raw_payload)
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,now(),$10)

--- a/src/contexts/conciliation/application/OnTransactionIngestedUseCase.ts
+++ b/src/contexts/conciliation/application/OnTransactionIngestedUseCase.ts
@@ -1,0 +1,36 @@
+import { db } from '../../../shared/infrastructure/db/client.js'
+import { Queues } from '../../../shared/infrastructure/queues/QueueRegistry.js'
+import { BankTransactionRepository } from '../../banking/infrastructure/BankTransactionRepository.js'
+import { IBankTransactionRepository } from '../../banking/domain/IBankTransactionRepository.js'
+import { TransactionIngestedEvent } from '../../../shared/events/events/TransactionIngested.event.js'
+
+export class OnTransactionIngestedUseCase {
+  constructor(
+    private readonly txRepo: IBankTransactionRepository = new BankTransactionRepository(),
+  ) {}
+
+  async execute(event: TransactionIngestedEvent): Promise<void> {
+    const txId = event.aggregateId
+
+    const { rows } = await db.query(
+      `SELECT 1 FROM conciliation_requests
+       WHERE account_id = $1
+         AND status IN ('pending', 'not_found')
+       LIMIT 1`,
+      [event.accountId]
+    )
+
+    if (rows.length === 0) {
+      await this.txRepo.markExcluded(txId)
+      console.log(`[OnTransactionIngested] tx ${txId} excluded (no active requests)`)
+      return
+    }
+
+    await Queues.txConciliation.add(
+      'process',
+      { transactionId: txId },
+      { jobId: `tx_conciliation_${txId}`, removeOnComplete: true }
+    )
+    console.log(`[OnTransactionIngested] tx ${txId} → enqueued tx-conciliation`)
+  }
+}

--- a/src/contexts/conciliation/application/ProcessIncomingTransactionUseCase.ts
+++ b/src/contexts/conciliation/application/ProcessIncomingTransactionUseCase.ts
@@ -1,0 +1,109 @@
+import crypto from 'crypto'
+import { withTransaction } from '../../../shared/infrastructure/db/client.js'
+import { EventBus } from '../../../shared/events/EventBus.js'
+import { ConciliationEngine, CandidateTransaction, RequestData } from '../domain/ConciliationEngine.js'
+import { ConciliationRequest } from '../domain/ConciliationRequest.js'
+import { ConciliationRequestRepository } from '../infrastructure/ConciliationRequestRepository.js'
+import { ConciliationAttemptRepository } from '../infrastructure/ConciliationAttemptRepository.js'
+import { ConciliatedTransactionRepository } from '../infrastructure/ConciliatedTransactionRepository.js'
+import { BankTransactionRepository } from '../../banking/infrastructure/BankTransactionRepository.js'
+
+interface JobData { transactionId: string }
+
+export class ProcessIncomingTransactionUseCase {
+  private engine = new ConciliationEngine()
+
+  async execute({ transactionId }: JobData): Promise<void> {
+    const matchedRequest = await withTransaction(async (client) => {
+      const txRepo = new BankTransactionRepository(client)
+      const requestRepo = new ConciliationRequestRepository(client)
+      const attemptRepo = new ConciliationAttemptRepository(client)
+      const matchRepo = new ConciliatedTransactionRepository(client)
+
+      const tx = await txRepo.findById(transactionId, { forUpdate: true })
+      if (!tx) return null
+      // Idempotencia: si ya fue excluida (match previo o no-match previo), no reprocesar.
+      const excluded = await txRepo.isExcluded(transactionId)
+      if (excluded) return null
+
+      const candidate: CandidateTransaction = {
+        id: tx.id,
+        amount: tx.amount,
+        currency: tx.currency,
+        senderName: tx.senderName,
+        receivedAt: tx.receivedAt,
+      }
+
+      const { rows: requestRows } = await client.query(
+        `SELECT * FROM conciliation_requests
+         WHERE account_id = $1
+           AND status IN ('pending', 'not_found')
+         ORDER BY created_at ASC
+         FOR UPDATE SKIP LOCKED`,
+        [tx.accountId]
+      )
+
+      let winner: ConciliationRequest | null = null
+      for (const row of requestRows) {
+        const req = ConciliationRequest.reconstitute(row.id, {
+          accountId: row.account_id,
+          externalId: row.external_id,
+          expectedAmount: Number(row.expected_amount),
+          currency: row.currency,
+          senderName: row.sender_name ?? undefined,
+          status: row.status,
+          idempotencyKey: row.idempotency_key ?? undefined,
+          retryCount: row.retry_count,
+          lastCheckedAt: row.last_checked_at ?? undefined,
+          createdAt: row.created_at,
+        })
+        const reqData: RequestData = {
+          expectedAmount: req.expectedAmount,
+          currency: req.currency,
+          senderName: req.senderName,
+          createdAt: req.createdAt,
+        }
+        const result = this.engine.evaluate(reqData, [candidate])
+        if (result.status === 'matched') {
+          winner = req
+          break
+        }
+      }
+
+      if (!winner) {
+        await txRepo.markExcluded(transactionId)
+        return null
+      }
+
+      winner.markProcessing()
+      winner.markMatched(transactionId)
+
+      await matchRepo.save({
+        id: crypto.randomUUID(),
+        accountId: winner.accountId,
+        requestId: winner.id,
+        bankTransactionId: transactionId,
+      })
+
+      await attemptRepo.save({
+        id: crypto.randomUUID(),
+        accountId: winner.accountId,
+        requestId: winner.id,
+        attemptNumber: winner.retryCount + 1,
+        status: 'success',
+        candidateIds: [transactionId],
+        selectedTransactionId: transactionId,
+      })
+
+      await requestRepo.save(winner)
+      await txRepo.markExcluded(transactionId)
+
+      return winner
+    })
+
+    if (!matchedRequest) return
+
+    await EventBus.publishAll(matchedRequest.domainEvents)
+    matchedRequest.clearDomainEvents()
+  }
+}

--- a/src/contexts/conciliation/application/RunConciliationUseCase.ts
+++ b/src/contexts/conciliation/application/RunConciliationUseCase.ts
@@ -4,6 +4,7 @@ import { ConciliationEngine } from '../domain/ConciliationEngine.js'
 import { ConciliationRequestRepository } from '../infrastructure/ConciliationRequestRepository.js'
 import { ConciliationAttemptRepository } from '../infrastructure/ConciliationAttemptRepository.js'
 import { ConciliatedTransactionRepository } from '../infrastructure/ConciliatedTransactionRepository.js'
+import { BankTransactionRepository } from '../../banking/infrastructure/BankTransactionRepository.js'
 import { Queues } from '../../../shared/infrastructure/queues/QueueRegistry.js'
 import crypto from 'crypto'
 
@@ -19,6 +20,7 @@ export class RunConciliationUseCase {
       const txRequestRepo = new ConciliationRequestRepository(client)
       const txAttemptRepo = new ConciliationAttemptRepository(client)
       const txMatchRepo = new ConciliatedTransactionRepository(client)
+      const bankTxRepo = new BankTransactionRepository(client)
 
       // FOR UPDATE SKIP LOCKED: si polling tiene la row lockeada, retornamos null.
       const request = await txRequestRepo.findById(requestId)
@@ -28,7 +30,7 @@ export class RunConciliationUseCase {
       const { rows: candidateRows } = await client.query(
         `SELECT id, amount, currency, sender_name, received_at
          FROM bank_transactions
-         WHERE account_id = $1 AND received_at >= now() - interval '7 days'`,
+         WHERE account_id = $1 AND excluded_at IS NULL`,
         [request.accountId]
       )
 
@@ -61,6 +63,7 @@ export class RunConciliationUseCase {
           requestId,
           bankTransactionId: result.transactionId!,
         })
+        await bankTxRepo.markExcluded(result.transactionId!)
         await txAttemptRepo.save({
           id: attemptId,
           accountId: request.accountId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,27 +8,13 @@ import { EventBus } from './shared/events/EventBus.js'
 import { TransactionIngestedEvent } from './shared/events/events/TransactionIngested.event.js'
 import { ConciliationMatchedEvent } from './shared/events/events/ConciliationMatched.event.js'
 import { Queues } from './shared/infrastructure/queues/QueueRegistry.js'
-import { db } from './shared/infrastructure/db/client.js'
+import { OnTransactionIngestedUseCase } from './contexts/conciliation/application/OnTransactionIngestedUseCase.js'
 
-// Cuando llega una transacción nueva → encolar conciliación de pendientes
+const onTransactionIngested = new OnTransactionIngestedUseCase()
+
+// Cuando llega una transacción nueva → decidir si excluirla o encolar conciliación
 EventBus.subscribe<TransactionIngestedEvent>('TransactionIngested', async (event) => {
-  const { rows } = await db.query(
-    `SELECT id FROM conciliation_requests
-     WHERE account_id = $1
-       AND status IN ('pending', 'not_found')
-       AND created_at > now() - interval '5 days'`,
-    [event.accountId]
-  )
-
-  for (const req of rows) {
-    await Queues.conciliation.add(
-      'run',
-      { requestId: req.id },
-      { jobId: `conciliation_${req.id}_${Date.now()}`, removeOnComplete: true }
-    )
-  }
-
-  console.log(`[EventBus] TransactionIngested → enqueued ${rows.length} conciliation(s)`)
+  await onTransactionIngested.execute(event)
 })
 
 // Cuando hay un match → notificar webhook

--- a/src/shared/infrastructure/db/migrations/020_bank_transactions_excluded_at.sql
+++ b/src/shared/infrastructure/db/migrations/020_bank_transactions_excluded_at.sql
@@ -1,0 +1,14 @@
+ALTER TABLE bank_transactions
+  ADD COLUMN excluded_at TIMESTAMPTZ NULL;
+
+CREATE INDEX idx_bank_transactions_account_active
+  ON bank_transactions (account_id, received_at DESC)
+  WHERE excluded_at IS NULL;
+
+UPDATE bank_transactions bt
+SET excluded_at = now()
+WHERE bt.received_at < now() - interval '4 days'
+  AND NOT EXISTS (
+    SELECT 1 FROM conciliated_transactions ct
+    WHERE ct.bank_transaction_id = bt.id
+  );

--- a/src/shared/infrastructure/queues/QueueRegistry.ts
+++ b/src/shared/infrastructure/queues/QueueRegistry.ts
@@ -18,5 +18,6 @@ export const Queues = {
   orderIngestion: new Queue('order-ingestion', { connection: redis, defaultJobOptions }),
   bankScrape:     new Queue('bank-scrape',     { connection: redis, defaultJobOptions }),
   conciliation:   new Queue('conciliation',    { connection: redis, defaultJobOptions }),
+  txConciliation: new Queue('tx-conciliation', { connection: redis, defaultJobOptions }),
   webhook:        new Queue('webhook',         { connection: redis, defaultJobOptions }),
 }

--- a/src/shared/infrastructure/queues/workers/conciliation.worker.ts
+++ b/src/shared/infrastructure/queues/workers/conciliation.worker.ts
@@ -18,6 +18,23 @@ conciliationWorker.on('failed', (job, err) => {
   console.error(`[conciliation] job ${job?.id} failed (attempt ${job?.attemptsMade}):`, err.message)
 })
 
+export const txConciliationWorker = new Worker(
+  'tx-conciliation',
+  async job => {
+    const mod = await import('../../../../contexts/conciliation/application/ProcessIncomingTransactionUseCase.js')
+    await new mod.ProcessIncomingTransactionUseCase().execute(job.data)
+  },
+  { connection: redis }
+)
+
+txConciliationWorker.on('completed', job => {
+  console.log(`[tx-conciliation] job ${job.id} completed`)
+})
+
+txConciliationWorker.on('failed', (job, err) => {
+  console.error(`[tx-conciliation] job ${job?.id} failed (attempt ${job?.attemptsMade}):`, err.message)
+})
+
 export const webhookWorker = new Worker(
   'webhook',
   async job => {


### PR DESCRIPTION
This pull request introduces a new mechanism for managing the lifecycle of bank transactions in the conciliation process by adding an "excluded" state to transactions. Transactions that are not relevant for conciliation are now explicitly marked as excluded, and the conciliation logic and queueing have been refactored to support this. The changes include database schema updates, repository enhancements, new use cases, queue management, and worker logic.

**Key changes include:**

### 1. Bank Transaction Exclusion State

- Added a new `excluded_at` column to the `bank_transactions` table, with an index for efficient querying, and a migration to retroactively exclude old, unmatched transactions. (`src/shared/infrastructure/db/migrations/020_bank_transactions_excluded_at.sql`)
- The `IBankTransactionRepository` interface and its implementation now support methods to mark transactions as excluded and check their exclusion status. (`src/contexts/banking/domain/IBankTransactionRepository.ts`, `src/contexts/banking/infrastructure/BankTransactionRepository.ts`) [[1]](diffhunk://#diff-0b4e918fc34c7fb781bf28504626cbb6240940fda1ae07bbec0f7ee50901fdecR4-R9) [[2]](diffhunk://#diff-19e4be02cfa0c0cfe17f24fbaa9ea1f9fb4d5d54b249592712633aa9fc05f358R1-R71)

### 2. Conciliation Process Refactoring

- Introduced `OnTransactionIngestedUseCase`, which determines if a new transaction should be excluded or enqueued for conciliation, replacing the previous direct queueing logic. (`src/contexts/conciliation/application/OnTransactionIngestedUseCase.ts`, `src/index.ts`) [[1]](diffhunk://#diff-5f846859dd85e4b869f2fc76e865dbe77fa693fbb60d33a37bd68cb72e197fecR1-R36) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L11-R17)
- Added `ProcessIncomingTransactionUseCase`, which processes a transaction for conciliation, ensures idempotency by checking exclusion, and updates related entities. (`src/contexts/conciliation/application/ProcessIncomingTransactionUseCase.ts`)

### 3. Queue and Worker Updates

- Added a new `tx-conciliation` queue and its associated worker to handle transaction-based conciliation jobs. (`src/shared/infrastructure/queues/QueueRegistry.ts`, `src/shared/infrastructure/queues/workers/conciliation.worker.ts`) [[1]](diffhunk://#diff-ebce05d2a1828561c27c27e9d2c78377a7677d23e83e09b0658d99871a9e1fddR21) [[2]](diffhunk://#diff-889081326ced6f1987b38b49e9eb5eda6a60349fb909ade25e346b73b8e5921eR21-R37)

### 4. Conciliation Logic Adjustments

- Conciliation now only considers non-excluded transactions as candidates, and marks matched transactions as excluded to prevent reprocessing. (`src/contexts/conciliation/application/RunConciliationUseCase.ts`) [[1]](diffhunk://#diff-f7dba4677727bc1c1963b9cbaf14cb7333fd2789b731c4bd0f5170b402d9a8e8R7) [[2]](diffhunk://#diff-f7dba4677727bc1c1963b9cbaf14cb7333fd2789b731c4bd0f5170b402d9a8e8R23) [[3]](diffhunk://#diff-f7dba4677727bc1c1963b9cbaf14cb7333fd2789b731c4bd0f5170b402d9a8e8L31-R33) [[4]](diffhunk://#diff-f7dba4677727bc1c1963b9cbaf14cb7333fd2789b731c4bd0f5170b402d9a8e8R66)

These changes ensure that only relevant transactions are processed for conciliation, improve idempotency and performance, and provide a clear lifecycle for bank transactions within the system.