### PR TITLE
Enhance server with static file serving and SPA fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "tsx watch src/index.ts",
-    "build": "tsc",
+    "build": "tsc && cp -r src/contexts/script-engine/infrastructure/scripts dist/contexts/script-engine/infrastructure/scripts",
     "start": "node dist/index.js",
     "migrate": "tsx --tsconfig tsconfig.json src/shared/infrastructure/db/migrate.ts"
   },

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1,5 +1,8 @@
 import express from "express";
 import cors from "cors";
+import path from "path";
+import { fileURLToPath } from "url";
+import { existsSync } from "fs";
 import { authRouter } from "./routes/auth.routes.js";
 import { accountsRouter } from "./routes/accounts.routes.js";
 import { banksRouter } from "./routes/banks.routes.js";
@@ -7,6 +10,9 @@ import { conciliationRouter } from "./routes/conciliation.routes.js";
 import { scriptsRouter } from "./routes/scripts.routes.js";
 import { errorMiddleware } from "./middlewares/error.middleware.js";
 import { authMiddleware } from "./middlewares/auth.middleware.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const clientDist = path.resolve(__dirname, "../../client/dist")
 
 export function createServer() {
   const app = express();
@@ -24,7 +30,12 @@ export function createServer() {
   app.get("/health", (_req, res) => res.json({ ok: true }));
   app.use("/auth", authRouter);
 
-  // Protected
+  // Static files — no auth required
+  if (existsSync(clientDist)) {
+    app.use(express.static(clientDist));
+  }
+
+  // Protected API
   app.use(authMiddleware);
   app.use("/accounts", accountsRouter);
   app.use("/banks", banksRouter);
@@ -32,5 +43,11 @@ export function createServer() {
   app.use("/scripts", scriptsRouter);
 
   app.use(errorMiddleware);
+
+  // SPA fallback — after API routes, no auth (React handles client-side auth)
+  if (existsSync(clientDist)) {
+    app.get("/{*splat}", (_req, res) => res.sendFile(path.join(clientDist, "index.html")));
+  }
+
   return app;
 }


### PR DESCRIPTION
This pull request adds support for serving a built React client from the server, enabling static file hosting and client-side routing fallback. It also updates the build process to ensure necessary static assets are copied for deployment.

**Static file serving and SPA support:**

* [`src/api/server.ts`](diffhunk://#diff-4f5348f6211cbb1a6e63df58580dcb1bc674a3152eb6ddafce64fd979ae490c8R3-R5): Adds logic to serve static files from the `client/dist` directory if it exists, and sets up a fallback route to serve `index.html` for client-side routing in a single-page application (SPA). This is done after API routes and does not require authentication, allowing React to handle client-side auth. [[1]](diffhunk://#diff-4f5348f6211cbb1a6e63df58580dcb1bc674a3152eb6ddafce64fd979ae490c8R3-R5) [[2]](diffhunk://#diff-4f5348f6211cbb1a6e63df58580dcb1bc674a3152eb6ddafce64fd979ae490c8R14-R16) [[3]](diffhunk://#diff-4f5348f6211cbb1a6e63df58580dcb1bc674a3152eb6ddafce64fd979ae490c8L27-R51)

**Build process update:**

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L9-R9): Updates the `build` script to copy the `src/contexts/script-engine/infrastructure/scripts` directory into the distribution folder after TypeScript compilation, ensuring these scripts are available in production builds.