### PR TITLE
Integrate structured logging across application components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 .env
 *.log
+logs/

--- a/src/api/middlewares/error.middleware.ts
+++ b/src/api/middlewares/error.middleware.ts
@@ -1,6 +1,9 @@
 import { Request, Response, NextFunction } from 'express'
+import { logger } from '../../shared/infrastructure/logger/index.js'
+
+const log = logger.child('[http]')
 
 export function errorMiddleware(err: Error, _req: Request, res: Response, _next: NextFunction): void {
-  console.error(err)
+  log.error(err.message, { stack: err.stack })
   res.status(500).json({ error: err.message })
 }

--- a/src/contexts/conciliation/application/ExpireStaleRequestsUseCase.ts
+++ b/src/contexts/conciliation/application/ExpireStaleRequestsUseCase.ts
@@ -2,6 +2,9 @@ import { db } from '../../../shared/infrastructure/db/client.js'
 import { EventBus } from '../../../shared/events/EventBus.js'
 import { ConciliationRequestRepository } from '../infrastructure/ConciliationRequestRepository.js'
 import { Queues } from '../../../shared/infrastructure/queues/QueueRegistry.js'
+import { logger } from '../../../shared/infrastructure/logger/index.js'
+
+const log = logger.child('[conciliation]')
 
 export class ExpireStaleRequestsUseCase {
   private readonly requestRepo = new ConciliationRequestRepository()
@@ -35,7 +38,7 @@ export class ExpireStaleRequestsUseCase {
     }
 
     if (rows.length > 0) {
-      console.log(`[ExpireStaleRequests] Expired ${rows.length} request(s)`)
+      log.info(`expired stale requests`, { count: rows.length })
     }
   }
 }

--- a/src/contexts/conciliation/application/OnTransactionIngestedUseCase.ts
+++ b/src/contexts/conciliation/application/OnTransactionIngestedUseCase.ts
@@ -3,6 +3,9 @@ import { Queues } from '../../../shared/infrastructure/queues/QueueRegistry.js'
 import { BankTransactionRepository } from '../../banking/infrastructure/BankTransactionRepository.js'
 import { IBankTransactionRepository } from '../../banking/domain/IBankTransactionRepository.js'
 import { TransactionIngestedEvent } from '../../../shared/events/events/TransactionIngested.event.js'
+import { logger } from '../../../shared/infrastructure/logger/index.js'
+
+const log = logger.child('[conciliation]')
 
 export class OnTransactionIngestedUseCase {
   constructor(
@@ -22,7 +25,7 @@ export class OnTransactionIngestedUseCase {
 
     if (rows.length === 0) {
       await this.txRepo.markExcluded(txId)
-      console.log(`[OnTransactionIngested] tx ${txId} excluded (no active requests)`)
+      log.info(`tx excluded — no active requests`, { txId })
       return
     }
 
@@ -31,6 +34,6 @@ export class OnTransactionIngestedUseCase {
       { transactionId: txId },
       { jobId: `tx_conciliation_${txId}`, removeOnComplete: true }
     )
-    console.log(`[OnTransactionIngested] tx ${txId} → enqueued tx-conciliation`)
+    log.info(`tx enqueued for tx-conciliation`, { txId })
   }
 }

--- a/src/contexts/conciliation/application/PollPendingOrdersUseCase.ts
+++ b/src/contexts/conciliation/application/PollPendingOrdersUseCase.ts
@@ -2,7 +2,10 @@ import { db } from '../../../shared/infrastructure/db/client.js'
 import { Queues } from '../../../shared/infrastructure/queues/QueueRegistry.js'
 import { ConciliationRequestRepository } from '../infrastructure/ConciliationRequestRepository.js'
 import { AccountConfigRepository } from '../../account/infrastructure/AccountConfigRepository.js'
+import { logger } from '../../../shared/infrastructure/logger/index.js'
 import crypto from 'crypto'
+
+const log = logger.child('[conciliation]')
 
 interface JobData { accountId: string }
 
@@ -63,7 +66,7 @@ export class PollPendingOrdersUseCase {
 
     for (const order of orders) {
       if (!order.external_id || order.amount == null || !order.currency || !order.name) {
-        console.warn(`[PollPendingOrders] Skipping order missing required fields (external_id, amount, currency, name):`, order)
+        log.warn(`skipping order missing required fields`, { order })
         continue
       }
 
@@ -97,7 +100,7 @@ export class PollPendingOrdersUseCase {
 
     const cancelledCount = await this.requestRepo.cancelMissing(accountId, seenExternalIds)
     if (cancelledCount > 0) {
-      console.log(`[PollPendingOrders] Cancelled ${cancelledCount} order(s) missing from source for account ${accountId}`)
+      log.info(`cancelled orders missing from source`, { accountId, cancelledCount })
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,9 @@ import { TransactionIngestedEvent } from './shared/events/events/TransactionInge
 import { ConciliationMatchedEvent } from './shared/events/events/ConciliationMatched.event.js'
 import { Queues } from './shared/infrastructure/queues/QueueRegistry.js'
 import { OnTransactionIngestedUseCase } from './contexts/conciliation/application/OnTransactionIngestedUseCase.js'
+import { logger } from './shared/infrastructure/logger/index.js'
+
+const log = logger.child('[app]')
 
 const onTransactionIngested = new OnTransactionIngestedUseCase()
 
@@ -33,7 +36,7 @@ EventBus.subscribe<ConciliationMatchedEvent>('ConciliationMatched', async (event
     { requestId: event.aggregateId },
     { jobId: `webhook_${event.aggregateId}`, removeOnComplete: true }
   )
-  console.log(`[EventBus] ConciliationMatched → webhook enqueued for ${event.aggregateId}`)
+  log.info(`ConciliationMatched — webhook enqueued`, { aggregateId: event.aggregateId })
 })
 
 const PORT = process.env.PORT ?? 3000
@@ -42,17 +45,19 @@ const app = createServer()
 const scheduler = new Scheduler()
 
 app.listen(PORT, async () => {
-  console.log(`Server running on port ${PORT}`)
+  log.info(`server listening`, { port: PORT })
   await scheduler.start()
 })
 
-console.log('Workers started:', [
-  orderIngestionWorker.name,
-  bankScrapeWorker.name,
-  conciliationWorker.name,
-  webhookWorker.name,
-  bankMovementWebhookWorker.name,
-].join(', '))
+log.info('workers started', {
+  workers: [
+    orderIngestionWorker.name,
+    bankScrapeWorker.name,
+    conciliationWorker.name,
+    webhookWorker.name,
+    bankMovementWebhookWorker.name,
+  ].join(', ')
+})
 
 process.on('SIGTERM', async () => {
   scheduler.stop()

--- a/src/shared/infrastructure/db/migrate.ts
+++ b/src/shared/infrastructure/db/migrate.ts
@@ -3,6 +3,9 @@ import { db } from './client.js'
 import fs from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
+import { logger } from '../logger/index.js'
+
+const log = logger.child('[migrate]')
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const migrationsDir = path.join(__dirname, 'migrations')
@@ -26,21 +29,21 @@ async function migrate() {
       [file]
     )
     if (rows.length > 0) {
-      console.log(`  skip  ${file}`)
+      log.info(`skip  ${file}`)
       continue
     }
 
     const sql = fs.readFileSync(path.join(migrationsDir, file), 'utf8')
     await db.query(sql)
     await db.query('INSERT INTO _migrations (filename) VALUES ($1)', [file])
-    console.log(`  apply ${file}`)
+    log.info(`apply ${file}`)
   }
 
-  console.log('\nDone.')
+  log.info('done')
   await db.end()
 }
 
 migrate().catch(err => {
-  console.error(err)
+  log.error('migration failed', { error: err instanceof Error ? err.message : String(err), stack: err instanceof Error ? err.stack : undefined })
   process.exit(1)
 })

--- a/src/shared/infrastructure/logger/index.ts
+++ b/src/shared/infrastructure/logger/index.ts
@@ -1,0 +1,28 @@
+import winston from 'winston'
+import { buildTransports } from './transports.js'
+
+const rootLogger = winston.createLogger({
+  level: process.env.LOG_LEVEL ?? 'info',
+  transports: buildTransports(),
+})
+
+export interface Logger {
+  debug(message: string, meta?: Record<string, unknown>): void
+  info(message: string, meta?: Record<string, unknown>): void
+  warn(message: string, meta?: Record<string, unknown>): void
+  error(message: string, meta?: Record<string, unknown>): void
+  child(context: string): Logger
+}
+
+function wrap(inner: winston.Logger, context?: string): Logger {
+  const base = context ? { context } : {}
+  return {
+    debug: (msg, meta) => inner.debug(msg, { ...base, ...meta }),
+    info:  (msg, meta) => inner.info(msg,  { ...base, ...meta }),
+    warn:  (msg, meta) => inner.warn(msg,  { ...base, ...meta }),
+    error: (msg, meta) => inner.error(msg, { ...base, ...meta }),
+    child: (ctx) => wrap(inner, ctx),
+  }
+}
+
+export const logger: Logger = wrap(rootLogger)

--- a/src/shared/infrastructure/logger/transports.ts
+++ b/src/shared/infrastructure/logger/transports.ts
@@ -1,0 +1,35 @@
+import winston from 'winston'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { mkdirSync } from 'fs'
+
+const { combine, timestamp, json, printf, colorize, errors } = winston.format
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const logsDir = path.resolve(__dirname, '../../../../..', 'logs')
+
+mkdirSync(logsDir, { recursive: true })
+
+const fileFormat = combine(errors({ stack: true }), timestamp(), json())
+
+const consoleFormat = combine(
+  errors({ stack: true }),
+  timestamp({ format: 'HH:mm:ss' }),
+  colorize({ all: true }),
+  printf(({ level, message, timestamp, context, ...meta }) => {
+    const ctx = context ? `${context} ` : ''
+    const extra = Object.keys(meta).length ? ' ' + JSON.stringify(meta) : ''
+    return `${timestamp} ${level}: ${ctx}${message}${extra}`
+  })
+)
+
+export function buildTransports(): winston.transport[] {
+  const transports: winston.transport[] = [
+    new winston.transports.File({ filename: path.join(logsDir, 'error.log'), level: 'error', format: fileFormat }),
+    new winston.transports.File({ filename: path.join(logsDir, 'app.log'), format: fileFormat }),
+  ]
+  if (process.env.NODE_ENV !== 'production') {
+    transports.push(new winston.transports.Console({ format: consoleFormat }))
+  }
+  return transports
+}

--- a/src/shared/infrastructure/queues/Scheduler.ts
+++ b/src/shared/infrastructure/queues/Scheduler.ts
@@ -2,6 +2,9 @@ import { Queues } from './QueueRegistry.js'
 import { enqueueBankScrape } from './BankScrapeQueue.js'
 import { db } from '../db/client.js'
 import { ExpireStaleRequestsUseCase } from '../../../contexts/conciliation/application/ExpireStaleRequestsUseCase.js'
+import { logger } from '../logger/index.js'
+
+const log = logger.child('[scheduler]')
 
 export class Scheduler {
   private timers: NodeJS.Timeout[] = []
@@ -23,15 +26,13 @@ export class Scheduler {
       setInterval(() => this.expireStaleRequests(), expireInterval),
     )
 
-    console.log(
-      `Scheduler started — polling every ${pollingInterval / 1000}s, scraping every ${scrapeInterval / 1000}s, expiring every ${expireInterval / 1000}s`
-    )
+    log.info('started', { pollingIntervalSec: pollingInterval / 1000, scrapeIntervalSec: scrapeInterval / 1000, expireIntervalSec: expireInterval / 1000 })
   }
 
   stop(): void {
     this.timers.forEach(t => clearInterval(t))
     this.timers = []
-    console.log('Scheduler stopped')
+    log.info('stopped')
   }
 
   private async enqueuePolling(): Promise<void> {
@@ -51,7 +52,7 @@ export class Scheduler {
       )
     }
 
-    console.log(`[Scheduler] Enqueued polling for ${accounts.length} account(s)`)
+    log.info(`enqueued polling`, { accountCount: accounts.length })
   }
 
   private async enqueueScraping(): Promise<void> {
@@ -69,11 +70,11 @@ export class Scheduler {
         queued += 1
       } else {
         skipped += 1
-        console.log(`[Scheduler] Skipping scrape for ${account.id} — already queued`)
+        log.debug(`skipping scrape — already queued`, { accountId: account.id })
       }
     }
 
-    console.log(`[Scheduler] Enqueued scraping for ${queued} account(s), skipped ${skipped}`)
+    log.info(`enqueued scraping`, { queued, skipped })
   }
 
   private async expireStaleRequests(): Promise<void> {

--- a/src/shared/infrastructure/queues/workers/bank-scrape.worker.ts
+++ b/src/shared/infrastructure/queues/workers/bank-scrape.worker.ts
@@ -1,12 +1,15 @@
 import { Worker, Job } from "bullmq";
 import { redis } from "../QueueRegistry.js";
+import { logger } from "../../logger/index.js";
+
+const log = logger.child('[bank-scrape]')
 
 const bankScrapeConcurrency = Number(process.env.BANK_SCRAPE_CONCURRENCY ?? 2);
 
 export const bankScrapeWorker = new Worker(
   "bank-scrape",
   async (job: Job) => {
-    console.log(`[bank-scrape] starting job ${job.id}`, job.data);
+    log.info(`starting job ${job.id}`, { jobData: job.data });
 
     const keepAlive = setInterval(() => {
       job.extendLock(job.token!, 60_000).catch(() => {});
@@ -16,9 +19,9 @@ export const bankScrapeWorker = new Worker(
       const mod =
         await import("../../../../contexts/banking/application/RunBankScrapeUseCase.js");
       await new mod.RunBankScrapeUseCase().execute(job.data);
-      console.log(`[bank-scrape] job ${job.id} completed`);
+      log.info(`job ${job.id} completed`);
     } catch (err) {
-      console.error(`[bank-scrape] job ${job.id} failed:`, err);
+      log.error(`job ${job.id} failed`, { error: err instanceof Error ? err.message : String(err) });
       throw err;
     } finally {
       clearInterval(keepAlive);
@@ -36,5 +39,5 @@ export const bankScrapeWorker = new Worker(
 );
 
 bankScrapeWorker.on("failed", (job, err) => {
-  console.error(`[bank-scrape] worker failed event:`, job?.id, err.message);
+  log.error(`worker failed event`, { jobId: job?.id, error: err.message });
 });

--- a/src/shared/infrastructure/queues/workers/conciliation.worker.ts
+++ b/src/shared/infrastructure/queues/workers/conciliation.worker.ts
@@ -1,5 +1,11 @@
 import { Worker } from 'bullmq'
 import { redis } from '../QueueRegistry.js'
+import { logger } from '../../logger/index.js'
+
+const conciliationLog = logger.child('[conciliation]')
+const txConciliationLog = logger.child('[tx-conciliation]')
+const webhookLog = logger.child('[webhook]')
+const bankMovementWebhookLog = logger.child('[bank-movement-webhook]')
 
 export const conciliationWorker = new Worker(
   'conciliation',
@@ -11,11 +17,11 @@ export const conciliationWorker = new Worker(
 )
 
 conciliationWorker.on('completed', job => {
-  console.log(`[conciliation] job ${job.id} completed`)
+  conciliationLog.info(`job ${job.id} completed`)
 })
 
 conciliationWorker.on('failed', (job, err) => {
-  console.error(`[conciliation] job ${job?.id} failed (attempt ${job?.attemptsMade}):`, err.message)
+  conciliationLog.error(`job ${job?.id} failed (attempt ${job?.attemptsMade})`, { error: err.message })
 })
 
 export const txConciliationWorker = new Worker(
@@ -28,11 +34,11 @@ export const txConciliationWorker = new Worker(
 )
 
 txConciliationWorker.on('completed', job => {
-  console.log(`[tx-conciliation] job ${job.id} completed`)
+  txConciliationLog.info(`job ${job.id} completed`)
 })
 
 txConciliationWorker.on('failed', (job, err) => {
-  console.error(`[tx-conciliation] job ${job?.id} failed (attempt ${job?.attemptsMade}):`, err.message)
+  txConciliationLog.error(`job ${job?.id} failed (attempt ${job?.attemptsMade})`, { error: err.message })
 })
 
 export const webhookWorker = new Worker(
@@ -45,11 +51,11 @@ export const webhookWorker = new Worker(
 )
 
 webhookWorker.on('completed', job => {
-  console.log(`[webhook] job ${job.id} completed`)
+  webhookLog.info(`job ${job.id} completed`)
 })
 
 webhookWorker.on('failed', (job, err) => {
-  console.error(`[webhook] job ${job?.id} failed (attempt ${job?.attemptsMade}):`, err.message)
+  webhookLog.error(`job ${job?.id} failed (attempt ${job?.attemptsMade})`, { error: err.message })
 })
 
 export const bankMovementWebhookWorker = new Worker(
@@ -62,9 +68,9 @@ export const bankMovementWebhookWorker = new Worker(
 )
 
 bankMovementWebhookWorker.on('completed', job => {
-  console.log(`[bank-movement-webhook] job ${job.id} completed`)
+  bankMovementWebhookLog.info(`job ${job.id} completed`)
 })
 
 bankMovementWebhookWorker.on('failed', (job, err) => {
-  console.error(`[bank-movement-webhook] job ${job?.id} failed (attempt ${job?.attemptsMade}):`, err.message)
+  bankMovementWebhookLog.error(`job ${job?.id} failed (attempt ${job?.attemptsMade})`, { error: err.message })
 })

--- a/src/shared/infrastructure/queues/workers/order-ingestion.worker.ts
+++ b/src/shared/infrastructure/queues/workers/order-ingestion.worker.ts
@@ -1,16 +1,19 @@
 import { Worker } from 'bullmq'
 import { redis } from '../QueueRegistry.js'
+import { logger } from '../../logger/index.js'
+
+const log = logger.child('[order-ingestion]')
 
 export const orderIngestionWorker = new Worker(
   'order-ingestion',
   async job => {
-    console.log(`[order-ingestion] starting job ${job.id}`, job.data)
+    log.info(`starting job ${job.id}`, { jobData: job.data })
     try {
       const mod = await import('../../../../contexts/conciliation/application/PollPendingOrdersUseCase.js')
       await new mod.PollPendingOrdersUseCase().execute(job.data)
-      console.log(`[order-ingestion] job ${job.id} completed`)
+      log.info(`job ${job.id} completed`)
     } catch (err) {
-      console.error(`[order-ingestion] job ${job.id} failed:`, err)
+      log.error(`job ${job.id} failed`, { error: err instanceof Error ? err.message : String(err) })
       throw err
     }
   },
@@ -18,5 +21,5 @@ export const orderIngestionWorker = new Worker(
 )
 
 orderIngestionWorker.on('failed', (job, err) => {
-  console.error(`[order-ingestion] worker failed event:`, job?.id, err.message)
+  log.error(`worker failed event`, { jobId: job?.id, error: err.message })
 })

--- a/src/shared/infrastructure/webhooks/WebhookSender.ts
+++ b/src/shared/infrastructure/webhooks/WebhookSender.ts
@@ -1,3 +1,7 @@
+import { logger } from '../logger/index.js'
+
+const log = logger.child('[webhook]')
+
 interface SendWebhookOptions {
   url: string
   payload: Record<string, unknown>
@@ -12,13 +16,13 @@ export async function sendWebhook({ url, payload, authType, authToken }: SendWeb
   }
 
   const body = JSON.stringify(payload)
-  console.log(`[webhook] POST ${url}`)
-  console.log(`[webhook] headers:`, JSON.stringify(headers))
-  console.log(`[webhook] body:`, body)
+  log.debug(`POST ${url}`)
+  log.debug(`headers`, { headers: { ...headers, Authorization: headers['Authorization'] ? '[REDACTED]' : undefined } })
+  log.debug(`body`, { body })
 
   const response = await fetch(url, { method: 'POST', headers, body })
   const responseBody = await response.text().catch(() => '')
-  console.log(`[webhook] response: ${response.status} ${response.statusText} — ${responseBody}`)
+  log.info(`response`, { status: response.status, statusText: response.statusText, body: responseBody })
 
   if (!response.ok) {
     throw new Error(


### PR DESCRIPTION
This pull request introduces a centralized, structured logging system across the codebase using a new logger abstraction built on top of Winston. All previous usages of `console.log`, `console.error`, and `console.warn` have been refactored to use the new logger, providing consistent log formatting, log levels, and support for context-rich metadata. The logger is now used throughout application logic, background workers, middleware, and infrastructure scripts.

The most important changes are:

**New Logging Infrastructure**

* Added a new logger implementation in `src/shared/infrastructure/logger/index.ts` that wraps Winston, provides a consistent `Logger` interface, supports hierarchical child loggers for contextual logging, and exports a singleton logger instance.
* Implemented log transport configuration in `src/shared/infrastructure/logger/transports.ts`, with support for log files and colorized console output, and automatic creation of a `logs` directory.

**Application-wide Logger Integration**

* Replaced all `console.log`, `console.error`, and `console.warn` statements with structured logger calls across the application, including API middleware (`error.middleware.ts`), use cases (`ExpireStaleRequestsUseCase.ts`, `OnTransactionIngestedUseCase.ts`, `PollPendingOrdersUseCase.ts`), the main entrypoint (`index.ts`), database migration scripts (`migrate.ts`), the scheduler (`Scheduler.ts`), and all queue workers (`bank-scrape.worker.ts`, `conciliation.worker.ts`). Each area uses a context-specific child logger for clarity. [[1]](diffhunk://#diff-ff5c04d2bd376d117b0af3d538a3d8358680ccce3026338b08ed9bb35391c85bR2-R7) [[2]](diffhunk://#diff-ba45468f9f62526c663b55d87d201b972bf7b6b09bdb42c18528b61777e8d319R5-R7) [[3]](diffhunk://#diff-ba45468f9f62526c663b55d87d201b972bf7b6b09bdb42c18528b61777e8d319L38-R41) [[4]](diffhunk://#diff-5f846859dd85e4b869f2fc76e865dbe77fa693fbb60d33a37bd68cb72e197fecR6-R8) [[5]](diffhunk://#diff-5f846859dd85e4b869f2fc76e865dbe77fa693fbb60d33a37bd68cb72e197fecL25-R28) [[6]](diffhunk://#diff-5f846859dd85e4b869f2fc76e865dbe77fa693fbb60d33a37bd68cb72e197fecL34-R37) [[7]](diffhunk://#diff-25a1f72e6edabef3ab898933d88ce8a104cb6061c0cebb22cc8307c53526569bR5-R9) [[8]](diffhunk://#diff-25a1f72e6edabef3ab898933d88ce8a104cb6061c0cebb22cc8307c53526569bL66-R69) [[9]](diffhunk://#diff-25a1f72e6edabef3ab898933d88ce8a104cb6061c0cebb22cc8307c53526569bL100-R103) [[10]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R12-R14) [[11]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L36-R39) [[12]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L45-R60) [[13]](diffhunk://#diff-e08136681add63007fe4919e7d5a128d01d604956125637b45131a46f3c7bf0cR6-R8) [[14]](diffhunk://#diff-e08136681add63007fe4919e7d5a128d01d604956125637b45131a46f3c7bf0cL29-R47) [[15]](diffhunk://#diff-7e5ae8d270f275030dfd7affe5542b927d33458eaecc9659cf013f87bb4688bdR5-R7) [[16]](diffhunk://#diff-7e5ae8d270f275030dfd7affe5542b927d33458eaecc9659cf013f87bb4688bdL26-R35) [[17]](diffhunk://#diff-7e5ae8d270f275030dfd7affe5542b927d33458eaecc9659cf013f87bb4688bdL54-R55) [[18]](diffhunk://#diff-7e5ae8d270f275030dfd7affe5542b927d33458eaecc9659cf013f87bb4688bdL72-R77) [[19]](diffhunk://#diff-ab387140dfdef2bfc7e2e54e209b28c9ea2f3a057ef62c61bc5c6ceeb08ae63dR3-R12) [[20]](diffhunk://#diff-ab387140dfdef2bfc7e2e54e209b28c9ea2f3a057ef62c61bc5c6ceeb08ae63dL19-R24) [[21]](diffhunk://#diff-ab387140dfdef2bfc7e2e54e209b28c9ea2f3a057ef62c61bc5c6ceeb08ae63dL39-R42) [[22]](diffhunk://#diff-889081326ced6f1987b38b49e9eb5eda6a60349fb909ade25e346b73b8e5921eR3-R8) [[23]](diffhunk://#diff-889081326ced6f1987b38b49e9eb5eda6a60349fb909ade25e346b73b8e5921eL14-R24) [[24]](diffhunk://#diff-889081326ced6f1987b38b49e9eb5eda6a60349fb909ade25e346b73b8e5921eL31-R41) [[25]](diffhunk://#diff-889081326ced6f1987b38b49e9eb5eda6a60349fb909ade25e346b73b8e5921eL48-R58) [[26]](diffhunk://#diff-889081326ced6f1987b38b49e9eb5eda6a60349fb909ade25e346b73b8e5921eL65-R75)

**Improved Log Structure and Metadata**

* All log messages now include structured metadata (such as job IDs, error messages, counts, and account IDs), making logs more useful for debugging and monitoring. Log context is consistently set for each logical subsystem (e.g., `[conciliation]`, `[scheduler]`, `[bank-scrape]`). [[1]](diffhunk://#diff-ba45468f9f62526c663b55d87d201b972bf7b6b09bdb42c18528b61777e8d319L38-R41) [[2]](diffhunk://#diff-5f846859dd85e4b869f2fc76e865dbe77fa693fbb60d33a37bd68cb72e197fecL25-R28) [[3]](diffhunk://#diff-5f846859dd85e4b869f2fc76e865dbe77fa693fbb60d33a37bd68cb72e197fecL34-R37) [[4]](diffhunk://#diff-25a1f72e6edabef3ab898933d88ce8a104cb6061c0cebb22cc8307c53526569bL66-R69) [[5]](diffhunk://#diff-25a1f72e6edabef3ab898933d88ce8a104cb6061c0cebb22cc8307c53526569bL100-R103) [[6]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L36-R39) [[7]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L45-R60) [[8]](diffhunk://#diff-7e5ae8d270f275030dfd7affe5542b927d33458eaecc9659cf013f87bb4688bdL26-R35) [[9]](diffhunk://#diff-7e5ae8d270f275030dfd7affe5542b927d33458eaecc9659cf013f87bb4688bdL54-R55) [[10]](diffhunk://#diff-7e5ae8d270f275030dfd7affe5542b927d33458eaecc9659cf013f87bb4688bdL72-R77) [[11]](diffhunk://#diff-ab387140dfdef2bfc7e2e54e209b28c9ea2f3a057ef62c61bc5c6ceeb08ae63dL19-R24) [[12]](diffhunk://#diff-ab387140dfdef2bfc7e2e54e209b28c9ea2f3a057ef62c61bc5c6ceeb08ae63dL39-R42) [[13]](diffhunk://#diff-889081326ced6f1987b38b49e9eb5eda6a60349fb909ade25e346b73b8e5921eL14-R24) [[14]](diffhunk://#diff-889081326ced6f1987b38b49e9eb5eda6a60349fb909ade25e346b73b8e5921eL31-R41) [[15]](diffhunk://#diff-889081326ced6f1987b38b49e9eb5eda6a60349fb909ade25e346b73b8e5921eL48-R58) [[16]](diffhunk://#diff-889081326ced6f1987b38b49e9eb5eda6a60349fb909ade25e346b73b8e5921eL65-R75)

Overall, these changes provide a robust and maintainable logging foundation, improving observability and operational insight throughout the system.