### PR TITLE
Add silent ingestion feature to account configuration

### DIFF
--- a/src/api/routes/accounts.routes.ts
+++ b/src/api/routes/accounts.routes.ts
@@ -31,6 +31,7 @@ function toJson(config: AccountConfig, bankUsername: string | null) {
     webhook_auth_token: config.webhookAuthToken,
     notify_on_expired: config.notifyOnExpired,
     webhook_extra_fields: config.webhookExtraFields,
+    silent_ingestion: config.silentIngestion,
     bank_username: bankUsername,
   }
 }
@@ -127,6 +128,7 @@ accountsRouter.put('/:accountId/config', async (req, res) => {
     notify_on_expired,
     webhook_extra_fields,
     mode,
+    silent_ingestion,
   } = req.body
 
   const normalizedMode: AccountMode = mode === 'passthrough' ? 'passthrough' : 'reconcile'
@@ -210,6 +212,7 @@ accountsRouter.put('/:accountId/config', async (req, res) => {
     webhookAuthToken: normalizedWebhookAuthToken,
     notifyOnExpired: notify_on_expired ?? false,
     webhookExtraFields: normalizedWebhookExtraFields,
+    silentIngestion: silent_ingestion ?? false,
   })
 
   const switchingToPassthrough =

--- a/src/contexts/account/domain/AccountConfig.ts
+++ b/src/contexts/account/domain/AccountConfig.ts
@@ -17,6 +17,7 @@ export interface AccountConfig {
   webhookAuthToken: string | null
   notifyOnExpired: boolean
   webhookExtraFields: Record<string, unknown> | null
+  silentIngestion: boolean
 }
 
 export interface AccountConfigInput {
@@ -33,4 +34,5 @@ export interface AccountConfigInput {
   webhookAuthToken: string | null
   notifyOnExpired: boolean
   webhookExtraFields: Record<string, unknown> | null
+  silentIngestion: boolean
 }

--- a/src/contexts/account/infrastructure/AccountConfigRepository.ts
+++ b/src/contexts/account/infrastructure/AccountConfigRepository.ts
@@ -18,6 +18,7 @@ function reconstitute(row: any): AccountConfig {
     webhookAuthToken: row.webhook_auth_token,
     notifyOnExpired: row.notify_on_expired,
     webhookExtraFields: row.webhook_extra_fields,
+    silentIngestion: row.silent_ingestion ?? false,
   }
 }
 
@@ -35,8 +36,8 @@ export class AccountConfigRepository implements IAccountConfigRepository {
       `INSERT INTO account_config
          (id, account_id, pending_orders_endpoint, webhook_url,
           retry_limit, polling_method, polling_body, auth_type, auth_token,
-          webhook_auth_type, webhook_auth_token, notify_on_expired, webhook_extra_fields, mode)
-       VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+          webhook_auth_type, webhook_auth_token, notify_on_expired, webhook_extra_fields, mode, silent_ingestion)
+       VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
        ON CONFLICT (account_id) DO UPDATE SET
          pending_orders_endpoint = $2,
          webhook_url             = $3,
@@ -50,6 +51,7 @@ export class AccountConfigRepository implements IAccountConfigRepository {
          notify_on_expired       = $11,
          webhook_extra_fields    = $12,
          mode                    = $13,
+         silent_ingestion        = $14,
          updated_at              = now()
        RETURNING *`,
       [
@@ -66,6 +68,7 @@ export class AccountConfigRepository implements IAccountConfigRepository {
         input.notifyOnExpired,
         input.webhookExtraFields,
         input.mode,
+        input.silentIngestion,
       ]
     )
     return reconstitute(rows[0])

--- a/src/contexts/banking/application/NotifyBankMovementUseCase.ts
+++ b/src/contexts/banking/application/NotifyBankMovementUseCase.ts
@@ -22,6 +22,8 @@ export class NotifyBankMovementUseCase {
     const claimed = await this.bankTxRepo.claimNotification(bankTransactionId)
     if (!claimed) return
 
+    if (config.silentIngestion) return
+
     const token = config.webhookAuthToken ?? config.authToken
     const authType = config.webhookAuthType ?? config.authType
 

--- a/src/shared/infrastructure/db/migrations/024_account_config_silent_ingestion.sql
+++ b/src/shared/infrastructure/db/migrations/024_account_config_silent_ingestion.sql
@@ -1,0 +1,2 @@
+ALTER TABLE account_config
+  ADD COLUMN IF NOT EXISTS silent_ingestion BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
This pull request adds support for a new `silentIngestion` configuration option to the account configuration. The main purpose of this option is to allow ingested bank transactions to skip notification webhooks when enabled. The changes include updating the API, domain models, database schema, and business logic to handle this new setting.

**Silent Ingestion Feature**

- Added a new `silentIngestion` boolean field to the `AccountConfig` and `AccountConfigInput` interfaces, and updated all relevant places in the API and domain logic to accept and return this value. [[1]](diffhunk://#diff-72952d52facec97c0a2335c9f473254269ef2d38df1e52743898e5bcc099ce2dR20) [[2]](diffhunk://#diff-72952d52facec97c0a2335c9f473254269ef2d38df1e52743898e5bcc099ce2dR37) [[3]](diffhunk://#diff-b91cc4eea65dab509e3aad90e0ee32cd45d0225aa075b988a9fc01183c309b58R34) [[4]](diffhunk://#diff-b91cc4eea65dab509e3aad90e0ee32cd45d0225aa075b988a9fc01183c309b58R131) [[5]](diffhunk://#diff-b91cc4eea65dab509e3aad90e0ee32cd45d0225aa075b988a9fc01183c309b58R215)
- Updated the `NotifyBankMovementUseCase` so that if `silentIngestion` is enabled for an account, notification webhooks are not sent for ingested bank transactions.

**Database and Persistence Updates**

- Modified the `account_config` database table to include a new `silent_ingestion` column with a default value of `FALSE`, and updated the migration scripts accordingly.
- Updated the `AccountConfigRepository` to read and write the new `silent_ingestion` field, including changes to the SQL queries and the `reconstitute` function. [[1]](diffhunk://#diff-fb92107c8601907a476febf640ab6fedef1126050ec8e7868f7de4b71c788cebR21) [[2]](diffhunk://#diff-fb92107c8601907a476febf640ab6fedef1126050ec8e7868f7de4b71c788cebL38-R40) [[3]](diffhunk://#diff-fb92107c8601907a476febf640ab6fedef1126050ec8e7868f7de4b71c788cebR54) [[4]](diffhunk://#diff-fb92107c8601907a476febf640ab6fedef1126050ec8e7868f7de4b71c788cebR71)