### PR TITLE
Revise webhook payload descriptions and update reserved keys

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -162,7 +162,7 @@
     "webhookPayloadDesc": "When an order is successfully reconciled, a POST will be sent to this URL with the following payload:",
     "webhookUrl": "Webhook URL (notifications)",
     "webhookExtraFields": "Extra fields (JSON)",
-    "webhookExtraFieldsDesc": "JSON object with extra fields that will be merged into the webhook payload (for example, a source or a fixed tag). You can't use these reserved keys: external_id, status, amount, currency, sender_name, id, received_at.",
+    "webhookExtraFieldsDesc": "JSON object with extra fields that will be merged into the webhook payload (for example, a source or a fixed tag). You can't use these reserved keys: external_id, status, amount, currency, name, id, received_at.",
     "webhookExtraFieldsInvalidJson": "Invalid JSON",
     "webhookExtraFieldsMustBeObject": "Must be a JSON object",
     "webhookExtraFieldsReserved": "These reserved keys can't be used: {{keys}}",

--- a/client/src/i18n/es.json
+++ b/client/src/i18n/es.json
@@ -162,7 +162,7 @@
     "webhookPayloadDesc": "Cuando una orden sea conciliada exitosamente, se enviará un POST a esta URL con el siguiente payload:",
     "webhookUrl": "Webhook URL (notificaciones)",
     "webhookExtraFields": "Campos adicionales (JSON)",
-    "webhookExtraFieldsDesc": "Objeto JSON con campos extra que se mergearán al payload del webhook (por ejemplo, un source o un tag fijo). No podés usar las claves reservadas: external_id, status, amount, currency, sender_name, id, received_at.",
+    "webhookExtraFieldsDesc": "Objeto JSON con campos extra que se mergearán al payload del webhook (por ejemplo, un source o un tag fijo). No podés usar las claves reservadas: external_id, status, amount, currency, name, id, received_at.",
     "webhookExtraFieldsInvalidJson": "El JSON no es válido",
     "webhookExtraFieldsMustBeObject": "Debe ser un objeto JSON",
     "webhookExtraFieldsReserved": "No podés usar estas claves reservadas: {{keys}}",

--- a/client/src/pages/AccountConfig.tsx
+++ b/client/src/pages/AccountConfig.tsx
@@ -32,7 +32,7 @@ interface AccountConfig {
   mode: 'reconcile' | 'passthrough'
 }
 
-const RESERVED_WEBHOOK_KEYS = ['external_id', 'status', 'amount', 'currency', 'sender_name', 'id', 'received_at']
+const RESERVED_WEBHOOK_KEYS = ['external_id', 'status', 'amount', 'currency', 'name', 'id', 'received_at']
 
 export function AccountConfig() {
   const { accountId } = useParams<{ accountId: string }>()
@@ -238,7 +238,7 @@ export function AccountConfig() {
     "external_id": "order-123",
     "amount": 1500.00,
     "currency": "UYU",
-    "sender_name": "Juan Pérez"
+    "name": "Juan Pérez"
   }
 ]`}</pre>
             </div>
@@ -295,13 +295,13 @@ export function AccountConfig() {
   "external_id": "order-123",
   "amount": 1500.00,
   "currency": "UYU",
-  "sender_name": "Juan Pérez"
+  "name": "Juan Pérez"
 }`
                   : `{
   "id": "uuid-del-movimiento",
   "amount": 1500.00,
   "currency": "UYU",
-  "sender_name": "Juan Pérez",
+  "name": "Juan Pérez",
   "received_at": "2026-04-24T12:00:00.000Z"
 }`}
               </pre>

--- a/src/api/routes/accounts.routes.ts
+++ b/src/api/routes/accounts.routes.ts
@@ -12,7 +12,7 @@ const repo = new AccountRepository()
 const configRepo = new AccountConfigRepository()
 const bankTxRepo = new BankTransactionRepository()
 
-const RESERVED_WEBHOOK_KEYS = ['external_id', 'status', 'amount', 'currency', 'sender_name', 'id', 'received_at']
+const RESERVED_WEBHOOK_KEYS = ['external_id', 'status', 'amount', 'currency', 'name', 'id', 'received_at']
 
 function toJson(config: AccountConfig, bankUsername: string | null) {
   return {

--- a/src/contexts/banking/application/NotifyBankMovementUseCase.ts
+++ b/src/contexts/banking/application/NotifyBankMovementUseCase.ts
@@ -28,7 +28,7 @@ export class NotifyBankMovementUseCase {
       id:          tx.id,
       amount:      tx.amount,
       currency:    tx.currency,
-      sender_name: tx.senderName ?? null,
+      name:        tx.senderName ?? null,
       received_at: tx.receivedAt instanceof Date ? tx.receivedAt.toISOString() : tx.receivedAt,
     }
 

--- a/src/contexts/conciliation/application/NotifyWebhookUseCase.ts
+++ b/src/contexts/conciliation/application/NotifyWebhookUseCase.ts
@@ -35,7 +35,7 @@ export class NotifyWebhookUseCase {
       status:      req.status,
       amount:      Number(req.expected_amount),
       currency:    req.currency,
-      sender_name: req.sender_name ?? null,
+      name:        req.sender_name ?? null,
     }
 
     const extraFields = req.webhook_extra_fields

--- a/src/contexts/conciliation/application/PollPendingOrdersUseCase.ts
+++ b/src/contexts/conciliation/application/PollPendingOrdersUseCase.ts
@@ -62,8 +62,8 @@ export class PollPendingOrdersUseCase {
     const seenExternalIds: string[] = []
 
     for (const order of orders) {
-      if (!order.external_id || order.amount == null || !order.currency || !order.sender_name) {
-        console.warn(`[PollPendingOrders] Skipping order missing required fields (external_id, amount, currency, sender_name):`, order)
+      if (!order.external_id || order.amount == null || !order.currency || !order.name) {
+        console.warn(`[PollPendingOrders] Skipping order missing required fields (external_id, amount, currency, name):`, order)
         continue
       }
 
@@ -83,7 +83,7 @@ export class PollPendingOrdersUseCase {
          VALUES ($1,$2,$3,$4,$5,$6,'pending',0,now())`,
         [
           requestId, accountId, externalId,
-          order.amount, order.currency, order.sender_name ?? null,
+          order.amount, order.currency, order.name ?? null,
         ]
       )
 


### PR DESCRIPTION
This pull request standardizes the naming of a key field in webhook payloads and related code, changing all occurrences of `sender_name` to `name`. It also updates reserved key lists, documentation, and validation logic to reflect this change. This ensures consistency across the codebase and improves clarity for both developers and users.

**Key changes:**

**API and backend logic:**
* Renamed the `sender_name` field to `name` in webhook payloads and all related backend logic, including the `NotifyBankMovementUseCase`, `NotifyWebhookUseCase`, and `PollPendingOrdersUseCase` classes. [[1]](diffhunk://#diff-35d38058e94673b91e6e500511f0faafea5fc0cc62e4a14fbaa76a8848918a2eL31-R31) [[2]](diffhunk://#diff-ef4d4abfcf1bb58d7bd6c960521b1f55b99053f454d2372265f7c85e4b2247cdL38-R38) [[3]](diffhunk://#diff-25a1f72e6edabef3ab898933d88ce8a104cb6061c0cebb22cc8307c53526569bL65-R66) [[4]](diffhunk://#diff-25a1f72e6edabef3ab898933d88ce8a104cb6061c0cebb22cc8307c53526569bL86-R86)

**Validation and reserved keys:**
* Updated the `RESERVED_WEBHOOK_KEYS` constant in both frontend (`AccountConfig.tsx`) and backend (`accounts.routes.ts`) to replace `sender_name` with `name`. [[1]](diffhunk://#diff-6e6402a92bc7af66be6a556d37e1d3195c7c8290ca7949fdb3fdedd320b62d1dL35-R35) [[2]](diffhunk://#diff-b91cc4eea65dab509e3aad90e0ee32cd45d0225aa075b988a9fc01183c309b58L15-R15)

**Documentation and user interface:**
* Updated webhook payload examples and reserved key descriptions in both English and Spanish translations, as well as in code samples, to use `name` instead of `sender_name`. [[1]](diffhunk://#diff-4ff768c3b7cbc0b99efd419ca4dbb0354dd4c09a0df1792551a2c0e7a6afb1f2L165-R165) [[2]](diffhunk://#diff-f15fde526479c9f454b4ac66327c362fed5b662075455e91061fd864d9052a44L165-R165) [[3]](diffhunk://#diff-6e6402a92bc7af66be6a556d37e1d3195c7c8290ca7949fdb3fdedd320b62d1dL241-R241) [[4]](diffhunk://#diff-6e6402a92bc7af66be6a556d37e1d3195c7c8290ca7949fdb3fdedd320b62d1dL298-R304)

These changes ensure that the `name` field is used consistently throughout the codebase and user-facing documentation, reducing confusion and potential integration issues.