### PR TITLE
Add user management routes and enhance security checks

### DIFF
--- a/src/api/routes/accounts.routes.ts
+++ b/src/api/routes/accounts.routes.ts
@@ -1,17 +1,20 @@
-import { Router } from 'express'
+import { Router, Response } from 'express'
 import { db } from '../../shared/infrastructure/db/client.js'
 import { AccountRepository } from '../../contexts/account/infrastructure/AccountRepository.js'
 import { AccountConfigRepository } from '../../contexts/account/infrastructure/AccountConfigRepository.js'
 import { BankTransactionRepository } from '../../contexts/banking/infrastructure/BankTransactionRepository.js'
+import { UserRepository } from '../../contexts/user/infrastructure/UserRepository.js'
 import { CreateAccountUseCase } from '../../contexts/account/application/CreateAccountUseCase.js'
 import { DeleteAccountUseCase } from '../../contexts/account/application/DeleteAccountUseCase.js'
-import { AccountConfig, AccountMode, AuthType, PollingMethod } from '../../contexts/account/domain/AccountConfig.js'
+import { AccountConfig, AuthType, PollingMethod } from '../../contexts/account/domain/AccountConfig.js'
 import { enqueueBankScrape } from '../../shared/infrastructure/queues/BankScrapeQueue.js'
+import { AuthRequest } from '../middlewares/auth.middleware.js'
 
 export const accountsRouter = Router()
 const repo = new AccountRepository()
 const configRepo = new AccountConfigRepository()
 const bankTxRepo = new BankTransactionRepository()
+const userRepo = new UserRepository()
 
 const RESERVED_WEBHOOK_KEYS = ['external_id', 'status', 'amount', 'currency', 'name', 'id', 'received_at']
 
@@ -19,7 +22,6 @@ function toJson(config: AccountConfig, bankUsername: string | null) {
   return {
     id: config.id,
     account_id: config.accountId,
-    mode: config.mode,
     pending_orders_endpoint: config.pendingOrdersEndpoint,
     webhook_url: config.webhookUrl,
     retry_limit: config.retryLimit,
@@ -44,36 +46,56 @@ async function getBankUsername(accountId: string): Promise<string | null> {
   return rows[0]?.username ?? null
 }
 
-accountsRouter.get('/', async (_req, res) => {
+/** Resolves the account if it belongs to the authenticated user; otherwise writes the error response. */
+async function requireOwnedAccount(req: AuthRequest, res: Response): Promise<{ accountId: string } | null> {
+  const userId = req.userId
+  if (!userId) {
+    res.status(401).json({ error: 'Unauthorized' })
+    return null
+  }
+  const account = await repo.findByIdForUser(String(req.params.accountId), userId)
+  if (!account) {
+    res.status(404).json({ error: 'Account not found' })
+    return null
+  }
+  return { accountId: account.id }
+}
+
+accountsRouter.get('/', async (req: AuthRequest, res) => {
+  const userId = req.userId
+  if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
   const { rows } = await db.query(
-    `SELECT a.id, b.code AS bank, a.name, a.status, ac.mode
+    `SELECT a.id, b.code AS bank, a.name, a.status
        FROM accounts a
        JOIN banks b ON b.id = a.bank_id
-       LEFT JOIN account_config ac ON ac.account_id = a.id
-      WHERE a.status = 'active'`
+      WHERE a.status = 'active' AND a.user_id = $1`,
+    [userId]
   )
   res.json(rows.map(r => ({
     id: r.id,
     bank: r.bank,
     name: r.name,
     status: r.status,
-    mode: r.mode ?? 'reconcile',
   })))
 })
 
-accountsRouter.post('/', async (req, res) => {
+accountsRouter.post('/', async (req: AuthRequest, res) => {
+  const userId = req.userId
+  if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
   const { bankId, name } = req.body
   if (!bankId || !name) {
     res.status(400).json({ error: 'bankId and name are required' })
     return
   }
   const useCase = new CreateAccountUseCase(repo)
-  const result = await useCase.execute({ bankId, name })
+  const result = await useCase.execute({ userId, bankId, name })
   res.status(201).json(result)
 })
 
-accountsRouter.get('/:accountId', async (req, res) => {
-  const account = await repo.findById(req.params.accountId)
+accountsRouter.get('/:accountId', async (req: AuthRequest, res) => {
+  const userId = req.userId
+  if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+  const account = await repo.findByIdForUser(String(req.params.accountId), userId)
   if (!account) {
     res.status(404).json({ error: 'Account not found' })
     return
@@ -81,7 +103,9 @@ accountsRouter.get('/:accountId', async (req, res) => {
   res.json({ id: account.id, bank: account.bank, name: account.name, status: account.status })
 })
 
-accountsRouter.delete('/:accountId', async (req, res) => {
+accountsRouter.delete('/:accountId', async (req: AuthRequest, res) => {
+  const owned = await requireOwnedAccount(req, res)
+  if (!owned) return
   const { confirmation_name } = req.body ?? {}
   if (typeof confirmation_name !== 'string' || !confirmation_name.trim()) {
     res.status(400).json({ error: 'confirmation_name is required' })
@@ -89,30 +113,36 @@ accountsRouter.delete('/:accountId', async (req, res) => {
   }
   const useCase = new DeleteAccountUseCase(repo)
   try {
-    await useCase.execute({ id: req.params.accountId, confirmationName: confirmation_name })
+    await useCase.execute({ id: owned.accountId, confirmationName: confirmation_name })
     res.status(204).end()
   } catch (e: any) {
     res.status(e.status ?? 500).json({ error: e.message })
   }
 })
 
-accountsRouter.get('/:accountId/config', async (req, res) => {
-  const config = await configRepo.findByAccountId(req.params.accountId)
+accountsRouter.get('/:accountId/config', async (req: AuthRequest, res) => {
+  const owned = await requireOwnedAccount(req, res)
+  if (!owned) return
+  const config = await configRepo.findByAccountId(owned.accountId)
   if (!config) {
     res.json(null)
     return
   }
-  const bankUsername = await getBankUsername(req.params.accountId)
+  const bankUsername = await getBankUsername(owned.accountId)
   res.json(toJson(config, bankUsername))
 })
 
-accountsRouter.post('/:accountId/scrape', async (req, res) => {
-  const result = await enqueueBankScrape(req.params.accountId)
+accountsRouter.post('/:accountId/scrape', async (req: AuthRequest, res) => {
+  const owned = await requireOwnedAccount(req, res)
+  if (!owned) return
+  const result = await enqueueBankScrape(owned.accountId)
   res.status(202).json(result)
 })
 
-accountsRouter.put('/:accountId/config', async (req, res) => {
-  const { accountId } = req.params
+accountsRouter.put('/:accountId/config', async (req: AuthRequest, res) => {
+  const owned = await requireOwnedAccount(req, res)
+  if (!owned) return
+  const { accountId } = owned
   const {
     pending_orders_endpoint,
     webhook_url,
@@ -127,11 +157,10 @@ accountsRouter.put('/:accountId/config', async (req, res) => {
     bank_password,
     notify_on_expired,
     webhook_extra_fields,
-    mode,
     silent_ingestion,
   } = req.body
 
-  const normalizedMode: AccountMode = mode === 'passthrough' ? 'passthrough' : 'reconcile'
+  const mode = await userRepo.getOperationMode(req.userId!)
   const normalizedPendingEndpoint =
     typeof pending_orders_endpoint === 'string' && pending_orders_endpoint.trim()
       ? pending_orders_endpoint.trim()
@@ -141,8 +170,8 @@ accountsRouter.put('/:accountId/config', async (req, res) => {
     res.status(400).json({ error: 'webhook_url is required' })
     return
   }
-  if (normalizedMode === 'reconcile' && !normalizedPendingEndpoint) {
-    res.status(400).json({ error: 'pending_orders_endpoint is required when mode is reconcile' })
+  if (mode === 'reconcile' && !normalizedPendingEndpoint) {
+    res.status(400).json({ error: 'pending_orders_endpoint is required when operation mode is reconcile' })
     return
   }
 
@@ -196,11 +225,8 @@ accountsRouter.put('/:accountId/config', async (req, res) => {
   const normalizedWebhookAuthToken =
     typeof webhook_auth_token === 'string' && webhook_auth_token.trim() ? webhook_auth_token.trim() : null
 
-  const previous = await configRepo.findByAccountId(accountId)
-
   const config = await configRepo.upsert({
     accountId,
-    mode: normalizedMode,
     pendingOrdersEndpoint: normalizedPendingEndpoint,
     webhookUrl: webhook_url,
     retryLimit: retry_limit ?? 3,
@@ -214,12 +240,6 @@ accountsRouter.put('/:accountId/config', async (req, res) => {
     webhookExtraFields: normalizedWebhookExtraFields,
     silentIngestion: silent_ingestion ?? false,
   })
-
-  const switchingToPassthrough =
-    normalizedMode === 'passthrough' && (!previous || previous.mode !== 'passthrough')
-  if (switchingToPassthrough) {
-    await bankTxRepo.markAllNotified(accountId)
-  }
 
   if (bank_username && bank_password) {
     await db.query(
@@ -237,7 +257,9 @@ accountsRouter.put('/:accountId/config', async (req, res) => {
   res.json(toJson(config, await getBankUsername(accountId)))
 })
 
-accountsRouter.get('/:accountId/movements', async (req, res) => {
+accountsRouter.get('/:accountId/movements', async (req: AuthRequest, res) => {
+  const owned = await requireOwnedAccount(req, res)
+  if (!owned) return
   const limit = Math.min(Number(req.query.limit ?? 100), 500)
   const offset = Number(req.query.offset ?? 0)
   const { rows } = await db.query(
@@ -246,16 +268,18 @@ accountsRouter.get('/:accountId/movements', async (req, res) => {
       WHERE account_id = $1
       ORDER BY received_at DESC
       LIMIT $2 OFFSET $3`,
-    [req.params.accountId, limit, offset]
+    [owned.accountId, limit, offset]
   )
   res.json(rows)
 })
 
-accountsRouter.post('/:accountId/movements/:movementId/notify', async (req, res) => {
-  const { accountId, movementId } = req.params
+accountsRouter.post('/:accountId/movements/:movementId/notify', async (req: AuthRequest, res) => {
+  const owned = await requireOwnedAccount(req, res)
+  if (!owned) return
+  const movementId = String(req.params.movementId)
   const { rows } = await db.query(
     `SELECT 1 FROM bank_transactions WHERE id = $1 AND account_id = $2`,
-    [movementId, accountId]
+    [movementId, owned.accountId]
   )
   if (rows.length === 0) {
     res.status(404).json({ error: 'Movement not found for this account' })

--- a/src/api/routes/conciliation.routes.ts
+++ b/src/api/routes/conciliation.routes.ts
@@ -1,21 +1,52 @@
-import { Router } from 'express'
+import { Router, Response } from 'express'
 import { db } from '../../shared/infrastructure/db/client.js'
 import { Queues } from '../../shared/infrastructure/queues/QueueRegistry.js'
+import { AuthRequest } from '../middlewares/auth.middleware.js'
 
 export const conciliationRouter = Router()
 
-conciliationRouter.get('/', async (req, res) => {
+/** Returns the authenticated userId, or writes a 401 and returns null. */
+function requireUser(req: AuthRequest, res: Response): string | null {
+  if (!req.userId) {
+    res.status(401).json({ error: 'Unauthorized' })
+    return null
+  }
+  return req.userId
+}
+
+async function ownsRequest(requestId: string, userId: string): Promise<boolean> {
+  const { rows } = await db.query(
+    `SELECT 1 FROM conciliation_requests cr
+       JOIN accounts a ON a.id = cr.account_id
+      WHERE cr.id = $1 AND a.user_id = $2`,
+    [requestId, userId]
+  )
+  return rows.length > 0
+}
+
+async function ownsAccount(accountId: string, userId: string): Promise<boolean> {
+  const { rows } = await db.query(
+    `SELECT 1 FROM accounts WHERE id = $1 AND user_id = $2`,
+    [accountId, userId]
+  )
+  return rows.length > 0
+}
+
+conciliationRouter.get('/', async (req: AuthRequest, res) => {
+  const userId = requireUser(req, res)
+  if (!userId) return
   const limit = Number(req.query.limit ?? 50)
   const offset = Number(req.query.offset ?? 0)
   const status = req.query.status as string | undefined
 
-  const conditions = status ? `WHERE status = $3` : ''
-  const params = status ? [limit, offset, status] : [limit, offset]
+  const conditions = status ? `AND cr.status = $4` : ''
+  const params = status ? [limit, offset, userId, status] : [limit, offset, userId]
 
   const { rows } = await db.query(
     `SELECT cr.*, a.bank, a.name as account_name
      FROM conciliation_requests cr
      JOIN accounts a ON a.id = cr.account_id
+     WHERE a.user_id = $3
      ${conditions}
      ORDER BY cr.created_at DESC
      LIMIT $1 OFFSET $2`,
@@ -24,13 +55,15 @@ conciliationRouter.get('/', async (req, res) => {
   res.json(rows)
 })
 
-conciliationRouter.get('/:requestId', async (req, res) => {
+conciliationRouter.get('/:requestId', async (req: AuthRequest, res) => {
+  const userId = requireUser(req, res)
+  if (!userId) return
   const { rows: [request] } = await db.query(
     `SELECT cr.*, a.bank, a.name as account_name
      FROM conciliation_requests cr
      JOIN accounts a ON a.id = cr.account_id
-     WHERE cr.id = $1`,
-    [req.params.requestId]
+     WHERE cr.id = $1 AND a.user_id = $2`,
+    [req.params.requestId, userId]
   )
   if (!request) { res.status(404).json({ error: 'Not found' }); return }
 
@@ -50,17 +83,35 @@ conciliationRouter.get('/:requestId', async (req, res) => {
   res.json({ ...request, attempts, match: match ?? null })
 })
 
-conciliationRouter.post('/:requestId/run', async (req, res) => {
-  await Queues.conciliation.add('run', { requestId: req.params.requestId })
+conciliationRouter.post('/:requestId/run', async (req: AuthRequest, res) => {
+  const userId = requireUser(req, res)
+  if (!userId) return
+  const requestId = String(req.params.requestId)
+  if (!(await ownsRequest(requestId, userId))) {
+    res.status(404).json({ error: 'Not found' }); return
+  }
+  await Queues.conciliation.add('run', { requestId })
   res.status(202).json({ queued: true })
 })
 
-conciliationRouter.post('/:requestId/notify', async (req, res) => {
-  await Queues.webhook.add('notify', { requestId: req.params.requestId })
+conciliationRouter.post('/:requestId/notify', async (req: AuthRequest, res) => {
+  const userId = requireUser(req, res)
+  if (!userId) return
+  const requestId = String(req.params.requestId)
+  if (!(await ownsRequest(requestId, userId))) {
+    res.status(404).json({ error: 'Not found' }); return
+  }
+  await Queues.webhook.add('notify', { requestId })
   res.status(202).json({ queued: true })
 })
 
-conciliationRouter.post('/poll/:accountId', async (req, res) => {
-  await Queues.orderIngestion.add('poll', { accountId: req.params.accountId })
+conciliationRouter.post('/poll/:accountId', async (req: AuthRequest, res) => {
+  const userId = requireUser(req, res)
+  if (!userId) return
+  const accountId = String(req.params.accountId)
+  if (!(await ownsAccount(accountId, userId))) {
+    res.status(404).json({ error: 'Account not found' }); return
+  }
+  await Queues.orderIngestion.add('poll', { accountId })
   res.status(202).json({ queued: true })
 })

--- a/src/api/routes/user.routes.ts
+++ b/src/api/routes/user.routes.ts
@@ -1,0 +1,32 @@
+import { Router } from 'express'
+import { UserRepository } from '../../contexts/user/infrastructure/UserRepository.js'
+import { ChangeOperationModeUseCase } from '../../contexts/user/application/ChangeOperationModeUseCase.js'
+import { OperationMode } from '../../contexts/user/domain/User.js'
+import { AuthRequest } from '../middlewares/auth.middleware.js'
+
+export const userRouter = Router()
+const userRepo = new UserRepository()
+
+userRouter.get('/', async (req: AuthRequest, res) => {
+  if (!req.userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+  const user = await userRepo.findById(req.userId)
+  if (!user) { res.status(404).json({ error: 'User not found' }); return }
+  res.json({
+    id: user.id,
+    email: user.email,
+    name: user.name,
+    operation_mode: user.operationMode,
+  })
+})
+
+userRouter.put('/operation-mode', async (req: AuthRequest, res) => {
+  if (!req.userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+  const { mode } = req.body
+  if (mode !== 'reconcile' && mode !== 'passthrough') {
+    res.status(400).json({ error: "mode must be 'reconcile' or 'passthrough'" })
+    return
+  }
+  const useCase = new ChangeOperationModeUseCase()
+  const result = await useCase.execute({ userId: req.userId, mode: mode as OperationMode })
+  res.json({ operation_mode: result.mode })
+})

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -8,6 +8,7 @@ import { accountsRouter } from "./routes/accounts.routes.js";
 import { banksRouter } from "./routes/banks.routes.js";
 import { conciliationRouter } from "./routes/conciliation.routes.js";
 import { scriptsRouter } from "./routes/scripts.routes.js";
+import { userRouter } from "./routes/user.routes.js";
 import { errorMiddleware } from "./middlewares/error.middleware.js";
 import { authMiddleware } from "./middlewares/auth.middleware.js";
 
@@ -37,6 +38,7 @@ export function createServer() {
 
   // Protected API
   app.use(authMiddleware);
+  app.use("/me", userRouter);
   app.use("/accounts", accountsRouter);
   app.use("/banks", banksRouter);
   app.use("/conciliation", conciliationRouter);

--- a/src/contexts/conciliation/application/PollPendingOrdersUseCase.ts
+++ b/src/contexts/conciliation/application/PollPendingOrdersUseCase.ts
@@ -2,6 +2,8 @@ import { db } from '../../../shared/infrastructure/db/client.js'
 import { Queues } from '../../../shared/infrastructure/queues/QueueRegistry.js'
 import { ConciliationRequestRepository } from '../infrastructure/ConciliationRequestRepository.js'
 import { AccountConfigRepository } from '../../account/infrastructure/AccountConfigRepository.js'
+import { AccountRepository } from '../../account/infrastructure/AccountRepository.js'
+import { UserRepository } from '../../user/infrastructure/UserRepository.js'
 import { logger } from '../../../shared/infrastructure/logger/index.js'
 import crypto from 'crypto'
 
@@ -12,12 +14,18 @@ interface JobData { accountId: string }
 export class PollPendingOrdersUseCase {
   private readonly requestRepo = new ConciliationRequestRepository()
   private readonly configRepo = new AccountConfigRepository()
+  private readonly accountRepo = new AccountRepository()
+  private readonly userRepo = new UserRepository()
 
   async execute({ accountId }: JobData): Promise<void> {
     const config = await this.configRepo.findByAccountId(accountId)
     if (!config) throw new Error(`No config for account ${accountId}`)
 
-    if (config.mode === 'passthrough') return
+    const account = await this.accountRepo.findById(accountId)
+    if (!account) throw new Error(`No account ${accountId}`)
+    const mode = await this.userRepo.getOperationMode(account.userId)
+
+    if (mode !== 'reconcile') return
     if (!config.pendingOrdersEndpoint) return
 
     // Build auth header

--- a/src/contexts/user/application/ChangeOperationModeUseCase.ts
+++ b/src/contexts/user/application/ChangeOperationModeUseCase.ts
@@ -1,0 +1,27 @@
+import { withTransaction } from '../../../shared/infrastructure/db/client.js'
+import { OperationMode } from '../domain/User.js'
+
+interface Input {
+  userId: string
+  mode: OperationMode
+}
+
+/**
+ * Changing the operation mode permanently deletes the user's movements and
+ * conciliations: data processed under one mode cannot be carried over to the
+ * other (security / compliance). Runs atomically so a partial wipe can't leave
+ * the user in a mixed state.
+ */
+export class ChangeOperationModeUseCase {
+  async execute({ userId, mode }: Input): Promise<{ mode: OperationMode }> {
+    await withTransaction(async (client) => {
+      const scope = `account_id IN (SELECT id FROM accounts WHERE user_id = $1)`
+      await client.query(`DELETE FROM conciliated_transactions WHERE ${scope}`, [userId])
+      await client.query(`DELETE FROM conciliation_attempts WHERE ${scope}`, [userId])
+      await client.query(`DELETE FROM conciliation_requests WHERE ${scope}`, [userId])
+      await client.query(`DELETE FROM bank_transactions WHERE ${scope}`, [userId])
+      await client.query(`UPDATE users SET operation_mode = $2 WHERE id = $1`, [userId, mode])
+    })
+    return { mode }
+  }
+}

--- a/src/contexts/user/domain/IUserRepository.ts
+++ b/src/contexts/user/domain/IUserRepository.ts
@@ -1,0 +1,7 @@
+import { OperationMode, User } from './User.js'
+
+export interface IUserRepository {
+  findById(id: string): Promise<User | null>
+  getOperationMode(userId: string): Promise<OperationMode | null>
+  setOperationMode(userId: string, mode: OperationMode): Promise<void>
+}

--- a/src/contexts/user/domain/User.ts
+++ b/src/contexts/user/domain/User.ts
@@ -1,0 +1,8 @@
+export type OperationMode = 'reconcile' | 'passthrough'
+
+export interface User {
+  id: string
+  email: string
+  name: string | null
+  operationMode: OperationMode | null
+}

--- a/src/contexts/user/infrastructure/UserRepository.ts
+++ b/src/contexts/user/infrastructure/UserRepository.ts
@@ -1,0 +1,31 @@
+import { db } from '../../../shared/infrastructure/db/client.js'
+import { IUserRepository } from '../domain/IUserRepository.js'
+import { OperationMode, User } from '../domain/User.js'
+
+export class UserRepository implements IUserRepository {
+  async findById(id: string): Promise<User | null> {
+    const { rows } = await db.query(
+      `SELECT id, email, name, operation_mode FROM users WHERE id = $1`,
+      [id]
+    )
+    if (!rows[0]) return null
+    return {
+      id: rows[0].id,
+      email: rows[0].email,
+      name: rows[0].name,
+      operationMode: rows[0].operation_mode as OperationMode | null,
+    }
+  }
+
+  async getOperationMode(userId: string): Promise<OperationMode | null> {
+    const { rows } = await db.query(
+      `SELECT operation_mode FROM users WHERE id = $1`,
+      [userId]
+    )
+    return (rows[0]?.operation_mode as OperationMode | null) ?? null
+  }
+
+  async setOperationMode(userId: string, mode: OperationMode): Promise<void> {
+    await db.query(`UPDATE users SET operation_mode = $2 WHERE id = $1`, [userId, mode])
+  }
+}


### PR DESCRIPTION
This pull request introduces comprehensive user-level authorization and operation mode management across the API. The main focus is to ensure that all account and conciliation operations are restricted to the authenticated user, and to centralize the operation mode (either 'reconcile' or 'passthrough') as a user-level setting. This change improves both security and flexibility, allowing users to control their operation mode and ensuring strict data isolation.

Key changes include:

**User Authorization and Ownership Enforcement**
- All account and conciliation routes now require authentication and verify that the resource (account or conciliation request) belongs to the authenticated user, returning appropriate error responses if not. Helper functions like `requireOwnedAccount`, `requireUser`, `ownsRequest`, and `ownsAccount` were introduced to enforce these checks. [[1]](diffhunk://#diff-b91cc4eea65dab509e3aad90e0ee32cd45d0225aa075b988a9fc01183c309b58L47-R145) [[2]](diffhunk://#diff-b91cc4eea65dab509e3aad90e0ee32cd45d0225aa075b988a9fc01183c309b58L240-R262) [[3]](diffhunk://#diff-282fbb90fa5ee6eab991b972453e9492eebf626d410dc1e0e6b542ef8019df66L1-R49) [[4]](diffhunk://#diff-282fbb90fa5ee6eab991b972453e9492eebf626d410dc1e0e6b542ef8019df66L27-R66) [[5]](diffhunk://#diff-282fbb90fa5ee6eab991b972453e9492eebf626d410dc1e0e6b542ef8019df66L53-R115)

**User Operation Mode Management**
- Operation mode (`reconcile` or `passthrough`) is now managed at the user level. A new `/me` endpoint allows users to view and change their operation mode. Changing the mode wipes all user data that is incompatible with the new mode to maintain data integrity and compliance. [[1]](diffhunk://#diff-fbe70d6effcf7c15be1662d50ad91141f5a348dbfef7eb12b83c5ac0cafb0c47R1-R32) [[2]](diffhunk://#diff-5ec54a69840a0fc7c7162cc73753873977f2de1cb403e18808d2b5790e34cc4fR1-R27) [[3]](diffhunk://#diff-4f5348f6211cbb1a6e63df58580dcb1bc674a3152eb6ddafce64fd979ae490c8R11) [[4]](diffhunk://#diff-4f5348f6211cbb1a6e63df58580dcb1bc674a3152eb6ddafce64fd979ae490c8R41) [[5]](diffhunk://#diff-eac5d8eaa107680f04b7de6e7062605ecdfbc76916f29c04d4f9b9cf69ee3d3fR1-R8) [[6]](diffhunk://#diff-377663994b9a4a4419f1e2c169d672fbc7e6221682acac850eb20f60e8f76473R1-R7)
- Account configuration and conciliation logic now reference the user's operation mode instead of a per-account mode. [[1]](diffhunk://#diff-b91cc4eea65dab509e3aad90e0ee32cd45d0225aa075b988a9fc01183c309b58L130-R163) [[2]](diffhunk://#diff-b91cc4eea65dab509e3aad90e0ee32cd45d0225aa075b988a9fc01183c309b58L144-R174) [[3]](diffhunk://#diff-b91cc4eea65dab509e3aad90e0ee32cd45d0225aa075b988a9fc01183c309b58L199-L203) [[4]](diffhunk://#diff-25a1f72e6edabef3ab898933d88ce8a104cb6061c0cebb22cc8307c53526569bR5-R6) [[5]](diffhunk://#diff-25a1f72e6edabef3ab898933d88ce8a104cb6061c0cebb22cc8307c53526569bR17-R28)

**API and Data Model Adjustments**
- The `mode` field was removed from account configuration and related API responses; operation mode is now determined solely by the user. [[1]](diffhunk://#diff-b91cc4eea65dab509e3aad90e0ee32cd45d0225aa075b988a9fc01183c309b58L1-L22) [[2]](diffhunk://#diff-b91cc4eea65dab509e3aad90e0ee32cd45d0225aa075b988a9fc01183c309b58L47-R145) [[3]](diffhunk://#diff-b91cc4eea65dab509e3aad90e0ee32cd45d0225aa075b988a9fc01183c309b58L130-R163) [[4]](diffhunk://#diff-b91cc4eea65dab509e3aad90e0ee32cd45d0225aa075b988a9fc01183c309b58L144-R174) [[5]](diffhunk://#diff-b91cc4eea65dab509e3aad90e0ee32cd45d0225aa075b988a9fc01183c309b58L199-L203) [[6]](diffhunk://#diff-b91cc4eea65dab509e3aad90e0ee32cd45d0225aa075b988a9fc01183c309b58L218-L223)
- All relevant routes and use cases were updated to use the user-level operation mode, and unnecessary logic for switching per-account modes was removed. [[1]](diffhunk://#diff-b91cc4eea65dab509e3aad90e0ee32cd45d0225aa075b988a9fc01183c309b58L218-L223) [[2]](diffhunk://#diff-25a1f72e6edabef3ab898933d88ce8a104cb6061c0cebb22cc8307c53526569bR17-R28)

**Security and Error Handling Improvements**
- Consistent 401 (Unauthorized) and 404 (Not Found) responses are now returned when users attempt to access resources they do not own or when authentication is missing. [[1]](diffhunk://#diff-b91cc4eea65dab509e3aad90e0ee32cd45d0225aa075b988a9fc01183c309b58L47-R145) [[2]](diffhunk://#diff-282fbb90fa5ee6eab991b972453e9492eebf626d410dc1e0e6b542ef8019df66L1-R49) [[3]](diffhunk://#diff-282fbb90fa5ee6eab991b972453e9492eebf626d410dc1e0e6b542ef8019df66L27-R66) [[4]](diffhunk://#diff-282fbb90fa5ee6eab991b972453e9492eebf626d410dc1e0e6b542ef8019df66L53-R115) [[5]](diffhunk://#diff-fbe70d6effcf7c15be1662d50ad91141f5a348dbfef7eb12b83c5ac0cafb0c47R1-R32)

These changes collectively enforce strict user-based access control and provide a robust mechanism for managing user operation modes across the application.