### PR TITLE
Add support for extra fields in webhook configuration

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -134,6 +134,11 @@
     "webhookPayload": "Payload you'll receive",
     "webhookPayloadDesc": "When an order is successfully reconciled, a POST will be sent to this URL. If the polling body includes payment_method_id, it will also be forwarded in the payload:",
     "webhookUrl": "Webhook URL (notifications)",
+    "webhookExtraFields": "Extra fields (JSON)",
+    "webhookExtraFieldsDesc": "JSON object with extra fields that will be merged into the webhook payload (for example, a source or a fixed tag). You can't use these reserved keys: external_id, status, amount, currency, sender_name, payment_method_id.",
+    "webhookExtraFieldsInvalidJson": "Invalid JSON",
+    "webhookExtraFieldsMustBeObject": "Must be a JSON object",
+    "webhookExtraFieldsReserved": "These reserved keys can't be used: {{keys}}",
     "save": "Save configuration",
     "saving": "Saving...",
     "saved": "Saved!"

--- a/client/src/i18n/es.json
+++ b/client/src/i18n/es.json
@@ -134,6 +134,11 @@
     "webhookPayload": "Payload que vas a recibir",
     "webhookPayloadDesc": "Cuando una orden sea conciliada exitosamente, se enviará un POST a esta URL. Si el body de polling incluye payment_method_id, también se incluirá en el payload:",
     "webhookUrl": "Webhook URL (notificaciones)",
+    "webhookExtraFields": "Campos adicionales (JSON)",
+    "webhookExtraFieldsDesc": "Objeto JSON con campos extra que se mergearán al payload del webhook (por ejemplo, un source o un tag fijo). No podés usar las claves reservadas: external_id, status, amount, currency, sender_name, payment_method_id.",
+    "webhookExtraFieldsInvalidJson": "El JSON no es válido",
+    "webhookExtraFieldsMustBeObject": "Debe ser un objeto JSON",
+    "webhookExtraFieldsReserved": "No podés usar estas claves reservadas: {{keys}}",
     "save": "Guardar configuración",
     "saving": "Guardando...",
     "saved": "¡Guardado!"

--- a/client/src/pages/AccountConfig.tsx
+++ b/client/src/pages/AccountConfig.tsx
@@ -19,7 +19,10 @@ interface AccountConfig {
   auth_token: string
   bank_username: string
   bank_password: string
+  webhook_extra_fields: string
 }
+
+const RESERVED_WEBHOOK_KEYS = ['external_id', 'status', 'amount', 'currency', 'sender_name', 'payment_method_id']
 
 export function AccountConfig() {
   const { accountId } = useParams<{ accountId: string }>()
@@ -34,8 +37,10 @@ export function AccountConfig() {
     auth_token: '',
     bank_username: '',
     bank_password: '',
+    webhook_extra_fields: '',
   })
   const [saved, setSaved] = useState(false)
+  const [extraFieldsError, setExtraFieldsError] = useState<string | null>(null)
 
   const { data, isLoading } = useQuery({
     queryKey: ['account-config', accountId],
@@ -44,8 +49,34 @@ export function AccountConfig() {
   })
 
   useEffect(() => {
-    if (data) setForm(f => ({ ...f, ...data, bank_password: '' }))
+    if (data) setForm(f => ({
+      ...f,
+      ...data,
+      bank_password: '',
+      webhook_extra_fields: data.webhook_extra_fields
+        ? JSON.stringify(data.webhook_extra_fields, null, 2)
+        : '',
+    }))
   }, [data])
+
+  function validateExtraFields(): string | null {
+    const raw = form.webhook_extra_fields.trim()
+    if (!raw) return null
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(raw)
+    } catch {
+      return t('accountConfig.webhookExtraFieldsInvalidJson')
+    }
+    if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return t('accountConfig.webhookExtraFieldsMustBeObject')
+    }
+    const conflicts = Object.keys(parsed as object).filter(k => RESERVED_WEBHOOK_KEYS.includes(k))
+    if (conflicts.length > 0) {
+      return t('accountConfig.webhookExtraFieldsReserved', { keys: conflicts.join(', ') })
+    }
+    return null
+  }
 
   const save = useMutation({
     mutationFn: () => api.put(`/accounts/${accountId}/config`, form),
@@ -54,6 +85,13 @@ export function AccountConfig() {
       setTimeout(() => setSaved(false), 2000)
     },
   })
+
+  function handleSave() {
+    const err = validateExtraFields()
+    setExtraFieldsError(err)
+    if (err) return
+    save.mutate()
+  }
 
   function field<K extends keyof AccountConfig>(key: K) {
     return {
@@ -192,10 +230,26 @@ export function AccountConfig() {
             <Label>{t('accountConfig.webhookUrl')}</Label>
             <Input placeholder="https://..." {...field('webhook_url')} />
           </div>
+          <div className="space-y-2">
+            <Label>{t('accountConfig.webhookExtraFields')}</Label>
+            <p className="text-xs text-muted-foreground">{t('accountConfig.webhookExtraFieldsDesc')}</p>
+            <textarea
+              className="w-full min-h-24 rounded-md border bg-transparent px-3 py-2 text-sm font-mono resize-y"
+              placeholder='{"source": "reconbanker"}'
+              value={form.webhook_extra_fields}
+              onChange={e => {
+                setForm(f => ({ ...f, webhook_extra_fields: e.target.value }))
+                if (extraFieldsError) setExtraFieldsError(null)
+              }}
+            />
+            {extraFieldsError && (
+              <p className="text-xs text-destructive">{extraFieldsError}</p>
+            )}
+          </div>
         </CardContent>
       </Card>
 
-      <Button onClick={() => save.mutate()} disabled={save.isPending} className="gap-2">
+      <Button onClick={handleSave} disabled={save.isPending} className="gap-2">
         <Save className="size-4" />
         {save.isPending ? t('accountConfig.saving') : saved ? t('accountConfig.saved') : t('accountConfig.save')}
       </Button>

--- a/src/api/routes/accounts.routes.ts
+++ b/src/api/routes/accounts.routes.ts
@@ -59,11 +59,36 @@ accountsRouter.put('/:accountId/config', async (req, res) => {
     bank_username,
     bank_password,
     notify_on_expired,
+    webhook_extra_fields,
   } = req.body
 
   if (!pending_orders_endpoint || !webhook_url) {
     res.status(400).json({ error: 'pending_orders_endpoint and webhook_url are required' })
     return
+  }
+
+  const RESERVED_WEBHOOK_KEYS = ['external_id', 'status', 'amount', 'currency', 'sender_name', 'payment_method_id']
+  let normalizedWebhookExtraFields: Record<string, unknown> | null = null
+  if (webhook_extra_fields != null && webhook_extra_fields !== '') {
+    let parsed: unknown = webhook_extra_fields
+    if (typeof webhook_extra_fields === 'string') {
+      try {
+        parsed = JSON.parse(webhook_extra_fields)
+      } catch {
+        res.status(400).json({ error: 'webhook_extra_fields must be valid JSON' })
+        return
+      }
+    }
+    if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      res.status(400).json({ error: 'webhook_extra_fields must be a JSON object' })
+      return
+    }
+    const conflicts = Object.keys(parsed as object).filter(k => RESERVED_WEBHOOK_KEYS.includes(k))
+    if (conflicts.length > 0) {
+      res.status(400).json({ error: `webhook_extra_fields cannot override reserved keys: ${conflicts.join(', ')}` })
+      return
+    }
+    normalizedWebhookExtraFields = parsed as Record<string, unknown>
   }
 
   const normalizedPollingMethod = (polling_method ?? 'GET') as 'GET' | 'POST'
@@ -99,8 +124,8 @@ accountsRouter.put('/:accountId/config', async (req, res) => {
     `INSERT INTO account_config
        (id, account_id, pending_orders_endpoint, webhook_url,
         retry_limit, polling_method, polling_body, auth_type, auth_token,
-        webhook_auth_type, webhook_auth_token, notify_on_expired)
-     VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+        webhook_auth_type, webhook_auth_token, notify_on_expired, webhook_extra_fields)
+     VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
      ON CONFLICT (account_id) DO UPDATE SET
        pending_orders_endpoint = $2,
        webhook_url             = $3,
@@ -112,6 +137,7 @@ accountsRouter.put('/:accountId/config', async (req, res) => {
        webhook_auth_type       = $9,
        webhook_auth_token      = $10,
        notify_on_expired       = $11,
+       webhook_extra_fields    = $12,
        updated_at              = now()
      RETURNING *`,
     [
@@ -121,6 +147,7 @@ accountsRouter.put('/:accountId/config', async (req, res) => {
       auth_type ?? 'bearer', normalizedAuthToken,
       webhook_auth_type ?? null, normalizedWebhookAuthToken,
       notify_on_expired ?? false,
+      normalizedWebhookExtraFields,
     ]
   )
 

--- a/src/contexts/conciliation/application/NotifyWebhookUseCase.ts
+++ b/src/contexts/conciliation/application/NotifyWebhookUseCase.ts
@@ -7,7 +7,7 @@ export class NotifyWebhookUseCase {
     const { rows: [req] } = await db.query(
       `SELECT cr.id, cr.external_id, cr.status, cr.expected_amount, cr.currency, cr.sender_name,
               ac.webhook_url, ac.webhook_auth_type, ac.webhook_auth_token, ac.auth_type, ac.auth_token,
-              ac.polling_body
+              ac.polling_body, ac.webhook_extra_fields
        FROM conciliation_requests cr
        JOIN account_config ac ON ac.account_id = cr.account_id
        WHERE cr.id = $1`,
@@ -40,6 +40,13 @@ export class NotifyWebhookUseCase {
       amount:      Number(req.expected_amount),
       currency:    req.currency,
       sender_name: req.sender_name ?? null,
+    }
+
+    const extraFields = req.webhook_extra_fields
+    if (extraFields && typeof extraFields === 'object' && !Array.isArray(extraFields)) {
+      for (const [k, v] of Object.entries(extraFields)) {
+        if (!(k in payload)) payload[k] = v
+      }
     }
 
     const pollingBody = req.polling_body

--- a/src/shared/infrastructure/db/migrations/021_account_config_webhook_extra_fields.sql
+++ b/src/shared/infrastructure/db/migrations/021_account_config_webhook_extra_fields.sql
@@ -1,0 +1,2 @@
+ALTER TABLE account_config
+  ADD COLUMN webhook_extra_fields JSONB NULL;


### PR DESCRIPTION
This pull request adds support for configuring extra JSON fields to be merged into webhook payloads for accounts. It introduces a new `webhook_extra_fields` option in the account configuration UI and backend, including validation to prevent reserved keys from being overridden. The webhook notification logic is updated to merge these extra fields into outgoing payloads. The changes also include database migration, backend validation, UI updates, and internationalization for both English and Spanish.

**Account configuration and validation:**

* Added a new `webhook_extra_fields` field to the account configuration UI (`AccountConfig.tsx`), with validation to ensure the input is valid JSON, is an object, and does not use reserved keys (`external_id`, `status`, `amount`, `currency`, `sender_name`, `payment_method_id`). [[1]](diffhunk://#diff-6e6402a92bc7af66be6a556d37e1d3195c7c8290ca7949fdb3fdedd320b62d1dR22-R26) [[2]](diffhunk://#diff-6e6402a92bc7af66be6a556d37e1d3195c7c8290ca7949fdb3fdedd320b62d1dL47-R80) [[3]](diffhunk://#diff-6e6402a92bc7af66be6a556d37e1d3195c7c8290ca7949fdb3fdedd320b62d1dR233-R252)
* Updated the backend API (`accounts.routes.ts`) to accept, validate, and store `webhook_extra_fields`, enforcing the same reserved key restrictions and JSON structure.

**Database changes:**

* Added a new nullable `webhook_extra_fields` JSONB column to the `account_config` table via migration.

**Webhook payload logic:**

* Updated the webhook notification use case to merge any configured extra fields into the outgoing payload, without overriding reserved keys.

**Internationalization:**

* Added English and Spanish translations for the new UI fields and validation messages related to extra webhook fields. [[1]](diffhunk://#diff-4ff768c3b7cbc0b99efd419ca4dbb0354dd4c09a0df1792551a2c0e7a6afb1f2R137-R141) [[2]](diffhunk://#diff-f15fde526479c9f454b4ac66327c362fed5b662075455e91061fd864d9052a44R137-R141)