### PR TITLE
Add silent ingestion support to account configuration

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -173,6 +173,8 @@
     "webhookExtraFieldsInvalidJson": "Invalid JSON",
     "webhookExtraFieldsMustBeObject": "Must be a JSON object",
     "webhookExtraFieldsReserved": "These reserved keys can't be used: {{keys}}",
+    "silentIngestion": "Silent ingestion",
+    "silentIngestionDesc": "Ingest movements without sending notifications. Use it when starting the system for the first time so existing movements from the day do not trigger webhooks. Turn it off when you want to receive notifications normally.",
     "save": "Save configuration",
     "saving": "Saving...",
     "saved": "Saved!",

--- a/client/src/i18n/es.json
+++ b/client/src/i18n/es.json
@@ -173,6 +173,8 @@
     "webhookExtraFieldsInvalidJson": "El JSON no es válido",
     "webhookExtraFieldsMustBeObject": "Debe ser un objeto JSON",
     "webhookExtraFieldsReserved": "No podés usar estas claves reservadas: {{keys}}",
+    "silentIngestion": "Ingesta silenciosa",
+    "silentIngestionDesc": "Ingestá movimientos sin enviar notificaciones. Usalo al arrancar el sistema por primera vez para que los movimientos existentes del día no disparen webhooks. Desactivalo cuando quieras recibir notificaciones normalmente.",
     "save": "Guardar configuración",
     "saving": "Guardando...",
     "saved": "¡Guardado!",

--- a/client/src/pages/AccountConfig.tsx
+++ b/client/src/pages/AccountConfig.tsx
@@ -30,6 +30,7 @@ interface AccountConfig {
   bank_password: string
   webhook_extra_fields: string
   mode: 'reconcile' | 'passthrough'
+  silent_ingestion: boolean
 }
 
 const RESERVED_WEBHOOK_KEYS = ['external_id', 'status', 'amount', 'currency', 'name', 'id', 'received_at']
@@ -50,6 +51,7 @@ export function AccountConfig() {
     bank_password: '',
     webhook_extra_fields: '',
     mode: 'reconcile',
+    silent_ingestion: false,
   })
   const [saved, setSaved] = useState(false)
   const [extraFieldsError, setExtraFieldsError] = useState<string | null>(null)
@@ -310,6 +312,18 @@ export function AccountConfig() {
           <div className="space-y-2">
             <Label>{t('accountConfig.webhookUrl')}</Label>
             <Input placeholder="https://..." {...field('webhook_url')} />
+          </div>
+          <div className="rounded-md border border-border bg-muted/30 p-3 flex items-start gap-4">
+            <Switch
+              checked={form.silent_ingestion}
+              onCheckedChange={(checked: boolean) =>
+                setForm(f => ({ ...f, silent_ingestion: checked }))
+              }
+            />
+            <div className="flex-1">
+              <p className="font-medium text-sm">{t('accountConfig.silentIngestion')}</p>
+              <p className="text-xs text-muted-foreground mt-1">{t('accountConfig.silentIngestionDesc')}</p>
+            </div>
           </div>
           <div className="space-y-2">
             <Label>{t('accountConfig.webhookExtraFields')}</Label>


### PR DESCRIPTION
This pull request adds support for a new "Silent Ingestion" feature in the account configuration UI, allowing users to ingest movements without triggering notifications or webhooks. The changes include UI updates, internationalization, and state management for the new setting.

**Silent Ingestion Feature:**

* Added a new `silent_ingestion` boolean field to the `AccountConfig` interface and initialized it in the form state to support the new setting. [[1]](diffhunk://#diff-6e6402a92bc7af66be6a556d37e1d3195c7c8290ca7949fdb3fdedd320b62d1dR33) [[2]](diffhunk://#diff-6e6402a92bc7af66be6a556d37e1d3195c7c8290ca7949fdb3fdedd320b62d1dR54)
* Introduced a UI switch in the `AccountConfig` page that lets users enable or disable silent ingestion, with descriptive text explaining its use case.

**Internationalization:**

* Added English and Spanish translations for the "Silent Ingestion" label and description in the `en.json` and `es.json` files to support multilingual users. [[1]](diffhunk://#diff-4ff768c3b7cbc0b99efd419ca4dbb0354dd4c09a0df1792551a2c0e7a6afb1f2R176-R177) [[2]](diffhunk://#diff-f15fde526479c9f454b4ac66327c362fed5b662075455e91061fd864d9052a44R176-R177)