### PR TITLE
Refactor webhook notification handling in NotifyBankMovementUseCase

### DIFF
--- a/src/api/routes/accounts.routes.ts
+++ b/src/api/routes/accounts.routes.ts
@@ -199,5 +199,5 @@ accountsRouter.put('/:accountId/config', async (req, res) => {
     )
   }
 
-  res.json(toJson(config, bank_username ?? (await getBankUsername(accountId))))
+  res.json(toJson(config, await getBankUsername(accountId)))
 })

--- a/src/contexts/banking/application/NotifyBankMovementUseCase.ts
+++ b/src/contexts/banking/application/NotifyBankMovementUseCase.ts
@@ -12,13 +12,15 @@ export class NotifyBankMovementUseCase {
     const tx = await this.bankTxRepo.findById(bankTransactionId)
     if (!tx) return
 
-    // notified_at no está en el dominio de BankTransaction; lo consultamos directo
-    if (await this.bankTxRepo.isNotified(bankTransactionId)) return
-
     const config = await this.configRepo.findByAccountId(tx.accountId)
     if (!config) return
     if (config.mode !== 'passthrough') return
     if (!config.webhookUrl) return
+
+    // Claim atómico antes de enviar: si otra ejecución ya lo notificó, salimos.
+    // Si el envío falla, liberamos el claim para que BullMQ pueda reintentar.
+    const claimed = await this.bankTxRepo.claimNotification(bankTransactionId)
+    if (!claimed) return
 
     const token = config.webhookAuthToken ?? config.authToken
     const authType = config.webhookAuthType ?? config.authType
@@ -38,13 +40,16 @@ export class NotifyBankMovementUseCase {
       }
     }
 
-    await sendWebhook({
-      url: config.webhookUrl,
-      payload,
-      authType,
-      authToken: token,
-    })
-
-    await this.bankTxRepo.markNotified(bankTransactionId)
+    try {
+      await sendWebhook({
+        url: config.webhookUrl,
+        payload,
+        authType,
+        authToken: token,
+      })
+    } catch (err) {
+      await this.bankTxRepo.releaseNotification(bankTransactionId)
+      throw err
+    }
   }
 }

--- a/src/contexts/banking/domain/IBankTransactionRepository.ts
+++ b/src/contexts/banking/domain/IBankTransactionRepository.ts
@@ -10,4 +10,9 @@ export interface IBankTransactionRepository {
   markNotified(id: string): Promise<void>
   markAllNotified(accountId: string): Promise<void>
   isNotified(id: string): Promise<boolean>
+  // Atomically marca notified_at = now() si estaba NULL. Devuelve true si lo hizo, false si ya estaba notificada.
+  // Usar para evitar doble notificación en webhooks idempotentes ante reintentos concurrentes.
+  claimNotification(id: string): Promise<boolean>
+  // Revierte notified_at a NULL. Usar para liberar el claim si el envío falla.
+  releaseNotification(id: string): Promise<void>
 }

--- a/src/contexts/banking/infrastructure/BankTransactionRepository.ts
+++ b/src/contexts/banking/infrastructure/BankTransactionRepository.ts
@@ -90,6 +90,22 @@ export class BankTransactionRepository implements IBankTransactionRepository {
     return rows[0]?.notified_at != null
   }
 
+  async claimNotification(id: string): Promise<boolean> {
+    const result = await this.executor.query(
+      `UPDATE bank_transactions SET notified_at = now()
+        WHERE id = $1 AND notified_at IS NULL`,
+      [id]
+    )
+    return (result.rowCount ?? 0) > 0
+  }
+
+  async releaseNotification(id: string): Promise<void> {
+    await this.executor.query(
+      `UPDATE bank_transactions SET notified_at = NULL WHERE id = $1`,
+      [id]
+    )
+  }
+
   async save(tx: BankTransaction): Promise<void> {
     await this.executor.query(
       `INSERT INTO bank_transactions


### PR DESCRIPTION
This pull request introduces an atomic notification mechanism to prevent duplicate webhook notifications for bank transactions, especially under concurrent or retried processing. The main changes include adding atomic claim and release methods for notification state, updating the notification use case to use these new methods, and cleaning up redundant logic.

**Atomic notification handling:**

* Added `claimNotification` and `releaseNotification` methods to `IBankTransactionRepository` and implemented them in `BankTransactionRepository`, enabling atomic marking and releasing of notification state to prevent duplicate webhook notifications. [[1]](diffhunk://#diff-0b4e918fc34c7fb781bf28504626cbb6240940fda1ae07bbec0f7ee50901fdecR13-R17) [[2]](diffhunk://#diff-19e4be02cfa0c0cfe17f24fbaa9ea1f9fb4d5d54b249592712633aa9fc05f358R93-R108)

**Notification process improvements:**

* Updated `NotifyBankMovementUseCase` to use the new atomic claim/release methods, ensuring that only one process can notify a transaction at a time, and to release the claim if webhook sending fails for proper retry handling. [[1]](diffhunk://#diff-35d38058e94673b91e6e500511f0faafea5fc0cc62e4a14fbaa76a8848918a2eL15-R24) [[2]](diffhunk://#diff-35d38058e94673b91e6e500511f0faafea5fc0cc62e4a14fbaa76a8848918a2eR43-R53)
* Removed the previous `isNotified` check in favor of the atomic claim, simplifying and strengthening the notification logic.

**Minor cleanup:**

* Simplified the response in the account config update endpoint by removing an unnecessary fallback for `bank_username`.