### PR TITLE
Refactor account management for user association and mode removal

### DIFF
--- a/client/src/pages/AccountConfig.tsx
+++ b/client/src/pages/AccountConfig.tsx
@@ -11,6 +11,7 @@ import { Switch } from '@/components/ui/switch'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { ArrowLeft, Save, Info, Trash2, AlertTriangle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { useUser } from '@/lib/useUser'
 
 interface AccountSummary {
   id: string
@@ -29,7 +30,6 @@ interface AccountConfig {
   bank_username: string
   bank_password: string
   webhook_extra_fields: string
-  mode: 'reconcile' | 'passthrough'
   silent_ingestion: boolean
 }
 
@@ -40,6 +40,8 @@ export function AccountConfig() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const { t } = useTranslation()
+  const { data: me } = useUser()
+  const mode = me?.operation_mode
   const [form, setForm] = useState<AccountConfig>({
     pending_orders_endpoint: '',
     webhook_url: '',
@@ -50,7 +52,6 @@ export function AccountConfig() {
     bank_username: '',
     bank_password: '',
     webhook_extra_fields: '',
-    mode: 'reconcile',
     silent_ingestion: false,
   })
   const [saved, setSaved] = useState(false)
@@ -161,29 +162,6 @@ export function AccountConfig() {
         </div>
       </div>
 
-      {/* Mode */}
-      <Card>
-        <CardHeader><CardTitle>{t('accountConfig.mode')}</CardTitle></CardHeader>
-        <CardContent>
-          <div className="flex items-start gap-4">
-            <Switch
-              checked={form.mode === 'reconcile'}
-              onCheckedChange={(checked: boolean) =>
-                setForm(f => ({ ...f, mode: checked ? 'reconcile' : 'passthrough' }))
-              }
-            />
-            <div className="flex-1">
-              <p className="font-medium text-sm">
-                {form.mode === 'reconcile' ? t('accountConfig.modeReconcile') : t('accountConfig.modePassthrough')}
-              </p>
-              <p className="text-xs text-muted-foreground mt-1">
-                {form.mode === 'reconcile' ? t('accountConfig.modeReconcileDesc') : t('accountConfig.modePassthroughDesc')}
-              </p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
       {/* Bank credentials */}
       <Card>
         <CardHeader><CardTitle>{t('accountConfig.bankCredentials')}</CardTitle></CardHeader>
@@ -226,7 +204,7 @@ export function AccountConfig() {
       </Card>
 
       {/* Order ingestion (reconcile mode only) */}
-      {form.mode === 'reconcile' && (
+      {mode === 'reconcile' && (
       <Card>
         <CardHeader><CardTitle>{t('accountConfig.orderIngestion')}</CardTitle></CardHeader>
         <CardContent className="space-y-4">
@@ -287,12 +265,12 @@ export function AccountConfig() {
             <div>
               <p className="font-medium mb-1">{t('accountConfig.webhookPayload')}</p>
               <p className="text-xs text-muted-foreground mb-2">
-                {form.mode === 'reconcile'
+                {mode === 'reconcile'
                   ? t('accountConfig.webhookPayloadDesc')
                   : t('accountConfig.webhookPayloadPassthroughDesc')}
               </p>
               <pre className="text-xs bg-background rounded p-2 font-mono whitespace-pre-wrap">
-                {form.mode === 'reconcile'
+                {mode === 'reconcile'
                   ? `{
   "external_id": "order-123",
   "amount": 1500.00,

--- a/src/contexts/account/application/CreateAccountUseCase.ts
+++ b/src/contexts/account/application/CreateAccountUseCase.ts
@@ -5,6 +5,7 @@ import { BankRepository } from '../infrastructure/BankRepository.js'
 import crypto from 'crypto'
 
 interface Input {
+  userId: string
   bankId: string
   name: string
 }
@@ -20,7 +21,7 @@ export class CreateAccountUseCase {
     if (!bank) throw Object.assign(new Error('Bank not found'), { status: 404 })
 
     const id = crypto.randomUUID()
-    const account = Account.create(id, bank.id, bank.code, input.name)
+    const account = Account.create(id, input.userId, bank.id, bank.code, input.name)
     await this.accountRepo.save(account)
     return { id }
   }

--- a/src/contexts/account/domain/Account.ts
+++ b/src/contexts/account/domain/Account.ts
@@ -4,6 +4,7 @@ import { AccountCreatedEvent } from '../../../shared/events/events/AccountCreate
 export type AccountStatus = 'active' | 'inactive'
 
 interface AccountProps {
+  userId: string
   bankId: string
   bank: string    // bank code, resolved from JOIN with banks table
   name?: string
@@ -19,8 +20,8 @@ export class Account extends AggregateRoot<string> {
     this.props = props
   }
 
-  static create(id: string, bankId: string, bankCode: string, name?: string): Account {
-    const account = new Account(id, { bankId, bank: bankCode, name, status: 'active', createdAt: new Date() })
+  static create(id: string, userId: string, bankId: string, bankCode: string, name?: string): Account {
+    const account = new Account(id, { userId, bankId, bank: bankCode, name, status: 'active', createdAt: new Date() })
     account.addDomainEvent(new AccountCreatedEvent(id, bankCode, name))
     return account
   }
@@ -29,6 +30,7 @@ export class Account extends AggregateRoot<string> {
     return new Account(id, props)
   }
 
+  get userId()  { return this.props.userId }
   get bankId()  { return this.props.bankId }
   get bank()    { return this.props.bank }
   get name()    { return this.props.name }

--- a/src/contexts/account/domain/AccountConfig.ts
+++ b/src/contexts/account/domain/AccountConfig.ts
@@ -1,11 +1,9 @@
-export type AccountMode = 'reconcile' | 'passthrough'
 export type AuthType = 'bearer' | 'api_key'
 export type PollingMethod = 'GET' | 'POST'
 
 export interface AccountConfig {
   id: string
   accountId: string
-  mode: AccountMode
   pendingOrdersEndpoint: string | null
   webhookUrl: string
   retryLimit: number
@@ -22,7 +20,6 @@ export interface AccountConfig {
 
 export interface AccountConfigInput {
   accountId: string
-  mode: AccountMode
   pendingOrdersEndpoint: string | null
   webhookUrl: string
   retryLimit: number

--- a/src/contexts/account/domain/IAccountRepository.ts
+++ b/src/contexts/account/domain/IAccountRepository.ts
@@ -2,7 +2,8 @@ import { Account } from './Account.js'
 
 export interface IAccountRepository {
   findById(id: string): Promise<Account | null>
-  findAll(): Promise<Account[]>
+  findByIdForUser(id: string, userId: string): Promise<Account | null>
+  findAllByUser(userId: string): Promise<Account[]>
   save(account: Account): Promise<void>
   delete(id: string): Promise<void>
 }

--- a/src/contexts/account/infrastructure/AccountConfigRepository.ts
+++ b/src/contexts/account/infrastructure/AccountConfigRepository.ts
@@ -1,12 +1,11 @@
 import { db } from '../../../shared/infrastructure/db/client.js'
-import { AccountConfig, AccountConfigInput, AccountMode, AuthType, PollingMethod } from '../domain/AccountConfig.js'
+import { AccountConfig, AccountConfigInput, AuthType, PollingMethod } from '../domain/AccountConfig.js'
 import { IAccountConfigRepository } from '../domain/IAccountConfigRepository.js'
 
 function reconstitute(row: any): AccountConfig {
   return {
     id: row.id,
     accountId: row.account_id,
-    mode: row.mode as AccountMode,
     pendingOrdersEndpoint: row.pending_orders_endpoint,
     webhookUrl: row.webhook_url,
     retryLimit: row.retry_limit,
@@ -36,8 +35,8 @@ export class AccountConfigRepository implements IAccountConfigRepository {
       `INSERT INTO account_config
          (id, account_id, pending_orders_endpoint, webhook_url,
           retry_limit, polling_method, polling_body, auth_type, auth_token,
-          webhook_auth_type, webhook_auth_token, notify_on_expired, webhook_extra_fields, mode, silent_ingestion)
-       VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+          webhook_auth_type, webhook_auth_token, notify_on_expired, webhook_extra_fields, silent_ingestion)
+       VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
        ON CONFLICT (account_id) DO UPDATE SET
          pending_orders_endpoint = $2,
          webhook_url             = $3,
@@ -50,8 +49,7 @@ export class AccountConfigRepository implements IAccountConfigRepository {
          webhook_auth_token      = $10,
          notify_on_expired       = $11,
          webhook_extra_fields    = $12,
-         mode                    = $13,
-         silent_ingestion        = $14,
+         silent_ingestion        = $13,
          updated_at              = now()
        RETURNING *`,
       [
@@ -67,7 +65,6 @@ export class AccountConfigRepository implements IAccountConfigRepository {
         input.webhookAuthToken,
         input.notifyOnExpired,
         input.webhookExtraFields,
-        input.mode,
         input.silentIngestion,
       ]
     )

--- a/src/contexts/account/infrastructure/AccountRepository.ts
+++ b/src/contexts/account/infrastructure/AccountRepository.ts
@@ -2,6 +2,17 @@ import { db } from '../../../shared/infrastructure/db/client.js'
 import { Account } from '../domain/Account.js'
 import { IAccountRepository } from '../domain/IAccountRepository.js'
 
+function reconstitute(row: any): Account {
+  return Account.reconstitute(row.id, {
+    userId: row.user_id,
+    bankId: row.bank_id,
+    bank: row.bank_code,
+    name: row.name,
+    status: row.status,
+    createdAt: row.created_at,
+  })
+}
+
 export class AccountRepository implements IAccountRepository {
   async findById(id: string): Promise<Account | null> {
     const { rows } = await db.query(
@@ -11,39 +22,37 @@ export class AccountRepository implements IAccountRepository {
         WHERE a.id = $1`,
       [id]
     )
-    if (!rows[0]) return null
-    return Account.reconstitute(rows[0].id, {
-      bankId: rows[0].bank_id,
-      bank: rows[0].bank_code,
-      name: rows[0].name,
-      status: rows[0].status,
-      createdAt: rows[0].created_at,
-    })
+    return rows[0] ? reconstitute(rows[0]) : null
   }
 
-  async findAll(): Promise<Account[]> {
+  async findByIdForUser(id: string, userId: string): Promise<Account | null> {
     const { rows } = await db.query(
       `SELECT a.*, b.code AS bank_code
          FROM accounts a
          JOIN banks b ON b.id = a.bank_id
-        WHERE a.status = $1`,
-      ['active']
+        WHERE a.id = $1 AND a.user_id = $2`,
+      [id, userId]
     )
-    return rows.map(r => Account.reconstitute(r.id, {
-      bankId: r.bank_id,
-      bank: r.bank_code,
-      name: r.name,
-      status: r.status,
-      createdAt: r.created_at,
-    }))
+    return rows[0] ? reconstitute(rows[0]) : null
+  }
+
+  async findAllByUser(userId: string): Promise<Account[]> {
+    const { rows } = await db.query(
+      `SELECT a.*, b.code AS bank_code
+         FROM accounts a
+         JOIN banks b ON b.id = a.bank_id
+        WHERE a.user_id = $1 AND a.status = $2`,
+      [userId, 'active']
+    )
+    return rows.map(reconstitute)
   }
 
   async save(account: Account): Promise<void> {
     await db.query(
-      `INSERT INTO accounts (id, bank_id, bank, name, status, created_at)
-       VALUES ($1, $2, $3, $4, $5, now())
-       ON CONFLICT (id) DO UPDATE SET name = $4, status = $5`,
-      [account.id, account.bankId, account.bank, account.name, account.status]
+      `INSERT INTO accounts (id, user_id, bank_id, bank, name, status, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6, now())
+       ON CONFLICT (id) DO UPDATE SET name = $5, status = $6`,
+      [account.id, account.userId, account.bankId, account.bank, account.name, account.status]
     )
   }
 

--- a/src/shared/infrastructure/db/migrations/027_user_operation_mode.sql
+++ b/src/shared/infrastructure/db/migrations/027_user_operation_mode.sql
@@ -1,0 +1,10 @@
+ALTER TABLE users
+  ADD COLUMN operation_mode TEXT NULL
+    CHECK (operation_mode IN ('reconcile', 'passthrough'));
+
+ALTER TABLE accounts
+  ADD COLUMN user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE;
+
+CREATE INDEX idx_accounts_user_id ON accounts(user_id);
+
+ALTER TABLE account_config DROP COLUMN mode;


### PR DESCRIPTION
This pull request introduces significant changes to how account modes and user associations are handled in the application. The main updates remove the `mode` field from account configuration, centralize operation mode at the user level, and ensure all accounts are explicitly linked to users. The frontend and backend have both been updated to reflect these changes, with relevant database migrations included.

**Backend changes:**

*Account mode and user association:*
- Removed the `mode` field from `AccountConfig` and related interfaces, repositories, and database tables, shifting the responsibility for operation mode to the user entity (`operation_mode` column in `users`). (`[[1]](diffhunk://#diff-72952d52facec97c0a2335c9f473254269ef2d38df1e52743898e5bcc099ce2dL1-L8)`, `[[2]](diffhunk://#diff-72952d52facec97c0a2335c9f473254269ef2d38df1e52743898e5bcc099ce2dL25)`, `[[3]](diffhunk://#diff-fb92107c8601907a476febf640ab6fedef1126050ec8e7868f7de4b71c788cebL2-L9)`, `[[4]](diffhunk://#diff-fb92107c8601907a476febf640ab6fedef1126050ec8e7868f7de4b71c788cebL39-R39)`, `[[5]](diffhunk://#diff-fb92107c8601907a476febf640ab6fedef1126050ec8e7868f7de4b71c788cebL53-R52)`, `[[6]](diffhunk://#diff-fb92107c8601907a476febf640ab6fedef1126050ec8e7868f7de4b71c788cebL70)`, `[[7]](diffhunk://#diff-8811df7671cc126e81abe1654de0e4b8f1163e993ce3a53aa7845b2ce8c961f0R1-R10)`)
- Added a `user_id` field to the `accounts` table and updated the domain model, repository, and use case logic to require and persist the user association for all accounts. (`[[1]](diffhunk://#diff-feaf21bc8d93e59962383861e4a41bfd4cd1b41d22945ca74ef5893b5aff8a24R7)`, `[[2]](diffhunk://#diff-feaf21bc8d93e59962383861e4a41bfd4cd1b41d22945ca74ef5893b5aff8a24L22-R24)`, `[[3]](diffhunk://#diff-feaf21bc8d93e59962383861e4a41bfd4cd1b41d22945ca74ef5893b5aff8a24R33)`, `[[4]](diffhunk://#diff-22145981941c2cf581dfc14d1543ea33f62f0be39e07241dab47f455586bf0a7R8)`, `[[5]](diffhunk://#diff-22145981941c2cf581dfc14d1543ea33f62f0be39e07241dab47f455586bf0a7L23-R24)`, `[[6]](diffhunk://#diff-e69026e8af1530cb37319d801c361a67e4f52f3eb270069a049e53b8b10c0b73R5-R15)`, `[[7]](diffhunk://#diff-e69026e8af1530cb37319d801c361a67e4f52f3eb270069a049e53b8b10c0b73L14-R55)`, `[[8]](diffhunk://#diff-4aab1fe9f7d66179e23d35a877f64eb0a5d8ac7ce7e9f6b4d2f20a680ecf722eL5-R6)`, `[[9]](diffhunk://#diff-8811df7671cc126e81abe1654de0e4b8f1163e993ce3a53aa7845b2ce8c961f0R1-R10)`)

*Repository and interface updates:*
- Updated `IAccountRepository` and its implementation to support fetching accounts by user, and to ensure all account operations are user-scoped. (`[[1]](diffhunk://#diff-4aab1fe9f7d66179e23d35a877f64eb0a5d8ac7ce7e9f6b4d2f20a680ecf722eL5-R6)`, `[[2]](diffhunk://#diff-e69026e8af1530cb37319d801c361a67e4f52f3eb270069a049e53b8b10c0b73R5-R15)`, `[[3]](diffhunk://#diff-e69026e8af1530cb37319d801c361a67e4f52f3eb270069a049e53b8b10c0b73L14-R55)`)

*Database migrations:*
- Added a migration to introduce the `operation_mode` column to the `users` table, add `user_id` to `accounts`, create an index on `user_id`, and remove the `mode` column from `account_config`. (`[src/shared/infrastructure/db/migrations/027_user_operation_mode.sqlR1-R10](diffhunk://#diff-8811df7671cc126e81abe1654de0e4b8f1163e993ce3a53aa7845b2ce8c961f0R1-R10)`)

**Frontend changes:**

*Account configuration UI:*
- Removed the mode switch from the account configuration form; the UI now derives the operation mode from the current user (`me.operation_mode`) instead of per-account configuration. (`[[1]](diffhunk://#diff-6e6402a92bc7af66be6a556d37e1d3195c7c8290ca7949fdb3fdedd320b62d1dL32)`, `[[2]](diffhunk://#diff-6e6402a92bc7af66be6a556d37e1d3195c7c8290ca7949fdb3fdedd320b62d1dL53)`, `[[3]](diffhunk://#diff-6e6402a92bc7af66be6a556d37e1d3195c7c8290ca7949fdb3fdedd320b62d1dL164-L186)`)
- Updated conditional rendering and logic in the `AccountConfig` page to use the user's operation mode for displaying relevant sections and descriptions. (`[[1]](diffhunk://#diff-6e6402a92bc7af66be6a556d37e1d3195c7c8290ca7949fdb3fdedd320b62d1dR43-R44)`, `[[2]](diffhunk://#diff-6e6402a92bc7af66be6a556d37e1d3195c7c8290ca7949fdb3fdedd320b62d1dL229-R207)`, `[[3]](diffhunk://#diff-6e6402a92bc7af66be6a556d37e1d3195c7c8290ca7949fdb3fdedd320b62d1dL290-R273)`)
- Introduced usage of the `useUser` hook to fetch current user data, including operation mode. (`[client/src/pages/AccountConfig.tsxR14](diffhunk://#diff-6e6402a92bc7af66be6a556d37e1d3195c7c8290ca7949fdb3fdedd320b62d1dR14)`)

These changes collectively simplify the model by making operation mode a user-level setting and ensure that all accounts are explicitly owned by users, improving both security and maintainability.