### PR TITLE
Add SQL migrations for active script constraints and Mi Dinero update

### DIFF
--- a/src/shared/infrastructure/db/migrations/025_fix_bank_script_active_constraint.sql
+++ b/src/shared/infrastructure/db/migrations/025_fix_bank_script_active_constraint.sql
@@ -1,0 +1,8 @@
+-- Enforce at most one active script per (bank, flow_type). The original
+-- UNIQUE(bank, flow_type, status) only allowed one row per status value
+-- (e.g. a single deprecated row), which breaks version history.
+ALTER TABLE bank_scripts DROP CONSTRAINT IF EXISTS uq_bank_script_active;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_bank_script_active
+  ON bank_scripts (bank, flow_type)
+  WHERE status = 'active';

--- a/src/shared/infrastructure/db/migrations/026_seed_midinero_script_v2_0_1.sql
+++ b/src/shared/infrastructure/db/migrations/026_seed_midinero_script_v2_0_1.sql
@@ -1,0 +1,25 @@
+-- Register Mi Dinero extract_transactions v2.0.1 as the new active script.
+-- Deprecates v2.0.0 (b2000000-0000-0000-0000-000000000001).
+-- Code is loaded from disk by ScriptLoader:
+--   src/contexts/script-engine/infrastructure/scripts/mi-dinero/extract_transactions.v2.0.1.js
+
+-- Deprecate the previous active version first to satisfy uq_bank_script_active
+UPDATE bank_scripts
+SET status = 'deprecated'
+WHERE id = 'b2000000-0000-0000-0000-000000000001'
+  AND status = 'active';
+
+INSERT INTO bank_scripts (id, bank, flow_type, version, status, origin, selector_map, bank_id, base_script_id)
+SELECT
+  'b2010000-0000-0000-0000-000000000001',
+  'mi-dinero',
+  'extract_transactions',
+  '2.0.1',
+  'active',
+  'system',
+  '{}',
+  b.id,
+  'b2000000-0000-0000-0000-000000000001'
+FROM banks b
+WHERE b.code = 'mi-dinero'
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
This pull request includes a database migration to fix a constraint on the `bank_scripts` table, ensuring only one active script exists per `(bank, flow_type)`, and seeds a new version of the Mi Dinero extract_transactions script, deprecating the previous version.

**Database constraint improvements:**

* Replaces the old unique constraint on `bank_scripts` with a partial unique index that enforces at most one active script per `(bank, flow_type)`, allowing multiple deprecated scripts for version history.

**Script seeding and versioning:**

* Deprecates the previous active Mi Dinero `extract_transactions` script (v2.0.0) and inserts v2.0.1 as the new active script, maintaining version history and preventing constraint violations.