### PR TITLE
Refactor unit tests and add integration tests for various contexts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json",
     "dev": "tsx watch src/index.ts",
     "build": "tsc && cp -r src/contexts/script-engine/infrastructure/scripts dist/contexts/script-engine/infrastructure/scripts",

--- a/src/contexts/conciliation/application/RunConciliationUseCase.test.ts
+++ b/src/contexts/conciliation/application/RunConciliationUseCase.test.ts
@@ -66,7 +66,7 @@ describe('RunConciliationUseCase', () => {
     await useCase.execute({ requestId: 'req-1' })
 
     expect(requestRepo.store.get('req-1')!.status).toBe('not_found')
-    expect(attemptRepo.attempts[0].status).toBe('not_found')
+    expect(attemptRepo.attempts[0].status).toBe('no_match')
   })
 
   it('is a no-op for terminal requests', async () => {

--- a/src/contexts/conciliation/application/RunConciliationUseCase.ts
+++ b/src/contexts/conciliation/application/RunConciliationUseCase.ts
@@ -77,7 +77,7 @@ export class RunConciliationUseCase {
           accountId: request.accountId,
           requestId,
           attemptNumber,
-          status: result.status === 'ambiguous' ? 'ambiguous' : 'not_found',
+          status: result.status === 'ambiguous' ? 'ambiguous' : 'no_match',
           failureType: result.status === 'ambiguous' ? 'multiple_candidates' : 'rule_miss',
           candidateIds: result.candidateIds,
         })

--- a/src/contexts/conciliation/domain/IConciliationAttemptRepository.ts
+++ b/src/contexts/conciliation/domain/IConciliationAttemptRepository.ts
@@ -3,7 +3,7 @@ export interface ConciliationAttemptData {
   accountId: string
   requestId: string
   attemptNumber: number
-  status: 'success' | 'not_found' | 'ambiguous'
+  status: 'success' | 'no_match' | 'ambiguous'
   failureType?: string
   candidateIds: string[]
   selectedTransactionId?: string

--- a/src/contexts/script-engine/infrastructure/BankScriptRepository.ts
+++ b/src/contexts/script-engine/infrastructure/BankScriptRepository.ts
@@ -51,8 +51,8 @@ export class BankScriptRepository implements IBankScriptRepository {
   async save(script: BankScript): Promise<void> {
     await this.executor.query(
       `INSERT INTO bank_scripts
-         (id, bank, flow_type, version, status, origin, base_script_id, code_snapshot, selector_map, created_at)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+         (id, bank, bank_id, flow_type, version, status, origin, base_script_id, code_snapshot, selector_map, created_at)
+       VALUES ($1,$2,(SELECT id FROM banks WHERE code = $2),$3,$4,$5,$6,$7,$8,$9,$10)
        ON CONFLICT (id) DO UPDATE SET
          status = EXCLUDED.status,
          code_snapshot = EXCLUDED.code_snapshot`,

--- a/tests/integration/_smoke.integration.test.ts
+++ b/tests/integration/_smoke.integration.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { getTestPool, truncateAll, closeTestPool } from './helpers/testDb.js'
+import { seedUser, getMiDineroBank, seedAccount } from './helpers/seed.js'
+
+describe('integration test infra (smoke)', () => {
+  beforeAll(async () => { await truncateAll() })
+  beforeEach(async () => { await truncateAll() })
+  afterAll(async () => { await closeTestPool() })
+
+  it('connects to the test database', async () => {
+    const { rows } = await getTestPool().query<{ db: string }>('SELECT current_database() AS db')
+    expect(rows[0].db).toBe(process.env.DATABASE_URL!.split('/').pop()!.split('?')[0])
+  })
+
+  it('has the seeded mi-dinero bank from migrations', async () => {
+    const bank = await getMiDineroBank()
+    expect(bank.code).toBe('mi-dinero')
+    expect(bank.id).toMatch(/^[0-9a-f-]{36}$/i)
+  })
+
+  it('seeds users and accounts', async () => {
+    const user = await seedUser({ email: 'smoke@test.com' })
+    const account = await seedAccount(user.id, { name: 'smoke-account' })
+    expect(account.userId).toBe(user.id)
+    expect(account.bank).toBe('mi-dinero')
+    const { rows } = await getTestPool().query(
+      'SELECT name FROM accounts WHERE id = $1', [account.id]
+    )
+    expect(rows[0].name).toBe('smoke-account')
+  })
+
+  it('truncates between tests (this row should not be visible to next test)', async () => {
+    await seedUser({ email: 'should-be-truncated@test.com' })
+    const { rows } = await getTestPool().query('SELECT COUNT(*)::int AS n FROM users')
+    expect(rows[0].n).toBe(1)
+  })
+
+  it('confirms previous test was truncated', async () => {
+    const { rows } = await getTestPool().query('SELECT COUNT(*)::int AS n FROM users')
+    expect(rows[0].n).toBe(0)
+  })
+})

--- a/tests/integration/account/AccountConfigRepository.integration.test.ts
+++ b/tests/integration/account/AccountConfigRepository.integration.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, afterAll, beforeEach } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser, seedAccount } from '../helpers/seed.js'
+import { AccountConfigRepository } from '../../../src/contexts/account/infrastructure/AccountConfigRepository.js'
+import { executorFromPool } from '../../../src/contexts/account/infrastructure/Executor.js'
+import type { AccountConfigInput } from '../../../src/contexts/account/domain/AccountConfig.js'
+
+describe('AccountConfigRepository (integration)', () => {
+  beforeEach(async () => { await truncateAll() })
+  afterAll(async () => { await closeTestPool() })
+
+  function makeRepo() {
+    return new AccountConfigRepository(executorFromPool(getTestPool()))
+  }
+
+  function buildInput(accountId: string, overrides: Partial<AccountConfigInput> = {}): AccountConfigInput {
+    return {
+      accountId,
+      pendingOrdersEndpoint: 'https://example.com/orders',
+      webhookUrl: 'https://hook.example.com',
+      retryLimit: 5,
+      pollingMethod: 'POST',
+      pollingBody: { foo: 'bar', n: 1 },
+      authType: 'bearer',
+      authToken: 'tok-123',
+      webhookAuthType: 'api_key',
+      webhookAuthToken: 'wh-tok',
+      notifyOnExpired: true,
+      webhookExtraFields: { custom: { nested: true }, list: [1, 2, 3] },
+      silentIngestion: true,
+      ...overrides,
+    }
+  }
+
+  describe('findByAccountId', () => {
+    it('returns null when no config exists', async () => {
+      const user = await seedUser()
+      const acc = await seedAccount(user.id)
+      const repo = makeRepo()
+      const found = await repo.findByAccountId(acc.id)
+      expect(found).toBeNull()
+    })
+
+    it('returns the existing config', async () => {
+      const user = await seedUser()
+      const acc = await seedAccount(user.id)
+      const repo = makeRepo()
+      await repo.upsert(buildInput(acc.id))
+
+      const found = await repo.findByAccountId(acc.id)
+      expect(found?.accountId).toBe(acc.id)
+      expect(found?.webhookUrl).toBe('https://hook.example.com')
+    })
+  })
+
+  describe('upsert', () => {
+    it('inserts a new config and returns all fields correctly', async () => {
+      const user = await seedUser()
+      const acc = await seedAccount(user.id)
+      const repo = makeRepo()
+      const input = buildInput(acc.id)
+      const result = await repo.upsert(input)
+
+      expect(result.id).toMatch(/^[0-9a-f-]{36}$/i)
+      expect(result.accountId).toBe(acc.id)
+      expect(result.pendingOrdersEndpoint).toBe(input.pendingOrdersEndpoint)
+      expect(result.webhookUrl).toBe(input.webhookUrl)
+      expect(result.retryLimit).toBe(5)
+      expect(result.pollingMethod).toBe('POST')
+      expect(result.pollingBody).toEqual({ foo: 'bar', n: 1 })
+      expect(result.authType).toBe('bearer')
+      expect(result.authToken).toBe('tok-123')
+      expect(result.webhookAuthType).toBe('api_key')
+      expect(result.webhookAuthToken).toBe('wh-tok')
+      expect(result.notifyOnExpired).toBe(true)
+      expect(result.webhookExtraFields).toEqual({ custom: { nested: true }, list: [1, 2, 3] })
+      expect(result.silentIngestion).toBe(true)
+    })
+
+    it('updates on conflict (account_id) preserving id and updating fields', async () => {
+      const user = await seedUser()
+      const acc = await seedAccount(user.id)
+      const repo = makeRepo()
+      const first = await repo.upsert(buildInput(acc.id))
+
+      const second = await repo.upsert(buildInput(acc.id, {
+        retryLimit: 10,
+        pollingMethod: 'GET',
+        pollingBody: null,
+        webhookExtraFields: { changed: true },
+        silentIngestion: false,
+        pendingOrdersEndpoint: null,
+      }))
+
+      expect(second.id).toBe(first.id)
+      expect(second.retryLimit).toBe(10)
+      expect(second.pollingMethod).toBe('GET')
+      expect(second.pollingBody).toBeNull()
+      expect(second.webhookExtraFields).toEqual({ changed: true })
+      expect(second.silentIngestion).toBe(false)
+      expect(second.pendingOrdersEndpoint).toBeNull()
+
+      const { rows } = await getTestPool().query(
+        'SELECT COUNT(*)::int AS n FROM account_config WHERE account_id = $1', [acc.id]
+      )
+      expect(rows[0].n).toBe(1)
+    })
+
+    it('persists JSONB fields as queryable JSON in the database', async () => {
+      const user = await seedUser()
+      const acc = await seedAccount(user.id)
+      const repo = makeRepo()
+      await repo.upsert(buildInput(acc.id, {
+        webhookExtraFields: { marker: 'unique-value' },
+      }))
+
+      const { rows } = await getTestPool().query(
+        `SELECT webhook_extra_fields ->> 'marker' AS marker FROM account_config WHERE account_id = $1`,
+        [acc.id]
+      )
+      expect(rows[0].marker).toBe('unique-value')
+    })
+  })
+})

--- a/tests/integration/account/AccountRepository.integration.test.ts
+++ b/tests/integration/account/AccountRepository.integration.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, afterAll, beforeEach } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser, seedAccount, getMiDineroBank } from '../helpers/seed.js'
+import { AccountRepository } from '../../../src/contexts/account/infrastructure/AccountRepository.js'
+import { executorFromPool } from '../../../src/contexts/account/infrastructure/Executor.js'
+import { Account } from '../../../src/contexts/account/domain/Account.js'
+
+describe('AccountRepository (integration)', () => {
+  beforeEach(async () => { await truncateAll() })
+  afterAll(async () => { await closeTestPool() })
+
+  function makeRepo() {
+    return new AccountRepository(executorFromPool(getTestPool()))
+  }
+
+  describe('findById', () => {
+    it('returns the account when it exists', async () => {
+      const user = await seedUser()
+      const acc = await seedAccount(user.id, { name: 'find-me' })
+      const repo = makeRepo()
+      const found = await repo.findById(acc.id)
+      expect(found).not.toBeNull()
+      expect(found!.id).toBe(acc.id)
+      expect(found!.userId).toBe(user.id)
+      expect(found!.bank).toBe('mi-dinero')
+      expect(found!.name).toBe('find-me')
+    })
+
+    it('returns null when the account does not exist', async () => {
+      const repo = makeRepo()
+      const result = await repo.findById(crypto.randomUUID())
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('findByIdForUser', () => {
+    it('returns the account when it belongs to the user', async () => {
+      const user = await seedUser()
+      const acc = await seedAccount(user.id)
+      const repo = makeRepo()
+      const found = await repo.findByIdForUser(acc.id, user.id)
+      expect(found?.id).toBe(acc.id)
+    })
+
+    it('returns null when the account belongs to another user', async () => {
+      const owner = await seedUser({ email: 'owner@test.com' })
+      const stranger = await seedUser({ email: 'stranger@test.com' })
+      const acc = await seedAccount(owner.id)
+      const repo = makeRepo()
+      const found = await repo.findByIdForUser(acc.id, stranger.id)
+      expect(found).toBeNull()
+    })
+  })
+
+  describe('findAllByUser', () => {
+    it('returns only active accounts belonging to the user', async () => {
+      const user = await seedUser()
+      const other = await seedUser({ email: 'other@test.com' })
+      const a1 = await seedAccount(user.id, { name: 'a1' })
+      const a2 = await seedAccount(user.id, { name: 'a2' })
+      await seedAccount(other.id, { name: 'other' })
+
+      // Mark a2 as inactive — should be filtered out
+      await getTestPool().query(`UPDATE accounts SET status = 'inactive' WHERE id = $1`, [a2.id])
+
+      const repo = makeRepo()
+      const list = await repo.findAllByUser(user.id)
+      expect(list).toHaveLength(1)
+      expect(list[0].id).toBe(a1.id)
+    })
+
+    it('returns empty array when user has no accounts', async () => {
+      const user = await seedUser()
+      const repo = makeRepo()
+      const list = await repo.findAllByUser(user.id)
+      expect(list).toEqual([])
+    })
+  })
+
+  describe('save', () => {
+    it('inserts a new account', async () => {
+      const user = await seedUser()
+      const bank = await getMiDineroBank()
+      const repo = makeRepo()
+      const id = crypto.randomUUID()
+      const account = Account.create(id, user.id, bank.id, bank.code, 'fresh')
+      await repo.save(account)
+
+      const found = await repo.findById(id)
+      expect(found?.name).toBe('fresh')
+      expect(found?.status).toBe('active')
+    })
+
+    it('updates name and status on conflict (idempotent)', async () => {
+      const user = await seedUser()
+      const bank = await getMiDineroBank()
+      const repo = makeRepo()
+      const id = crypto.randomUUID()
+      const account = Account.create(id, user.id, bank.id, bank.code, 'first')
+      await repo.save(account)
+      await repo.save(account)
+      await repo.save(account)
+
+      const { rows } = await getTestPool().query('SELECT COUNT(*)::int AS n FROM accounts WHERE id=$1', [id])
+      expect(rows[0].n).toBe(1)
+    })
+  })
+
+  describe('delete', () => {
+    it('removes the account by id', async () => {
+      const user = await seedUser()
+      const acc = await seedAccount(user.id)
+      const repo = makeRepo()
+      await repo.delete(acc.id)
+
+      const found = await repo.findById(acc.id)
+      expect(found).toBeNull()
+    })
+  })
+
+  describe('withTx', () => {
+    it('returns a new repository instance bound to the provided executor', async () => {
+      const user = await seedUser()
+      const bank = await getMiDineroBank()
+      const pool = getTestPool()
+      const client = await pool.connect()
+      try {
+        await client.query('BEGIN')
+        const txExec = { query: (text: string, params?: unknown[]) => client.query(text, params as any) }
+        const baseRepo = makeRepo()
+        const txRepo = baseRepo.withTx(txExec as any)
+        expect(txRepo).not.toBe(baseRepo)
+
+        const id = crypto.randomUUID()
+        const account = Account.create(id, user.id, bank.id, bank.code, 'tx-only')
+        await txRepo.save(account)
+
+        // Inside the tx, it's visible
+        const inside = await txRepo.findById(id)
+        expect(inside?.id).toBe(id)
+
+        // Outside the tx (different connection), not yet visible
+        const outside = await baseRepo.findById(id)
+        expect(outside).toBeNull()
+
+        await client.query('ROLLBACK')
+
+        const afterRollback = await baseRepo.findById(id)
+        expect(afterRollback).toBeNull()
+      } finally {
+        client.release()
+      }
+    })
+  })
+})

--- a/tests/integration/account/BankCredentialsRepository.integration.test.ts
+++ b/tests/integration/account/BankCredentialsRepository.integration.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, afterAll, beforeEach } from 'vitest'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser, seedAccount } from '../helpers/seed.js'
+import { BankCredentialsRepository } from '../../../src/contexts/account/infrastructure/BankCredentialsRepository.js'
+import { executorFromPool } from '../../../src/contexts/account/infrastructure/Executor.js'
+
+describe('BankCredentialsRepository (integration)', () => {
+  beforeEach(async () => { await truncateAll() })
+  afterAll(async () => { await closeTestPool() })
+
+  function makeRepo() {
+    return new BankCredentialsRepository(executorFromPool(getTestPool()))
+  }
+
+  describe('findUsernameByAccount', () => {
+    it('returns the username when credentials are valid', async () => {
+      const user = await seedUser()
+      const acc = await seedAccount(user.id)
+      const repo = makeRepo()
+      await repo.upsert({ accountId: acc.id, username: 'alice', encryptedPassword: 'enc' })
+
+      expect(await repo.findUsernameByAccount(acc.id)).toBe('alice')
+    })
+
+    it('returns null when credentials are invalid', async () => {
+      const user = await seedUser()
+      const acc = await seedAccount(user.id)
+      const repo = makeRepo()
+      await repo.upsert({ accountId: acc.id, username: 'alice', encryptedPassword: 'enc' })
+      await getTestPool().query(`UPDATE bank_credentials SET status='invalid' WHERE account_id=$1`, [acc.id])
+
+      expect(await repo.findUsernameByAccount(acc.id)).toBeNull()
+    })
+
+    it('returns null when no credentials exist', async () => {
+      const user = await seedUser()
+      const acc = await seedAccount(user.id)
+      const repo = makeRepo()
+      expect(await repo.findUsernameByAccount(acc.id)).toBeNull()
+    })
+  })
+
+  describe('upsert', () => {
+    it('inserts credentials with status=valid', async () => {
+      const user = await seedUser()
+      const acc = await seedAccount(user.id)
+      const repo = makeRepo()
+      await repo.upsert({ accountId: acc.id, username: '  bob  ', encryptedPassword: 'enc' })
+
+      const rec = await repo.findByAccountId(acc.id)
+      expect(rec?.username).toBe('bob') // trimmed
+      expect(rec?.status).toBe('valid')
+    })
+
+    it('is idempotent: updates on conflict and only keeps a single row', async () => {
+      const user = await seedUser()
+      const acc = await seedAccount(user.id)
+      const repo = makeRepo()
+      await repo.upsert({ accountId: acc.id, username: 'alice', encryptedPassword: 'enc-1' })
+      await repo.upsert({ accountId: acc.id, username: 'alice2', encryptedPassword: 'enc-2' })
+
+      const { rows } = await getTestPool().query(
+        'SELECT username, encrypted_password, status FROM bank_credentials WHERE account_id=$1',
+        [acc.id]
+      )
+      expect(rows).toHaveLength(1)
+      expect(rows[0].username).toBe('alice2')
+      expect(rows[0].encrypted_password).toBe('enc-2')
+      expect(rows[0].status).toBe('valid')
+    })
+
+    it('resets status back to valid after an invalid-status row is re-upserted', async () => {
+      const user = await seedUser()
+      const acc = await seedAccount(user.id)
+      const repo = makeRepo()
+      await repo.upsert({ accountId: acc.id, username: 'alice', encryptedPassword: 'enc' })
+      await getTestPool().query(`UPDATE bank_credentials SET status='invalid' WHERE account_id=$1`, [acc.id])
+      await repo.upsert({ accountId: acc.id, username: 'alice', encryptedPassword: 'enc' })
+
+      const rec = await repo.findByAccountId(acc.id)
+      expect(rec?.status).toBe('valid')
+    })
+  })
+
+  describe('findByAccountId', () => {
+    it('returns null when no record exists', async () => {
+      const user = await seedUser()
+      const acc = await seedAccount(user.id)
+      const repo = makeRepo()
+      expect(await repo.findByAccountId(acc.id)).toBeNull()
+    })
+
+    it('returns the full record', async () => {
+      const user = await seedUser()
+      const acc = await seedAccount(user.id)
+      const repo = makeRepo()
+      await repo.upsert({ accountId: acc.id, username: 'alice', encryptedPassword: 'enc' })
+
+      const rec = await repo.findByAccountId(acc.id)
+      expect(rec).toMatchObject({
+        accountId: acc.id,
+        username: 'alice',
+        status: 'valid',
+      })
+    })
+  })
+
+  describe('deleteByAccountId', () => {
+    it('removes the credentials record', async () => {
+      const user = await seedUser()
+      const acc = await seedAccount(user.id)
+      const repo = makeRepo()
+      await repo.upsert({ accountId: acc.id, username: 'alice', encryptedPassword: 'enc' })
+      await repo.deleteByAccountId(acc.id)
+
+      expect(await repo.findByAccountId(acc.id)).toBeNull()
+    })
+
+    it('is a no-op when no record exists', async () => {
+      const user = await seedUser()
+      const acc = await seedAccount(user.id)
+      const repo = makeRepo()
+      await expect(repo.deleteByAccountId(acc.id)).resolves.toBeUndefined()
+    })
+  })
+})

--- a/tests/integration/account/BankRepository.integration.test.ts
+++ b/tests/integration/account/BankRepository.integration.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, afterAll, beforeEach } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { getMiDineroBank } from '../helpers/seed.js'
+import { BankRepository } from '../../../src/contexts/account/infrastructure/BankRepository.js'
+import { executorFromPool } from '../../../src/contexts/account/infrastructure/Executor.js'
+import { Bank } from '../../../src/contexts/account/domain/Bank.js'
+
+describe('BankRepository (integration)', () => {
+  beforeEach(async () => { await truncateAll() })
+  afterAll(async () => {
+    // Clean up extra banks created by save() tests so we don't pollute the
+    // seed data for subsequent suites.
+    await getTestPool().query(`DELETE FROM banks WHERE code <> 'mi-dinero'`)
+    await closeTestPool()
+  })
+
+  function makeRepo() {
+    return new BankRepository(executorFromPool(getTestPool()))
+  }
+
+  describe('findById', () => {
+    it('returns the seeded mi-dinero bank', async () => {
+      const seeded = await getMiDineroBank()
+      const repo = makeRepo()
+      const bank = await repo.findById(seeded.id)
+      expect(bank?.id).toBe(seeded.id)
+      expect(bank?.code).toBe('mi-dinero')
+    })
+
+    it('returns null when the bank does not exist', async () => {
+      const repo = makeRepo()
+      const result = await repo.findById(crypto.randomUUID())
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('findAll', () => {
+    it('returns banks ordered by name', async () => {
+      // Insert two extra banks and check sort order.
+      await getTestPool().query(`DELETE FROM banks WHERE code <> 'mi-dinero'`)
+      const repo = makeRepo()
+      const zebra = Bank.create(crypto.randomUUID(), 'zebra-bank', 'Zebra Bank')
+      const alpha = Bank.create(crypto.randomUUID(), 'alpha-bank', 'Alpha Bank')
+      await repo.save(zebra)
+      await repo.save(alpha)
+
+      const all = await repo.findAll()
+      const names = all.map(b => b.name)
+      const sorted = [...names].sort((a, b) => a.localeCompare(b))
+      expect(names).toEqual(sorted)
+      expect(names).toContain('Alpha Bank')
+      expect(names).toContain('Zebra Bank')
+
+      // Cleanup
+      await getTestPool().query(`DELETE FROM banks WHERE code IN ('zebra-bank','alpha-bank')`)
+    })
+  })
+
+  describe('save', () => {
+    it('inserts a new bank created via Bank.create', async () => {
+      const repo = makeRepo()
+      const id = crypto.randomUUID()
+      const bank = Bank.create(id, 'test-bank', 'Test Bank', 'https://login.test')
+      await repo.save(bank)
+
+      const found = await repo.findById(id)
+      expect(found?.code).toBe('test-bank')
+      expect(found?.name).toBe('Test Bank')
+      expect(found?.loginUrl).toBe('https://login.test')
+      expect(found?.status).toBe('pending')
+
+      await getTestPool().query(`DELETE FROM banks WHERE id = $1`, [id])
+    })
+
+    it('updates the bank on conflict (id)', async () => {
+      const repo = makeRepo()
+      const id = crypto.randomUUID()
+      const bank = Bank.create(id, 'upd-bank', 'Original Name')
+      await repo.save(bank)
+
+      // mutate via raw row update (simulate reconstitute & save loop)
+      await getTestPool().query(
+        `UPDATE banks SET name = 'Updated Name' WHERE id = $1`, [id]
+      )
+      const reread = await repo.findById(id)
+      expect(reread?.name).toBe('Updated Name')
+
+      await getTestPool().query(`DELETE FROM banks WHERE id = $1`, [id])
+    })
+  })
+})

--- a/tests/integration/account/CreateAccountUseCase.integration.test.ts
+++ b/tests/integration/account/CreateAccountUseCase.integration.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, afterAll, beforeEach } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser, getMiDineroBank } from '../helpers/seed.js'
+import { CreateAccountUseCase } from '../../../src/contexts/account/application/CreateAccountUseCase.js'
+import { AccountRepository } from '../../../src/contexts/account/infrastructure/AccountRepository.js'
+import { BankRepository } from '../../../src/contexts/account/infrastructure/BankRepository.js'
+import { executorFromPool } from '../../../src/contexts/account/infrastructure/Executor.js'
+import { NotFoundError } from '../../../src/shared/errors/index.js'
+
+describe('CreateAccountUseCase (integration)', () => {
+  beforeEach(async () => { await truncateAll() })
+  afterAll(async () => { await closeTestPool() })
+
+  function makeUseCase() {
+    const exec = executorFromPool(getTestPool())
+    return new CreateAccountUseCase(new AccountRepository(exec), new BankRepository(exec))
+  }
+
+  it('creates and persists the account when bankId is valid (happy path)', async () => {
+    const user = await seedUser()
+    const bank = await getMiDineroBank()
+    const useCase = makeUseCase()
+
+    const { id } = await useCase.execute({ userId: user.id, bankId: bank.id, name: 'My Account' })
+    expect(id).toMatch(/^[0-9a-f-]{36}$/i)
+
+    const { rows } = await getTestPool().query(
+      'SELECT user_id, bank_id, name, status FROM accounts WHERE id=$1', [id]
+    )
+    expect(rows[0]).toMatchObject({
+      user_id: user.id,
+      bank_id: bank.id,
+      name: 'My Account',
+      status: 'active',
+    })
+  })
+
+  it('throws NotFoundError when bankId does not exist', async () => {
+    const user = await seedUser()
+    const useCase = makeUseCase()
+
+    await expect(
+      useCase.execute({ userId: user.id, bankId: crypto.randomUUID(), name: 'X' })
+    ).rejects.toBeInstanceOf(NotFoundError)
+
+    const { rows } = await getTestPool().query('SELECT COUNT(*)::int AS n FROM accounts')
+    expect(rows[0].n).toBe(0)
+  })
+})

--- a/tests/integration/account/UpsertAccountConfigUseCase.integration.test.ts
+++ b/tests/integration/account/UpsertAccountConfigUseCase.integration.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, afterAll, beforeEach } from 'vitest'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser, seedAccount } from '../helpers/seed.js'
+import { UpsertAccountConfigUseCase } from '../../../src/contexts/account/application/UpsertAccountConfigUseCase.js'
+import type { UpsertAccountConfigInput } from '../../../src/contexts/account/application/dto/AccountConfigDto.js'
+import { AccountRepository } from '../../../src/contexts/account/infrastructure/AccountRepository.js'
+import { AccountConfigRepository } from '../../../src/contexts/account/infrastructure/AccountConfigRepository.js'
+import { BankCredentialsRepository } from '../../../src/contexts/account/infrastructure/BankCredentialsRepository.js'
+import { executorFromPool } from '../../../src/contexts/account/infrastructure/Executor.js'
+import { UserOperationModeReaderAdapter } from '../../../src/contexts/account/infrastructure/adapters/UserOperationModeReaderAdapter.js'
+import { UserRepository } from '../../../src/contexts/user/infrastructure/UserRepository.js'
+import { executorFromPool as userExecutorFromPool } from '../../../src/contexts/user/infrastructure/Executor.js'
+import { NotFoundError, ValidationError } from '../../../src/shared/errors/index.js'
+
+function makeUseCase() {
+  const exec = executorFromPool(getTestPool())
+  const userExec = userExecutorFromPool(getTestPool())
+  return new UpsertAccountConfigUseCase(
+    new AccountRepository(exec),
+    new AccountConfigRepository(exec),
+    new BankCredentialsRepository(exec),
+    new UserOperationModeReaderAdapter(new UserRepository(userExec)),
+  )
+}
+
+function baseInput(accountId: string, userId: string, overrides: Partial<UpsertAccountConfigInput> = {}): UpsertAccountConfigInput {
+  return {
+    userId,
+    accountId,
+    pendingOrdersEndpoint: 'https://example.com/orders',
+    webhookUrl: 'https://hook.example.com',
+    retryLimit: 3,
+    pollingMethod: 'GET',
+    pollingBody: null,
+    authType: 'bearer',
+    authToken: 'tok',
+    webhookAuthType: null,
+    webhookAuthToken: null,
+    notifyOnExpired: false,
+    webhookExtraFields: null,
+    silentIngestion: false,
+    bankUsername: null,
+    bankPassword: null,
+    ...overrides,
+  }
+}
+
+describe('UpsertAccountConfigUseCase (integration)', () => {
+  beforeEach(async () => { await truncateAll() })
+  afterAll(async () => { await closeTestPool() })
+
+  it('persists the config and credentials, returns bankUsername (happy path, reconcile mode)', async () => {
+    const user = await seedUser({ operationMode: 'reconcile' })
+    const acc = await seedAccount(user.id)
+    const useCase = makeUseCase()
+
+    const result = await useCase.execute(baseInput(acc.id, user.id, {
+      bankUsername: 'alice',
+      bankPassword: 'secret',
+    }))
+
+    expect(result.accountId).toBe(acc.id)
+    expect(result.webhookUrl).toBe('https://hook.example.com')
+    expect(result.bankUsername).toBe('alice')
+
+    const { rows: configs } = await getTestPool().query(
+      `SELECT account_id, webhook_url FROM account_config WHERE account_id=$1`, [acc.id]
+    )
+    expect(configs).toHaveLength(1)
+    expect(configs[0].webhook_url).toBe('https://hook.example.com')
+
+    const { rows: creds } = await getTestPool().query(
+      `SELECT username, status FROM bank_credentials WHERE account_id=$1`, [acc.id]
+    )
+    expect(creds).toHaveLength(1)
+    expect(creds[0].username).toBe('alice')
+    expect(creds[0].status).toBe('valid')
+  })
+
+  it('passthrough mode allows null pendingOrdersEndpoint', async () => {
+    const user = await seedUser({ operationMode: 'passthrough' })
+    const acc = await seedAccount(user.id)
+    const useCase = makeUseCase()
+
+    const result = await useCase.execute(baseInput(acc.id, user.id, {
+      pendingOrdersEndpoint: null,
+    }))
+    expect(result.pendingOrdersEndpoint).toBeNull()
+  })
+
+  it('throws ValidationError when mode=reconcile and pendingOrdersEndpoint is null', async () => {
+    const user = await seedUser({ operationMode: 'reconcile' })
+    const acc = await seedAccount(user.id)
+    const useCase = makeUseCase()
+
+    await expect(
+      useCase.execute(baseInput(acc.id, user.id, { pendingOrdersEndpoint: null }))
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it('throws ValidationError when mode=reconcile and pendingOrdersEndpoint is blank', async () => {
+    const user = await seedUser({ operationMode: 'reconcile' })
+    const acc = await seedAccount(user.id)
+    const useCase = makeUseCase()
+
+    await expect(
+      useCase.execute(baseInput(acc.id, user.id, { pendingOrdersEndpoint: '   ' }))
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it('throws ValidationError when webhookUrl is missing', async () => {
+    const user = await seedUser({ operationMode: 'passthrough' })
+    const acc = await seedAccount(user.id)
+    const useCase = makeUseCase()
+
+    await expect(
+      useCase.execute(baseInput(acc.id, user.id, { webhookUrl: '' }))
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it('throws NotFoundError when account belongs to another user', async () => {
+    const owner = await seedUser({ email: 'owner@test.com', operationMode: 'passthrough' })
+    const stranger = await seedUser({ email: 'stranger@test.com', operationMode: 'passthrough' })
+    const acc = await seedAccount(owner.id)
+    const useCase = makeUseCase()
+
+    await expect(
+      useCase.execute(baseInput(acc.id, stranger.id))
+    ).rejects.toBeInstanceOf(NotFoundError)
+  })
+
+  it('does NOT upsert credentials when bankPassword is missing', async () => {
+    const user = await seedUser({ operationMode: 'passthrough' })
+    const acc = await seedAccount(user.id)
+    const useCase = makeUseCase()
+
+    const result = await useCase.execute(baseInput(acc.id, user.id, {
+      bankUsername: 'alice',
+      bankPassword: null,
+    }))
+    expect(result.bankUsername).toBeNull()
+
+    const { rows } = await getTestPool().query(
+      `SELECT COUNT(*)::int AS n FROM bank_credentials WHERE account_id=$1`, [acc.id]
+    )
+    expect(rows[0].n).toBe(0)
+  })
+
+  it('is idempotent: two consecutive upserts leave a single config and single credentials row', async () => {
+    const user = await seedUser({ operationMode: 'passthrough' })
+    const acc = await seedAccount(user.id)
+    const useCase = makeUseCase()
+
+    const first = await useCase.execute(baseInput(acc.id, user.id, {
+      pendingOrdersEndpoint: null,
+      retryLimit: 3,
+      bankUsername: 'alice',
+      bankPassword: 'secret',
+    }))
+
+    const second = await useCase.execute(baseInput(acc.id, user.id, {
+      pendingOrdersEndpoint: null,
+      retryLimit: 7,
+      webhookUrl: 'https://hook.example.com/v2',
+      bankUsername: 'alice-v2',
+      bankPassword: 'secret-v2',
+    }))
+
+    expect(second.id).toBe(first.id)
+    expect(second.retryLimit).toBe(7)
+    expect(second.webhookUrl).toBe('https://hook.example.com/v2')
+    expect(second.bankUsername).toBe('alice-v2')
+
+    const { rows: configs } = await getTestPool().query(
+      `SELECT COUNT(*)::int AS n FROM account_config WHERE account_id=$1`, [acc.id]
+    )
+    expect(configs[0].n).toBe(1)
+
+    const { rows: creds } = await getTestPool().query(
+      `SELECT COUNT(*)::int AS n FROM bank_credentials WHERE account_id=$1`, [acc.id]
+    )
+    expect(creds[0].n).toBe(1)
+  })
+})

--- a/tests/integration/banking/BankMovementReadModel.integration.test.ts
+++ b/tests/integration/banking/BankMovementReadModel.integration.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser, seedAccount, SeededAccount } from '../helpers/seed.js'
+import { BankMovementReadModel } from '../../../src/contexts/banking/infrastructure/BankMovementReadModel.js'
+import { BankTransactionRepository } from '../../../src/contexts/banking/infrastructure/BankTransactionRepository.js'
+import { executorFromPool } from '../../../src/contexts/banking/infrastructure/Executor.js'
+import { BankTransaction } from '../../../src/contexts/banking/domain/BankTransaction.js'
+
+let account: SeededAccount
+let otherAccount: SeededAccount
+let scriptId: string
+let txRepo: BankTransactionRepository
+let readModel: BankMovementReadModel
+
+async function getActiveScriptId(): Promise<string> {
+  const { rows } = await getTestPool().query(
+    `SELECT id FROM bank_scripts WHERE bank='mi-dinero' AND flow_type='extract_transactions' AND status='active' LIMIT 1`
+  )
+  return rows[0].id
+}
+
+async function seedTx(accId: string, externalId: string, receivedAt: Date, senderName: string | null = 'Alice'): Promise<string> {
+  const tx = BankTransaction.create(crypto.randomUUID(), {
+    accountId: accId,
+    externalId,
+    referenceHash: `ref-${externalId}`,
+    amount: 50,
+    currency: 'USD',
+    senderName: senderName ?? undefined,
+    receivedAt,
+    scriptId,
+    rawPayload: {},
+  })
+  await txRepo.save(tx)
+  return tx.id
+}
+
+describe('BankMovementReadModel (integration)', () => {
+  beforeEach(async () => {
+    await truncateAll()
+    const user = await seedUser({ email: `rm-${crypto.randomBytes(3).toString('hex')}@test.com` })
+    account = await seedAccount(user.id, { name: 'a' })
+    otherAccount = await seedAccount(user.id, { name: 'b' })
+    scriptId = await getActiveScriptId()
+    txRepo = new BankTransactionRepository(executorFromPool(getTestPool()))
+    readModel = new BankMovementReadModel(getTestPool())
+  })
+  afterAll(async () => { await closeTestPool() })
+
+  it('list returns camelCase DTOs', async () => {
+    await seedTx(account.id, 'e1', new Date('2024-01-01'), 'Alice')
+    const rows = await readModel.list({ accountId: account.id, limit: 10, offset: 0 })
+    expect(rows).toHaveLength(1)
+    const r = rows[0]
+    expect(r.externalId).toBe('e1')
+    expect(r.senderName).toBe('Alice')
+    expect(r.receivedAt).toBeInstanceOf(Date)
+    expect(r.notifiedAt).toBeNull()
+    expect(r.excludedAt).toBeNull()
+    expect(typeof r.amount).toBe('number')
+    expect(r.amount).toBe(50)
+  })
+
+  it('list orders by received_at DESC', async () => {
+    await seedTx(account.id, 'old', new Date('2024-01-01'))
+    await seedTx(account.id, 'new', new Date('2024-06-01'))
+    await seedTx(account.id, 'mid', new Date('2024-03-01'))
+    const rows = await readModel.list({ accountId: account.id, limit: 10, offset: 0 })
+    expect(rows.map((r) => r.externalId)).toEqual(['new', 'mid', 'old'])
+  })
+
+  it('list applies limit and offset', async () => {
+    await seedTx(account.id, 'e1', new Date('2024-01-01'))
+    await seedTx(account.id, 'e2', new Date('2024-02-01'))
+    await seedTx(account.id, 'e3', new Date('2024-03-01'))
+    const page1 = await readModel.list({ accountId: account.id, limit: 2, offset: 0 })
+    const page2 = await readModel.list({ accountId: account.id, limit: 2, offset: 2 })
+    expect(page1.map((r) => r.externalId)).toEqual(['e3', 'e2'])
+    expect(page2.map((r) => r.externalId)).toEqual(['e1'])
+  })
+
+  it('list filters by accountId', async () => {
+    await seedTx(account.id, 'mine', new Date('2024-01-01'))
+    await seedTx(otherAccount.id, 'theirs', new Date('2024-02-01'))
+    const rows = await readModel.list({ accountId: account.id, limit: 10, offset: 0 })
+    expect(rows).toHaveLength(1)
+    expect(rows[0].externalId).toBe('mine')
+  })
+})

--- a/tests/integration/banking/BankTransactionRepository.integration.test.ts
+++ b/tests/integration/banking/BankTransactionRepository.integration.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser, seedAccount, getMiDineroBank, SeededAccount } from '../helpers/seed.js'
+import { BankTransactionRepository } from '../../../src/contexts/banking/infrastructure/BankTransactionRepository.js'
+import { executorFromPool } from '../../../src/contexts/banking/infrastructure/Executor.js'
+import { BankTransaction } from '../../../src/contexts/banking/domain/BankTransaction.js'
+
+let account: SeededAccount
+let scriptId: string
+let repo: BankTransactionRepository
+
+async function getActiveScriptId(): Promise<string> {
+  const { rows } = await getTestPool().query(
+    `SELECT id FROM bank_scripts WHERE bank='mi-dinero' AND flow_type='extract_transactions' AND status='active' LIMIT 1`
+  )
+  return rows[0].id
+}
+
+function makeTx(overrides: Partial<{ externalId: string; receivedAt: Date; senderName?: string }> = {}): BankTransaction {
+  return BankTransaction.create(crypto.randomUUID(), {
+    accountId: account.id,
+    externalId: overrides.externalId ?? `ext-${crypto.randomBytes(3).toString('hex')}`,
+    referenceHash: `ref-${crypto.randomBytes(3).toString('hex')}`,
+    amount: 100.5,
+    currency: 'USD',
+    senderName: overrides.senderName ?? 'Alice',
+    receivedAt: overrides.receivedAt ?? new Date(),
+    scriptId,
+    rawPayload: { source: 'test' },
+  })
+}
+
+describe('BankTransactionRepository (integration)', () => {
+  beforeEach(async () => {
+    await truncateAll()
+    const user = await seedUser({ email: `btx-${crypto.randomBytes(3).toString('hex')}@test.com` })
+    account = await seedAccount(user.id)
+    scriptId = await getActiveScriptId()
+    repo = new BankTransactionRepository(executorFromPool(getTestPool()))
+  })
+  afterAll(async () => { await closeTestPool() })
+
+  it('save persists a new transaction', async () => {
+    const tx = makeTx({ externalId: 'ext-1' })
+    await repo.save(tx)
+    const { rows } = await getTestPool().query('SELECT * FROM bank_transactions WHERE id=$1', [tx.id])
+    expect(rows).toHaveLength(1)
+    expect(rows[0].external_id).toBe('ext-1')
+    expect(Number(rows[0].amount)).toBe(100.5)
+  })
+
+  it('save is idempotent on (account_id, external_id) — ON CONFLICT DO NOTHING', async () => {
+    const tx1 = makeTx({ externalId: 'dup' })
+    const tx2 = makeTx({ externalId: 'dup' })
+    await repo.save(tx1)
+    await repo.save(tx2)
+    const { rows } = await getTestPool().query(
+      'SELECT id FROM bank_transactions WHERE account_id=$1 AND external_id=$2',
+      [account.id, 'dup']
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].id).toBe(tx1.id)
+  })
+
+  it('findById returns aggregate', async () => {
+    const tx = makeTx()
+    await repo.save(tx)
+    const found = await repo.findById(tx.id)
+    expect(found?.id).toBe(tx.id)
+    expect(found?.amount).toBe(100.5)
+  })
+
+  it('findById returns null when missing', async () => {
+    const found = await repo.findById(crypto.randomUUID())
+    expect(found).toBeNull()
+  })
+
+  it('findById with forUpdate runs without error', async () => {
+    const tx = makeTx()
+    await repo.save(tx)
+    const found = await repo.findById(tx.id, { forUpdate: true })
+    expect(found?.id).toBe(tx.id)
+  })
+
+  it('findByExternalId returns the transaction', async () => {
+    const tx = makeTx({ externalId: 'lookup-me' })
+    await repo.save(tx)
+    const found = await repo.findByExternalId(account.id, 'lookup-me')
+    expect(found?.id).toBe(tx.id)
+  })
+
+  it('findLatestExternalId returns the latest by received_at DESC', async () => {
+    await repo.save(makeTx({ externalId: 'older', receivedAt: new Date('2024-01-01') }))
+    await repo.save(makeTx({ externalId: 'newest', receivedAt: new Date('2024-06-01') }))
+    await repo.save(makeTx({ externalId: 'middle', receivedAt: new Date('2024-03-01') }))
+    const latest = await repo.findLatestExternalId(account.id)
+    expect(latest).toBe('newest')
+  })
+
+  it('findLatestExternalId returns null when no transactions', async () => {
+    expect(await repo.findLatestExternalId(account.id)).toBeNull()
+  })
+
+  it('markExcluded + isExcluded', async () => {
+    const tx = makeTx()
+    await repo.save(tx)
+    expect(await repo.isExcluded(tx.id)).toBe(false)
+    await repo.markExcluded(tx.id)
+    expect(await repo.isExcluded(tx.id)).toBe(true)
+  })
+
+  it('markNotified + isNotified', async () => {
+    const tx = makeTx()
+    await repo.save(tx)
+    expect(await repo.isNotified(tx.id)).toBe(false)
+    await repo.markNotified(tx.id)
+    expect(await repo.isNotified(tx.id)).toBe(true)
+  })
+
+  it('markAllNotified sets notified_at for all pending in account', async () => {
+    const a = makeTx({ externalId: 'a' })
+    const b = makeTx({ externalId: 'b' })
+    await repo.save(a)
+    await repo.save(b)
+    await repo.markAllNotified(account.id)
+    expect(await repo.isNotified(a.id)).toBe(true)
+    expect(await repo.isNotified(b.id)).toBe(true)
+  })
+
+  describe('claimNotification (CAS)', () => {
+    it('returns true on first call, false on subsequent', async () => {
+      const tx = makeTx()
+      await repo.save(tx)
+      expect(await repo.claimNotification(tx.id)).toBe(true)
+      expect(await repo.claimNotification(tx.id)).toBe(false)
+    })
+
+    it('only one of two concurrent claims wins', async () => {
+      const tx = makeTx()
+      await repo.save(tx)
+      const [a, b] = await Promise.all([
+        repo.claimNotification(tx.id),
+        repo.claimNotification(tx.id),
+      ])
+      expect([a, b].filter(Boolean)).toHaveLength(1)
+      expect([a, b].filter((v) => !v)).toHaveLength(1)
+    })
+
+    it('releaseNotification allows re-claim', async () => {
+      const tx = makeTx()
+      await repo.save(tx)
+      expect(await repo.claimNotification(tx.id)).toBe(true)
+      await repo.releaseNotification(tx.id)
+      expect(await repo.isNotified(tx.id)).toBe(false)
+      expect(await repo.claimNotification(tx.id)).toBe(true)
+    })
+  })
+
+  it('withTx returns a repo bound to the given executor', async () => {
+    const client = await getTestPool().connect()
+    try {
+      await client.query('BEGIN')
+      const txRepo = repo.withTx({ query: (text, params) => client.query(text, params as any) })
+      const tx = makeTx({ externalId: 'in-tx' })
+      await txRepo.save(tx)
+      // visible inside the transaction
+      const insideTx = await txRepo.findById(tx.id)
+      expect(insideTx?.id).toBe(tx.id)
+      // not yet visible outside
+      const outsideBefore = await repo.findById(tx.id)
+      expect(outsideBefore).toBeNull()
+      await client.query('COMMIT')
+      const outsideAfter = await repo.findById(tx.id)
+      expect(outsideAfter?.id).toBe(tx.id)
+    } finally {
+      client.release()
+    }
+  })
+})

--- a/tests/integration/banking/NotifyBankMovementUseCase.integration.test.ts
+++ b/tests/integration/banking/NotifyBankMovementUseCase.integration.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser, seedAccount, SeededAccount, SeededUser } from '../helpers/seed.js'
+import { BankTransactionRepository } from '../../../src/contexts/banking/infrastructure/BankTransactionRepository.js'
+import { executorFromPool as bankingExec } from '../../../src/contexts/banking/infrastructure/Executor.js'
+import { executorFromPool as accountExec } from '../../../src/contexts/account/infrastructure/Executor.js'
+import { executorFromPool as userExec } from '../../../src/contexts/user/infrastructure/Executor.js'
+import { AccountRepository } from '../../../src/contexts/account/infrastructure/AccountRepository.js'
+import { AccountConfigRepository } from '../../../src/contexts/account/infrastructure/AccountConfigRepository.js'
+import { UserRepository } from '../../../src/contexts/user/infrastructure/UserRepository.js'
+import { AccountForBankingReaderAdapter } from '../../../src/contexts/banking/infrastructure/adapters/AccountForBankingReaderAdapter.js'
+import { NotificationConfigReaderAdapter } from '../../../src/contexts/banking/infrastructure/adapters/NotificationConfigReaderAdapter.js'
+import { UserOperationModeReaderAdapter } from '../../../src/contexts/banking/infrastructure/adapters/UserOperationModeReaderAdapter.js'
+import { NotifyBankMovementUseCase } from '../../../src/contexts/banking/application/NotifyBankMovementUseCase.js'
+import { BankTransaction } from '../../../src/contexts/banking/domain/BankTransaction.js'
+
+let user: SeededUser
+let account: SeededAccount
+let scriptId: string
+let txRepo: BankTransactionRepository
+let configRepo: AccountConfigRepository
+let userRepo: UserRepository
+
+async function getActiveScriptId(): Promise<string> {
+  const { rows } = await getTestPool().query(
+    `SELECT id FROM bank_scripts WHERE bank='mi-dinero' AND flow_type='extract_transactions' AND status='active' LIMIT 1`
+  )
+  return rows[0].id
+}
+
+async function seedAccountConfig(opts: {
+  webhookUrl?: string | null
+  silentIngestion?: boolean
+} = {}): Promise<void> {
+  // Need to insert directly because the AccountConfigRepository.upsert requires
+  // webhook_url NOT NULL. To test "no webhook" we set empty string and have the
+  // adapter pass that through — but the use case checks for falsy URL.
+  // Easier: insert directly with raw SQL when nullability is needed.
+  await getTestPool().query(
+    `INSERT INTO account_config
+      (id, account_id, pending_orders_endpoint, webhook_url, retry_limit,
+       polling_method, polling_body, auth_type, auth_token,
+       webhook_auth_type, webhook_auth_token, notify_on_expired,
+       webhook_extra_fields, silent_ingestion)
+     VALUES (gen_random_uuid(),$1,$2,$3,3,'GET',NULL,'bearer','tok',NULL,NULL,false,$4,$5)`,
+    [
+      account.id,
+      'https://orders.example/pending',
+      opts.webhookUrl === undefined ? 'https://hook.example.com' : (opts.webhookUrl ?? ''),
+      JSON.stringify({ source: 'bank' }),
+      opts.silentIngestion ?? false,
+    ]
+  )
+}
+
+async function seedBankTx(opts: { senderName?: string | null } = {}): Promise<BankTransaction> {
+  const tx = BankTransaction.create(crypto.randomUUID(), {
+    accountId: account.id,
+    externalId: `ext-${crypto.randomBytes(3).toString('hex')}`,
+    referenceHash: 'ref',
+    amount: 250,
+    currency: 'USD',
+    senderName: opts.senderName === undefined ? 'Alice' : (opts.senderName ?? undefined),
+    receivedAt: new Date('2024-05-01T10:00:00Z'),
+    scriptId,
+    rawPayload: { foo: 'bar' },
+  })
+  await txRepo.save(tx)
+  return tx
+}
+
+function buildUseCase(sendWebhookFn: any) {
+  const pool = getTestPool()
+  return new NotifyBankMovementUseCase({
+    bankTxRepo: txRepo,
+    accountReader: new AccountForBankingReaderAdapter(new AccountRepository(accountExec(pool))),
+    configReader: new NotificationConfigReaderAdapter(new AccountConfigRepository(accountExec(pool))),
+    userModeReader: new UserOperationModeReaderAdapter(new UserRepository(userExec(pool))),
+    sendWebhookFn,
+  })
+}
+
+describe('NotifyBankMovementUseCase (integration)', () => {
+  beforeEach(async () => {
+    await truncateAll()
+    const pool = getTestPool()
+    user = await seedUser({ email: `nbm-${crypto.randomBytes(3).toString('hex')}@test.com`, operationMode: 'passthrough' })
+    account = await seedAccount(user.id)
+    scriptId = await getActiveScriptId()
+    txRepo = new BankTransactionRepository(bankingExec(pool))
+    configRepo = new AccountConfigRepository(accountExec(pool))
+    userRepo = new UserRepository(userExec(pool))
+  })
+  afterAll(async () => { await closeTestPool() })
+
+  it('happy path: claims notification and invokes send with correct payload', async () => {
+    await seedAccountConfig()
+    const tx = await seedBankTx()
+    const send = vi.fn().mockResolvedValue(undefined)
+    const useCase = buildUseCase(send)
+    await useCase.execute({ bankTransactionId: tx.id })
+
+    expect(send).toHaveBeenCalledTimes(1)
+    const call = send.mock.calls[0][0]
+    expect(call.url).toBe('https://hook.example.com')
+    expect(call.payload.id).toBe(tx.id)
+    expect(call.payload.amount).toBe(250)
+    expect(call.payload.currency).toBe('USD')
+    expect(call.payload.name).toBe('Alice')
+    expect(call.payload.received_at).toBe(new Date('2024-05-01T10:00:00Z').toISOString())
+    expect(call.payload.source).toBe('bank')
+    expect(await txRepo.isNotified(tx.id)).toBe(true)
+  })
+
+  it('silentIngestion=true claims but does not send', async () => {
+    await seedAccountConfig({ silentIngestion: true })
+    const tx = await seedBankTx()
+    const send = vi.fn().mockResolvedValue(undefined)
+    await buildUseCase(send).execute({ bankTransactionId: tx.id })
+    expect(send).not.toHaveBeenCalled()
+    expect(await txRepo.isNotified(tx.id)).toBe(true)
+  })
+
+  it('mode=reconcile: does nothing (no claim, no send)', async () => {
+    await userRepo.setOperationMode(user.id, 'reconcile')
+    await seedAccountConfig()
+    const tx = await seedBankTx()
+    const send = vi.fn().mockResolvedValue(undefined)
+    await buildUseCase(send).execute({ bankTransactionId: tx.id })
+    expect(send).not.toHaveBeenCalled()
+    expect(await txRepo.isNotified(tx.id)).toBe(false)
+  })
+
+  it('no webhook url: does nothing', async () => {
+    await seedAccountConfig({ webhookUrl: '' })
+    const tx = await seedBankTx()
+    const send = vi.fn().mockResolvedValue(undefined)
+    await buildUseCase(send).execute({ bankTransactionId: tx.id })
+    expect(send).not.toHaveBeenCalled()
+    expect(await txRepo.isNotified(tx.id)).toBe(false)
+  })
+
+  it('no senderName: does nothing', async () => {
+    await seedAccountConfig()
+    const tx = await seedBankTx({ senderName: null })
+    const send = vi.fn().mockResolvedValue(undefined)
+    await buildUseCase(send).execute({ bankTransactionId: tx.id })
+    expect(send).not.toHaveBeenCalled()
+    expect(await txRepo.isNotified(tx.id)).toBe(false)
+  })
+
+  it('send failure releases the claim (notified_at back to NULL) and rethrows', async () => {
+    await seedAccountConfig()
+    const tx = await seedBankTx()
+    const send = vi.fn().mockRejectedValue(new Error('5xx'))
+    const useCase = buildUseCase(send)
+    await expect(useCase.execute({ bankTransactionId: tx.id })).rejects.toThrow('5xx')
+    expect(await txRepo.isNotified(tx.id)).toBe(false)
+  })
+
+  it('second invocation with the same tx does not double-send (claim already taken)', async () => {
+    await seedAccountConfig()
+    const tx = await seedBankTx()
+    const send = vi.fn().mockResolvedValue(undefined)
+    const useCase = buildUseCase(send)
+    await useCase.execute({ bankTransactionId: tx.id })
+    await useCase.execute({ bankTransactionId: tx.id })
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/integration/banking/ScrapeRunRepository.integration.test.ts
+++ b/tests/integration/banking/ScrapeRunRepository.integration.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser, seedAccount, SeededAccount } from '../helpers/seed.js'
+import { ScrapeRunRepository } from '../../../src/contexts/banking/infrastructure/ScrapeRunRepository.js'
+import { executorFromPool } from '../../../src/contexts/banking/infrastructure/Executor.js'
+
+let account: SeededAccount
+let scriptId: string
+let repo: ScrapeRunRepository
+
+async function getActiveScriptId(): Promise<string> {
+  const { rows } = await getTestPool().query(
+    `SELECT id FROM bank_scripts WHERE bank='mi-dinero' AND flow_type='extract_transactions' AND status='active' LIMIT 1`
+  )
+  return rows[0].id
+}
+
+describe('ScrapeRunRepository (integration)', () => {
+  beforeEach(async () => {
+    await truncateAll()
+    const user = await seedUser({ email: `srr-${crypto.randomBytes(3).toString('hex')}@test.com` })
+    account = await seedAccount(user.id)
+    scriptId = await getActiveScriptId()
+    repo = new ScrapeRunRepository(executorFromPool(getTestPool()))
+  })
+  afterAll(async () => { await closeTestPool() })
+
+  it('create persists a row with status running', async () => {
+    const runId = crypto.randomUUID()
+    await repo.create(runId, account.id, scriptId)
+    const { rows } = await getTestPool().query('SELECT * FROM bank_scrape_runs WHERE id=$1', [runId])
+    expect(rows[0].status).toBe('running')
+    expect(rows[0].account_id).toBe(account.id)
+    expect(rows[0].script_id).toBe(scriptId)
+    expect(rows[0].started_at).toBeInstanceOf(Date)
+    expect(rows[0].finished_at).toBeNull()
+  })
+
+  it('markSuccess sets status=success and transactions_found', async () => {
+    const runId = crypto.randomUUID()
+    await repo.create(runId, account.id, scriptId)
+    await repo.markSuccess(runId, 7)
+    const { rows } = await getTestPool().query('SELECT * FROM bank_scrape_runs WHERE id=$1', [runId])
+    expect(rows[0].status).toBe('success')
+    expect(rows[0].transactions_found).toBe(7)
+    expect(rows[0].finished_at).toBeInstanceOf(Date)
+  })
+
+  it('markFailed sets status=failed, failure_type and error_message', async () => {
+    const runId = crypto.randomUUID()
+    await repo.create(runId, account.id, scriptId)
+    await repo.markFailed(runId, 'boom')
+    const { rows } = await getTestPool().query('SELECT * FROM bank_scrape_runs WHERE id=$1', [runId])
+    expect(rows[0].status).toBe('failed')
+    expect(rows[0].error_message).toBe('boom')
+    expect(rows[0].failure_type).toBe('unknown')
+    expect(rows[0].finished_at).toBeInstanceOf(Date)
+  })
+})

--- a/tests/integration/conciliation/ConciliatedTransactionRepository.integration.test.ts
+++ b/tests/integration/conciliation/ConciliatedTransactionRepository.integration.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser, seedAccount } from '../helpers/seed.js'
+import { executorFromPool } from '../../../src/contexts/conciliation/infrastructure/Executor.js'
+import { ConciliatedTransactionRepository } from '../../../src/contexts/conciliation/infrastructure/ConciliatedTransactionRepository.js'
+import { insertConciliationRequest, insertBankTransaction } from './helpers.js'
+
+describe('ConciliatedTransactionRepository (integration)', () => {
+  beforeEach(async () => { await truncateAll() })
+  afterAll(async () => { await closeTestPool() })
+
+  function buildRepo() {
+    return new ConciliatedTransactionRepository(executorFromPool(getTestPool()))
+  }
+
+  it('save persists a primary match and findPrimaryByRequest finds it', async () => {
+    const user = await seedUser()
+    const acc = await seedAccount(user.id)
+    const req = await insertConciliationRequest({ accountId: acc.id })
+    const btx = await insertBankTransaction({ accountId: acc.id })
+    const repo = buildRepo()
+    const matchId = crypto.randomUUID()
+
+    await repo.save({
+      id: matchId,
+      accountId: acc.id,
+      requestId: req.id,
+      bankTransactionId: btx.id,
+    })
+
+    const found = await repo.findPrimaryByRequest(req.id)
+    expect(found).not.toBeNull()
+    expect(found!.id).toBe(matchId)
+
+    const { rows } = await getTestPool().query(
+      `SELECT matched_by, is_primary, is_notified FROM conciliated_transactions WHERE id = $1`,
+      [matchId]
+    )
+    expect(rows[0].matched_by).toBe('engine')
+    expect(rows[0].is_primary).toBe(true)
+    expect(rows[0].is_notified).toBe(false)
+  })
+
+  it('findPrimaryByRequest returns null when no match exists', async () => {
+    const found = await buildRepo().findPrimaryByRequest(crypto.randomUUID())
+    expect(found).toBeNull()
+  })
+
+  it('markNotified flips is_notified to true', async () => {
+    const user = await seedUser()
+    const acc = await seedAccount(user.id)
+    const req = await insertConciliationRequest({ accountId: acc.id })
+    const btx = await insertBankTransaction({ accountId: acc.id })
+    const repo = buildRepo()
+    const matchId = crypto.randomUUID()
+    await repo.save({ id: matchId, accountId: acc.id, requestId: req.id, bankTransactionId: btx.id })
+
+    await repo.markNotified(matchId)
+
+    const { rows } = await getTestPool().query(
+      `SELECT is_notified FROM conciliated_transactions WHERE id = $1`, [matchId]
+    )
+    expect(rows[0].is_notified).toBe(true)
+  })
+})

--- a/tests/integration/conciliation/ConciliationAttemptRepository.integration.test.ts
+++ b/tests/integration/conciliation/ConciliationAttemptRepository.integration.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser, seedAccount } from '../helpers/seed.js'
+import { executorFromPool } from '../../../src/contexts/conciliation/infrastructure/Executor.js'
+import { ConciliationAttemptRepository } from '../../../src/contexts/conciliation/infrastructure/ConciliationAttemptRepository.js'
+import { insertConciliationRequest, insertBankTransaction } from './helpers.js'
+
+describe('ConciliationAttemptRepository (integration)', () => {
+  beforeEach(async () => { await truncateAll() })
+  afterAll(async () => { await closeTestPool() })
+
+  function buildRepo() {
+    return new ConciliationAttemptRepository(executorFromPool(getTestPool()))
+  }
+
+  it('save persists an attempt with candidateIds as JSONB', async () => {
+    const user = await seedUser()
+    const acc = await seedAccount(user.id)
+    const req = await insertConciliationRequest({ accountId: acc.id })
+    const btx1 = await insertBankTransaction({ accountId: acc.id, externalId: 'btx-a' })
+    const btx2 = await insertBankTransaction({ accountId: acc.id, externalId: 'btx-b' })
+
+    const id = crypto.randomUUID()
+    await buildRepo().save({
+      id,
+      accountId: acc.id,
+      requestId: req.id,
+      attemptNumber: 1,
+      status: 'success',
+      candidateIds: [btx1.id, btx2.id],
+      selectedTransactionId: btx1.id,
+    })
+
+    const { rows } = await getTestPool().query(
+      `SELECT id, request_id, attempt_number, status, matched_candidates, selected_transaction_id
+         FROM conciliation_attempts WHERE id = $1`,
+      [id]
+    )
+    expect(rows[0].request_id).toBe(req.id)
+    expect(rows[0].attempt_number).toBe(1)
+    expect(rows[0].status).toBe('success')
+    expect(rows[0].selected_transaction_id).toBe(btx1.id)
+    const candidates = typeof rows[0].matched_candidates === 'string'
+      ? JSON.parse(rows[0].matched_candidates)
+      : rows[0].matched_candidates
+    expect(candidates).toEqual([btx1.id, btx2.id])
+  })
+
+  it('save accepts a failed attempt with failure_type and no selected transaction', async () => {
+    const user = await seedUser()
+    const acc = await seedAccount(user.id)
+    const req = await insertConciliationRequest({ accountId: acc.id })
+
+    const id = crypto.randomUUID()
+    await buildRepo().save({
+      id,
+      accountId: acc.id,
+      requestId: req.id,
+      attemptNumber: 1,
+      status: 'no_match',
+      failureType: 'rule_miss',
+      candidateIds: [],
+    })
+
+    const { rows } = await getTestPool().query(
+      `SELECT status, failure_type, selected_transaction_id, matched_candidates
+         FROM conciliation_attempts WHERE id = $1`, [id]
+    )
+    expect(rows[0].status).toBe('no_match')
+    expect(rows[0].failure_type).toBe('rule_miss')
+    expect(rows[0].selected_transaction_id).toBeNull()
+  })
+})

--- a/tests/integration/conciliation/ConciliationReadModel.integration.test.ts
+++ b/tests/integration/conciliation/ConciliationReadModel.integration.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser, seedAccount } from '../helpers/seed.js'
+import { ConciliationReadModel } from '../../../src/contexts/conciliation/infrastructure/ConciliationReadModel.js'
+import { insertConciliationRequest, insertBankTransaction } from './helpers.js'
+
+describe('ConciliationReadModel (integration)', () => {
+  beforeEach(async () => { await truncateAll() })
+  afterAll(async () => { await closeTestPool() })
+
+  function buildRm() {
+    return new ConciliationReadModel(getTestPool())
+  }
+
+  it('list returns only the user\'s requests', async () => {
+    const owner = await seedUser()
+    const stranger = await seedUser()
+    const accOwner = await seedAccount(owner.id)
+    const accStranger = await seedAccount(stranger.id)
+    await insertConciliationRequest({ accountId: accOwner.id, externalId: 'mine' })
+    await insertConciliationRequest({ accountId: accStranger.id, externalId: 'theirs' })
+
+    const items = await buildRm().list({ userId: owner.id, limit: 10, offset: 0 })
+    expect(items).toHaveLength(1)
+    expect(items[0].externalId).toBe('mine')
+    expect(items[0].bank).toBe('mi-dinero')
+    expect(items[0].accountName).toBe(accOwner.name)
+  })
+
+  it('list filters by status', async () => {
+    const user = await seedUser()
+    const acc = await seedAccount(user.id)
+    await insertConciliationRequest({ accountId: acc.id, externalId: 'p', status: 'pending' })
+    await insertConciliationRequest({ accountId: acc.id, externalId: 'm', status: 'matched' })
+
+    const items = await buildRm().list({ userId: user.id, limit: 10, offset: 0, status: 'matched' })
+    expect(items).toHaveLength(1)
+    expect(items[0].externalId).toBe('m')
+  })
+
+  it('list honors limit and offset, ordered by created_at DESC', async () => {
+    const user = await seedUser()
+    const acc = await seedAccount(user.id)
+    await insertConciliationRequest({ accountId: acc.id, externalId: 'first', createdAt: new Date(Date.now() - 2000) })
+    await insertConciliationRequest({ accountId: acc.id, externalId: 'second', createdAt: new Date(Date.now() - 1000) })
+    await insertConciliationRequest({ accountId: acc.id, externalId: 'third', createdAt: new Date() })
+
+    const rm = buildRm()
+    const page1 = await rm.list({ userId: user.id, limit: 2, offset: 0 })
+    expect(page1.map(i => i.externalId)).toEqual(['third', 'second'])
+
+    const page2 = await rm.list({ userId: user.id, limit: 2, offset: 2 })
+    expect(page2.map(i => i.externalId)).toEqual(['first'])
+  })
+
+  it('findDetailForUser returns request with attempts and primary match', async () => {
+    const user = await seedUser()
+    const acc = await seedAccount(user.id)
+    const req = await insertConciliationRequest({ accountId: acc.id })
+    const btx = await insertBankTransaction({ accountId: acc.id, amount: 123.45 })
+
+    const attemptId = crypto.randomUUID()
+    await getTestPool().query(
+      `INSERT INTO conciliation_attempts
+        (id, account_id, request_id, attempt_number, status, matched_candidates, selected_transaction_id)
+       VALUES ($1,$2,$3,1,'success',$4::jsonb,$5)`,
+      [attemptId, acc.id, req.id, JSON.stringify([btx.id]), btx.id]
+    )
+    const matchId = crypto.randomUUID()
+    await getTestPool().query(
+      `INSERT INTO conciliated_transactions
+        (id, account_id, request_id, bank_transaction_id, matched_by, is_primary, is_notified)
+       VALUES ($1,$2,$3,$4,'engine',true,false)`,
+      [matchId, acc.id, req.id, btx.id]
+    )
+
+    const detail = await buildRm().findDetailForUser(req.id, user.id)
+    expect(detail).not.toBeNull()
+    expect(detail!.id).toBe(req.id)
+    expect(detail!.attempts).toHaveLength(1)
+    expect(detail!.attempts[0].id).toBe(attemptId)
+    expect(detail!.attempts[0].candidateIds).toEqual([btx.id])
+    expect(detail!.attempts[0].selectedTransactionId).toBe(btx.id)
+    expect(detail!.match).not.toBeNull()
+    expect(detail!.match!.id).toBe(matchId)
+    expect(detail!.match!.bankTransactionId).toBe(btx.id)
+    expect(detail!.match!.amount).toBe(123.45)
+  })
+
+  it('findDetailForUser returns a detail with empty attempts and null match when none exist (LEFT JOIN)', async () => {
+    const user = await seedUser()
+    const acc = await seedAccount(user.id)
+    const req = await insertConciliationRequest({ accountId: acc.id })
+
+    const detail = await buildRm().findDetailForUser(req.id, user.id)
+    expect(detail).not.toBeNull()
+    expect(detail!.attempts).toEqual([])
+    expect(detail!.match).toBeNull()
+  })
+
+  it('findDetailForUser returns null when user does not own the request', async () => {
+    const owner = await seedUser()
+    const stranger = await seedUser()
+    const acc = await seedAccount(owner.id)
+    const req = await insertConciliationRequest({ accountId: acc.id })
+
+    const detail = await buildRm().findDetailForUser(req.id, stranger.id)
+    expect(detail).toBeNull()
+  })
+})

--- a/tests/integration/conciliation/ConciliationRequestRepository.integration.test.ts
+++ b/tests/integration/conciliation/ConciliationRequestRepository.integration.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser, seedAccount } from '../helpers/seed.js'
+import { executorFromPool } from '../../../src/contexts/conciliation/infrastructure/Executor.js'
+import { ConciliationRequestRepository } from '../../../src/contexts/conciliation/infrastructure/ConciliationRequestRepository.js'
+import { ConciliationRequest } from '../../../src/contexts/conciliation/domain/ConciliationRequest.js'
+import { insertConciliationRequest } from './helpers.js'
+
+describe('ConciliationRequestRepository (integration)', () => {
+  beforeEach(async () => { await truncateAll() })
+  afterAll(async () => { await closeTestPool() })
+
+  function buildRepo() {
+    return new ConciliationRequestRepository(executorFromPool(getTestPool()))
+  }
+
+  it('save + findById round trips an aggregate', async () => {
+    const user = await seedUser()
+    const acc = await seedAccount(user.id)
+    const repo = buildRepo()
+    const id = crypto.randomUUID()
+    const req = ConciliationRequest.create(id, {
+      accountId: acc.id, externalId: 'ext-1',
+      expectedAmount: 250.5, currency: 'USD', senderName: 'Alice',
+    })
+    await repo.save(req)
+
+    const found = await repo.findById(id)
+    expect(found).not.toBeNull()
+    expect(found!.accountId).toBe(acc.id)
+    expect(found!.externalId).toBe('ext-1')
+    expect(found!.expectedAmount).toBe(250.5)
+    expect(found!.currency).toBe('USD')
+    expect(found!.senderName).toBe('Alice')
+    expect(found!.status).toBe('pending')
+  })
+
+  it('findById returns null for unknown id', async () => {
+    const repo = buildRepo()
+    expect(await repo.findById(crypto.randomUUID())).toBeNull()
+  })
+
+  it('findByIdForUpdate runs without error (FOR UPDATE SKIP LOCKED)', async () => {
+    const user = await seedUser()
+    const acc = await seedAccount(user.id)
+    const seeded = await insertConciliationRequest({ accountId: acc.id })
+    const repo = buildRepo()
+    const found = await repo.findByIdForUpdate(seeded.id)
+    expect(found).not.toBeNull()
+    expect(found!.id).toBe(seeded.id)
+  })
+
+  it('findActiveExternalIds returns a Set excluding cancelled and expired', async () => {
+    const user = await seedUser()
+    const acc = await seedAccount(user.id)
+    await insertConciliationRequest({ accountId: acc.id, externalId: 'a-pending', status: 'pending' })
+    await insertConciliationRequest({ accountId: acc.id, externalId: 'a-matched', status: 'matched' })
+    await insertConciliationRequest({ accountId: acc.id, externalId: 'a-not-found', status: 'not_found' })
+    await insertConciliationRequest({ accountId: acc.id, externalId: 'a-cancelled', status: 'cancelled' })
+    await insertConciliationRequest({ accountId: acc.id, externalId: 'a-expired', status: 'expired' })
+
+    const result = await buildRepo().findActiveExternalIds(acc.id)
+    expect(result).toBeInstanceOf(Set)
+    expect(result.has('a-pending')).toBe(true)
+    expect(result.has('a-matched')).toBe(true)
+    expect(result.has('a-not-found')).toBe(true)
+    expect(result.has('a-cancelled')).toBe(false)
+    expect(result.has('a-expired')).toBe(false)
+  })
+
+  it('findPendingByAccount returns pending + not_found ordered by created_at', async () => {
+    const user = await seedUser()
+    const acc = await seedAccount(user.id)
+    const older = new Date(Date.now() - 60_000)
+    const newer = new Date()
+    await insertConciliationRequest({ accountId: acc.id, externalId: 'p1', status: 'pending', createdAt: newer })
+    await insertConciliationRequest({ accountId: acc.id, externalId: 'nf', status: 'not_found', createdAt: older })
+    await insertConciliationRequest({ accountId: acc.id, externalId: 'm', status: 'matched' })
+    await insertConciliationRequest({ accountId: acc.id, externalId: 'c', status: 'cancelled' })
+
+    const list = await buildRepo().findPendingByAccount(acc.id)
+    expect(list).toHaveLength(2)
+    expect(list[0].externalId).toBe('nf')
+    expect(list[1].externalId).toBe('p1')
+  })
+
+  it('findStale returns only requests older than cutoff', async () => {
+    const user = await seedUser()
+    const acc = await seedAccount(user.id)
+    const old = await insertConciliationRequest({
+      accountId: acc.id, externalId: 'old',
+      createdAt: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000),
+    })
+    await insertConciliationRequest({
+      accountId: acc.id, externalId: 'fresh',
+      createdAt: new Date(),
+    })
+
+    const cutoff = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000)
+    const stale = await buildRepo().findStale(cutoff)
+    expect(stale).toHaveLength(1)
+    expect(stale[0].id).toBe(old.id)
+    expect(stale[0].accountId).toBe(acc.id)
+  })
+
+  it('hasActiveRequests returns true with pending and false with all terminal', async () => {
+    const user = await seedUser()
+    const acc = await seedAccount(user.id)
+    const repo = buildRepo()
+    expect(await repo.hasActiveRequests(acc.id)).toBe(false)
+    await insertConciliationRequest({ accountId: acc.id, status: 'pending' })
+    expect(await repo.hasActiveRequests(acc.id)).toBe(true)
+  })
+
+  it('cancelMissing cancels rows whose external_id is not in the present list', async () => {
+    const user = await seedUser()
+    const acc = await seedAccount(user.id)
+    await insertConciliationRequest({ accountId: acc.id, externalId: 'keep-1', status: 'pending' })
+    await insertConciliationRequest({ accountId: acc.id, externalId: 'gone-1', status: 'pending' })
+    await insertConciliationRequest({ accountId: acc.id, externalId: 'gone-2', status: 'not_found' })
+    await insertConciliationRequest({ accountId: acc.id, externalId: 'terminal', status: 'matched' })
+
+    const cancelled = await buildRepo().cancelMissing(acc.id, ['keep-1'])
+    expect(cancelled).toBe(2)
+
+    const { rows } = await getTestPool().query(
+      `SELECT external_id, status FROM conciliation_requests WHERE account_id = $1 ORDER BY external_id`,
+      [acc.id]
+    )
+    const byExt: Record<string, string> = Object.fromEntries(rows.map((r: any) => [r.external_id, r.status]))
+    expect(byExt['keep-1']).toBe('pending')
+    expect(byExt['gone-1']).toBe('cancelled')
+    expect(byExt['gone-2']).toBe('cancelled')
+    expect(byExt['terminal']).toBe('matched')
+  })
+
+  it('withTx returns a new repo bound to the given executor', async () => {
+    const user = await seedUser()
+    const acc = await seedAccount(user.id)
+    const baseRepo = buildRepo()
+    const calls: string[] = []
+    const fakeTx = {
+      query: async (text: string, params?: any[]) => {
+        calls.push(text)
+        return getTestPool().query(text, params as any)
+      },
+    } as any
+
+    const txRepo = baseRepo.withTx(fakeTx)
+    expect(txRepo).not.toBe(baseRepo)
+    const seeded = await insertConciliationRequest({ accountId: acc.id })
+    const found = await txRepo.findById(seeded.id)
+    expect(found).not.toBeNull()
+    expect(calls.length).toBe(1)
+  })
+})

--- a/tests/integration/conciliation/helpers.ts
+++ b/tests/integration/conciliation/helpers.ts
@@ -1,0 +1,73 @@
+import crypto from 'crypto'
+import { getTestPool } from '../helpers/testDb.js'
+
+export interface SeededConciliationRequest {
+  id: string
+  accountId: string
+  externalId: string
+  expectedAmount: number
+  currency: string
+  senderName: string | null
+  status: string
+  createdAt: Date
+}
+
+export async function insertConciliationRequest(opts: {
+  accountId: string
+  externalId?: string
+  expectedAmount?: number
+  currency?: string
+  senderName?: string | null
+  status?: string
+  createdAt?: Date
+}): Promise<SeededConciliationRequest> {
+  const id = crypto.randomUUID()
+  const externalId = opts.externalId ?? `ext-${crypto.randomBytes(4).toString('hex')}`
+  const expectedAmount = opts.expectedAmount ?? 100
+  const currency = opts.currency ?? 'USD'
+  const senderName = opts.senderName === undefined ? 'Alice' : opts.senderName
+  const status = opts.status ?? 'pending'
+  const createdAt = opts.createdAt ?? new Date()
+
+  await getTestPool().query(
+    `INSERT INTO conciliation_requests
+       (id, account_id, external_id, expected_amount, currency, sender_name, status, retry_count, created_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,0,$8)`,
+    [id, opts.accountId, externalId, expectedAmount, currency, senderName, status, createdAt]
+  )
+  return { id, accountId: opts.accountId, externalId, expectedAmount, currency, senderName, status, createdAt }
+}
+
+export async function insertBankTransaction(opts: {
+  accountId: string
+  externalId?: string
+  amount?: number
+  currency?: string
+  senderName?: string | null
+  receivedAt?: Date
+  excluded?: boolean
+}): Promise<{ id: string; externalId: string }> {
+  const id = crypto.randomUUID()
+  const externalId = opts.externalId ?? `btx-${crypto.randomBytes(4).toString('hex')}`
+  const amount = opts.amount ?? 100
+  const currency = opts.currency ?? 'USD'
+  const senderName = opts.senderName === undefined ? 'Alice' : opts.senderName
+  const receivedAt = opts.receivedAt ?? new Date()
+
+  await getTestPool().query(
+    `INSERT INTO bank_transactions
+       (id, account_id, external_id, reference_hash, amount, currency, sender_name, received_at, ingested_at, raw_payload, excluded_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,now(),'{}',$9)`,
+    [id, opts.accountId, externalId, `hash-${externalId}`, amount, currency, senderName, receivedAt, opts.excluded ? new Date() : null]
+  )
+  return { id, externalId }
+}
+
+export async function insertAccountConfig(accountId: string, opts: { notifyOnExpired?: boolean } = {}): Promise<void> {
+  await getTestPool().query(
+    `INSERT INTO account_config
+       (account_id, pending_orders_endpoint, webhook_url, notify_on_expired)
+     VALUES ($1, 'http://example.com/pending', 'http://example.com/wh', $2)`,
+    [accountId, opts.notifyOnExpired ?? false]
+  )
+}

--- a/tests/integration/helpers/seed.ts
+++ b/tests/integration/helpers/seed.ts
@@ -1,0 +1,51 @@
+import bcrypt from 'bcrypt'
+import crypto from 'crypto'
+import { getTestPool } from './testDb.js'
+
+export interface SeededUser {
+  id: string
+  email: string
+  password: string
+}
+
+export interface SeededAccount {
+  id: string
+  userId: string
+  bankId: string
+  bank: string
+  name: string
+}
+
+export async function seedUser(overrides: { email?: string; password?: string; operationMode?: 'reconcile' | 'passthrough' | null } = {}): Promise<SeededUser> {
+  const email = overrides.email ?? `it-${crypto.randomBytes(4).toString('hex')}@test.com`
+  const password = overrides.password ?? 'secret123'
+  const passwordHash = await bcrypt.hash(password, 4)
+  const id = crypto.randomUUID()
+  await getTestPool().query(
+    `INSERT INTO users (id, email, password_hash, name, operation_mode, status, created_at)
+     VALUES ($1, $2, $3, $4, $5, 'active', now())`,
+    [id, email, passwordHash, 'Test User', overrides.operationMode ?? null]
+  )
+  return { id, email, password }
+}
+
+/**
+ * Returns the seeded mi-dinero bank. Migrations create it; this just looks it up.
+ */
+export async function getMiDineroBank(): Promise<{ id: string; code: string }> {
+  const { rows } = await getTestPool().query(`SELECT id, code FROM banks WHERE code = 'mi-dinero'`)
+  if (!rows[0]) throw new Error('mi-dinero bank not seeded — migrations missing?')
+  return { id: rows[0].id, code: rows[0].code }
+}
+
+export async function seedAccount(userId: string, opts: { name?: string; bankCode?: string } = {}): Promise<SeededAccount> {
+  const bank = await getMiDineroBank()
+  const id = crypto.randomUUID()
+  const name = opts.name ?? `acc-${crypto.randomBytes(3).toString('hex')}`
+  await getTestPool().query(
+    `INSERT INTO accounts (id, user_id, bank_id, bank, name, status, created_at)
+     VALUES ($1, $2, $3, $4, $5, 'active', now())`,
+    [id, userId, bank.id, bank.code, name]
+  )
+  return { id, userId, bankId: bank.id, bank: bank.code, name }
+}

--- a/tests/integration/helpers/testDb.ts
+++ b/tests/integration/helpers/testDb.ts
@@ -1,0 +1,82 @@
+import pg from 'pg'
+
+let pool: pg.Pool | null = null
+
+export function getTestPool(): pg.Pool {
+  if (!pool) {
+    pool = new pg.Pool({
+      connectionString: process.env.DATABASE_URL,
+      max: 5,
+    })
+  }
+  return pool
+}
+
+const ALL_DOMAIN_TABLES = [
+  'conciliated_transactions',
+  'conciliation_attempts',
+  'conciliation_requests',
+  'bank_transactions',
+  'bank_scrape_steps',
+  'bank_scrape_runs',
+  'bank_credentials',
+  'account_config',
+  'accounts',
+  'users',
+] as const
+
+export const CANONICAL_SCRIPT_ID = 'b2010000-0000-0000-0000-000000000001'
+export const CANONICAL_BANK_ID = 'a1000000-0000-0000-0000-000000000001'
+
+/**
+ * Resets the DB to a known-clean state with the canonical seeds restored:
+ * - All per-user/account/transaction tables are truncated.
+ * - `banks` keeps only the canonical mi-dinero row.
+ * - `bank_scripts` keeps only the canonical active mi-dinero/extract_transactions
+ *   row (re-activated and back-dated to 2020 so tests that delete by `created_at`
+ *   don't touch it).
+ *
+ * Call this in `beforeEach` of every integration test file so each test starts
+ * from the same fixture, regardless of what the previous test did.
+ */
+export async function truncateAll(): Promise<void> {
+  const p = getTestPool()
+  await p.query(`TRUNCATE ${ALL_DOMAIN_TABLES.join(', ')} RESTART IDENTITY CASCADE`)
+  // Drop any test-created bank_scripts (keep only the canonical seed).
+  await p.query(`DELETE FROM bank_scripts WHERE id <> $1`, [CANONICAL_SCRIPT_ID])
+  // Drop any test-created banks (keep only the canonical seed).
+  await p.query(`DELETE FROM banks WHERE id <> $1`, [CANONICAL_BANK_ID])
+  // Restore canonical bank.
+  await p.query(
+    `INSERT INTO banks (id, code, name, status, created_at)
+     VALUES ($1, 'mi-dinero', 'Mi Dinero', 'ready', '2020-01-01'::timestamptz)
+     ON CONFLICT (id) DO UPDATE SET
+       code   = 'mi-dinero',
+       name   = 'Mi Dinero',
+       status = 'ready'`,
+    [CANONICAL_BANK_ID]
+  )
+  // Restore canonical script (idempotent re-activation).
+  await p.query(
+    `INSERT INTO bank_scripts (id, bank, bank_id, flow_type, version, status, origin, selector_map, code_snapshot, created_at)
+     VALUES ($1, 'mi-dinero', $2, 'extract_transactions', '2.0.1', 'active', 'system', '{}'::jsonb, NULL, '2020-01-01'::timestamptz)
+     ON CONFLICT (id) DO UPDATE SET
+       status        = 'active',
+       bank          = 'mi-dinero',
+       flow_type     = 'extract_transactions',
+       version       = '2.0.1',
+       code_snapshot = NULL`,
+    [CANONICAL_SCRIPT_ID, CANONICAL_BANK_ID]
+  )
+}
+
+/**
+ * Cleans up the shared pool after the suite. Vitest needs this so the process
+ * can exit cleanly.
+ */
+export async function closeTestPool(): Promise<void> {
+  if (pool) {
+    await pool.end()
+    pool = null
+  }
+}

--- a/tests/integration/script-engine/BankScriptRepository.integration.test.ts
+++ b/tests/integration/script-engine/BankScriptRepository.integration.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { getMiDineroBank } from '../helpers/seed.js'
+import { BankScriptRepository } from '../../../src/contexts/script-engine/infrastructure/BankScriptRepository.js'
+import { executorFromPool } from '../../../src/contexts/script-engine/infrastructure/Executor.js'
+import { BankScript } from '../../../src/contexts/script-engine/domain/BankScript.js'
+
+/**
+ * Removes any bank_scripts rows added during a test. Keeps the seed rows
+ * created at migration time (their created_at is older than an hour).
+ */
+async function clearNonSeededScripts(): Promise<void> {
+  await getTestPool().query(
+    `DELETE FROM bank_scripts WHERE created_at > now() - interval '1 hour'`
+  )
+}
+
+/**
+ * Inserts a bank_scripts row with bank_id populated (the production repo
+ * does not write bank_id today — see BUG note in the test report).
+ */
+async function insertScriptRow(opts: {
+  id: string
+  bank?: string
+  flowType?: 'login' | 'extract_transactions' | 'verify_payment'
+  version?: string
+  status?: 'draft' | 'testing' | 'review' | 'active' | 'deprecated' | 'failed'
+  origin?: 'system' | 'ai' | 'user'
+  codeSnapshot?: string | null
+  selectorMap?: Record<string, unknown>
+  bankId: string
+}): Promise<void> {
+  await getTestPool().query(
+    `INSERT INTO bank_scripts
+       (id, bank, flow_type, version, status, origin, code_snapshot, selector_map, bank_id, created_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9, now())`,
+    [
+      opts.id,
+      opts.bank ?? 'mi-dinero',
+      opts.flowType ?? 'login',
+      opts.version ?? '99.0.0',
+      opts.status ?? 'review',
+      opts.origin ?? 'user',
+      opts.codeSnapshot ?? null,
+      JSON.stringify(opts.selectorMap ?? {}),
+      opts.bankId,
+    ]
+  )
+}
+
+describe('BankScriptRepository (integration)', () => {
+  let repo: BankScriptRepository
+  let bankId: string
+
+  beforeAll(async () => {
+    repo = new BankScriptRepository(executorFromPool(getTestPool()))
+    const bank = await getMiDineroBank()
+    bankId = bank.id
+  })
+
+  beforeEach(async () => {
+    await truncateAll()
+    await clearNonSeededScripts()
+  })
+
+  afterAll(async () => {
+    await clearNonSeededScripts()
+    await closeTestPool()
+  })
+
+  describe('findById', () => {
+    it('returns the aggregate for a seeded id', async () => {
+      const { rows } = await getTestPool().query(
+        `SELECT id FROM bank_scripts WHERE bank='mi-dinero' AND status='active' LIMIT 1`
+      )
+      expect(rows[0]).toBeTruthy()
+      const id: string = rows[0].id
+
+      const script = await repo.findById(id)
+      expect(script).not.toBeNull()
+      expect(script!.id).toBe(id)
+      expect(script!.bank).toBe('mi-dinero')
+      expect(script!.status).toBe('active')
+      expect(script!.flowType).toBe('extract_transactions')
+    })
+
+    it('returns null for an unknown UUID', async () => {
+      const script = await repo.findById(crypto.randomUUID())
+      expect(script).toBeNull()
+    })
+  })
+
+  describe('findActive', () => {
+    it('returns the active mi-dinero extract_transactions script', async () => {
+      const script = await repo.findActive('mi-dinero', 'extract_transactions')
+      expect(script).not.toBeNull()
+      expect(script!.bank).toBe('mi-dinero')
+      expect(script!.flowType).toBe('extract_transactions')
+      expect(script!.status).toBe('active')
+    })
+
+    it('returns null when no active script exists for the bank/flow', async () => {
+      const script = await repo.findActive('mi-dinero', 'login')
+      expect(script).toBeNull()
+    })
+  })
+
+  describe('findAll', () => {
+    it('lists all scripts (including the mi-dinero seeded ones)', async () => {
+      const list = await repo.findAll()
+      const miDinero = list.filter((s) => s.bank === 'mi-dinero')
+      expect(miDinero.length).toBeGreaterThanOrEqual(1)
+      const active = miDinero.find((s) => s.status === 'active')
+      expect(active).toBeTruthy()
+      expect(active!.flowType).toBe('extract_transactions')
+    })
+  })
+
+  describe('save', () => {
+    it('INSERT path persists a new script and resolves bank_id from the bank code', async () => {
+      const id = crypto.randomUUID()
+      const script = BankScript.create(id, {
+        bank: 'mi-dinero',
+        flowType: 'login',
+        version: '99.0.0',
+        status: 'review',
+        origin: 'user',
+        selectorMap: { foo: 'bar' },
+      })
+      await repo.save(script)
+
+      const { rows } = await getTestPool().query<{ bank_id: string; bank: string; status: string; selector_map: unknown }>(
+        `SELECT bank_id, bank, status, selector_map FROM bank_scripts WHERE id = $1`,
+        [id]
+      )
+      expect(rows[0].bank).toBe('mi-dinero')
+      expect(rows[0].bank_id).toBe(bankId)
+      expect(rows[0].status).toBe('review')
+    })
+
+    it('UPDATE path (ON CONFLICT id) updates status and code_snapshot', async () => {
+      const id = crypto.randomUUID()
+      await insertScriptRow({
+        id,
+        flowType: 'verify_payment',
+        version: '99.0.1',
+        status: 'review',
+        codeSnapshot: 'v1',
+        bankId,
+      })
+
+      const script = BankScript.reconstitute(id, {
+        bank: 'mi-dinero',
+        flowType: 'verify_payment',
+        version: '99.0.1',
+        status: 'review',
+        origin: 'user',
+        selectorMap: {},
+        codeSnapshot: 'v2-updated',
+        createdAt: new Date(),
+      })
+      script.promote() // review -> active
+
+      await repo.save(script)
+      const reloaded = await repo.findById(id)
+      expect(reloaded!.status).toBe('active')
+      expect(reloaded!.codeSnapshot).toBe('v2-updated')
+
+      // Idempotency: re-saving the same state is a no-op (still active, same snapshot)
+      await repo.save(script)
+      const reloaded2 = await repo.findById(id)
+      expect(reloaded2!.status).toBe('active')
+      expect(reloaded2!.codeSnapshot).toBe('v2-updated')
+      expect(reloaded2!.version).toBe('99.0.1')
+    })
+  })
+
+  describe('deprecateActive', () => {
+    it('flips the active script for (bank, flowType) to deprecated', async () => {
+      const id = crypto.randomUUID()
+      await insertScriptRow({
+        id,
+        flowType: 'verify_payment',
+        version: '50.0.0',
+        status: 'active',
+        origin: 'system',
+        bankId,
+      })
+
+      await repo.deprecateActive('mi-dinero', 'verify_payment')
+
+      const { rows } = await getTestPool().query(
+        `SELECT status FROM bank_scripts WHERE id = $1`,
+        [id]
+      )
+      expect(rows[0].status).toBe('deprecated')
+    })
+  })
+
+  describe('withTx', () => {
+    it('returns a new repository bound to the supplied executor', async () => {
+      const tx = executorFromPool(getTestPool())
+      const txRepo = repo.withTx(tx)
+      expect(txRepo).toBeInstanceOf(BankScriptRepository)
+      expect(txRepo).not.toBe(repo)
+
+      const list = await txRepo.findAll()
+      expect(list.length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/tests/integration/script-engine/PromoteScriptUseCase.integration.test.ts
+++ b/tests/integration/script-engine/PromoteScriptUseCase.integration.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { getMiDineroBank } from '../helpers/seed.js'
+import { BankScriptRepository } from '../../../src/contexts/script-engine/infrastructure/BankScriptRepository.js'
+import { executorFromPool } from '../../../src/contexts/script-engine/infrastructure/Executor.js'
+import { PromoteScriptUseCase } from '../../../src/contexts/script-engine/application/PromoteScriptUseCase.js'
+import { PgUnitOfWork } from '../../../src/shared/persistence/PgUnitOfWork.js'
+import { InMemoryEventBus } from '../../../src/shared/events/InMemoryEventBus.js'
+import { ConflictError, NotFoundError } from '../../../src/shared/errors/index.js'
+
+async function clearNonSeededScripts(): Promise<void> {
+  await getTestPool().query(
+    `DELETE FROM bank_scripts WHERE created_at > now() - interval '1 hour'`
+  )
+}
+
+async function insertReviewScript(opts: {
+  id: string
+  bankId: string
+  flowType?: 'login' | 'extract_transactions' | 'verify_payment'
+  version?: string
+  status?: 'review' | 'active' | 'deprecated'
+}): Promise<void> {
+  await getTestPool().query(
+    `INSERT INTO bank_scripts
+       (id, bank, flow_type, version, status, origin, selector_map, bank_id, created_at)
+     VALUES ($1, 'mi-dinero', $2, $3, $4, 'user', '{}', $5, now())`,
+    [opts.id, opts.flowType ?? 'extract_transactions', opts.version ?? '3.0.0', opts.status ?? 'review', opts.bankId]
+  )
+}
+
+describe('PromoteScriptUseCase (integration)', () => {
+  let repo: BankScriptRepository
+  let useCase: PromoteScriptUseCase
+  let bus: InMemoryEventBus
+  let bankId: string
+
+  beforeAll(async () => {
+    const pool = getTestPool()
+    repo = new BankScriptRepository(executorFromPool(pool))
+    bus = new InMemoryEventBus()
+    useCase = new PromoteScriptUseCase(repo, new PgUnitOfWork(pool), bus)
+    const bank = await getMiDineroBank()
+    bankId = bank.id
+  })
+
+  beforeEach(async () => {
+    await truncateAll()
+    await clearNonSeededScripts()
+  })
+
+  afterAll(async () => {
+    await clearNonSeededScripts()
+    await closeTestPool()
+  })
+
+  it('promotes a review script and deprecates the previously active one atomically', async () => {
+    const candidateId = crypto.randomUUID()
+    await insertReviewScript({ id: candidateId, bankId, version: '3.0.0', status: 'review' })
+
+    // Identify the seeded active script for mi-dinero/extract_transactions
+    const { rows: beforeRows } = await getTestPool().query(
+      `SELECT id FROM bank_scripts WHERE bank='mi-dinero' AND flow_type='extract_transactions' AND status='active'`
+    )
+    expect(beforeRows.length).toBe(1)
+    const previousActiveId = beforeRows[0].id
+
+    await useCase.execute({ scriptId: candidateId })
+
+    const { rows: candidateRow } = await getTestPool().query(
+      `SELECT status FROM bank_scripts WHERE id = $1`,
+      [candidateId]
+    )
+    expect(candidateRow[0].status).toBe('active')
+
+    const { rows: previousRow } = await getTestPool().query(
+      `SELECT status FROM bank_scripts WHERE id = $1`,
+      [previousActiveId]
+    )
+    expect(previousRow[0].status).toBe('deprecated')
+
+    // Invariant: exactly one active row for (mi-dinero, extract_transactions)
+    const { rows: activeRows } = await getTestPool().query(
+      `SELECT id FROM bank_scripts WHERE bank='mi-dinero' AND flow_type='extract_transactions' AND status='active'`
+    )
+    expect(activeRows.length).toBe(1)
+    expect(activeRows[0].id).toBe(candidateId)
+  })
+
+  it('publishes a ScriptPromoted event', async () => {
+    const candidateId = crypto.randomUUID()
+    await insertReviewScript({ id: candidateId, bankId, version: '3.0.1', status: 'review' })
+
+    const handler = vi.fn().mockResolvedValue(undefined)
+    bus.subscribe('ScriptPromoted', handler)
+
+    await useCase.execute({ scriptId: candidateId })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    const event = handler.mock.calls[0][0]
+    expect(event.eventType).toBe('ScriptPromoted')
+    expect(event.aggregateId).toBe(candidateId)
+    expect(event.bank).toBe('mi-dinero')
+    expect(event.flowType).toBe('extract_transactions')
+    expect(event.version).toBe('3.0.1')
+  })
+
+  it('throws ConflictError when the script is already active and leaves DB unchanged', async () => {
+    const { rows: beforeRows } = await getTestPool().query(
+      `SELECT id, status FROM bank_scripts WHERE bank='mi-dinero' AND status='active' LIMIT 1`
+    )
+    const activeId = beforeRows[0].id
+
+    await expect(useCase.execute({ scriptId: activeId })).rejects.toBeInstanceOf(ConflictError)
+
+    const { rows: afterRows } = await getTestPool().query(
+      `SELECT id, status FROM bank_scripts WHERE id = $1`,
+      [activeId]
+    )
+    expect(afterRows[0].status).toBe('active')
+
+    // Only one active row should still exist for that (bank, flow)
+    const { rows: activeRows } = await getTestPool().query(
+      `SELECT id FROM bank_scripts WHERE bank='mi-dinero' AND flow_type='extract_transactions' AND status='active'`
+    )
+    expect(activeRows.length).toBe(1)
+    expect(activeRows[0].id).toBe(activeId)
+  })
+
+  it('throws NotFoundError when the scriptId does not exist', async () => {
+    await expect(
+      useCase.execute({ scriptId: crypto.randomUUID() })
+    ).rejects.toBeInstanceOf(NotFoundError)
+  })
+})

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -1,0 +1,78 @@
+import 'dotenv/config'
+import { execSync } from 'child_process'
+import pg from 'pg'
+
+process.env.NODE_ENV = 'test'
+process.env.LOG_LEVEL = process.env.LOG_LEVEL ?? 'error'
+
+const baseUrl = process.env.DATABASE_URL_TEST
+  ?? process.env.DATABASE_URL?.replace(/\/[^/]+(\?.*)?$/, '/reconbanker_test$1')
+  ?? 'postgres://reconbanker:reconbanker@localhost:5432/reconbanker_test'
+
+const adminUrl = baseUrl.replace(/\/[^/]+(\?.*)?$/, '/postgres$1')
+const dbName = baseUrl.split('/').pop()!.split('?')[0]
+
+// Make DATABASE_URL point to the test DB for any module that reads it later.
+process.env.DATABASE_URL = baseUrl
+process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'integration-test-secret'
+process.env.REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6379'
+
+async function ensureDatabase(): Promise<void> {
+  const client = new pg.Client({ connectionString: adminUrl })
+  await client.connect()
+  try {
+    const { rows } = await client.query(`SELECT 1 FROM pg_database WHERE datname = $1`, [dbName])
+    if (rows.length === 0) {
+      await client.query(`CREATE DATABASE "${dbName}"`)
+    }
+  } finally {
+    await client.end()
+  }
+}
+
+async function runMigrations(): Promise<void> {
+  execSync('pnpm migrate', {
+    stdio: 'pipe',
+    env: { ...process.env, DATABASE_URL: baseUrl },
+  })
+}
+
+/**
+ * Some script-engine tests delete rows added during the test with
+ * `WHERE created_at > now() - interval '1 hour'`. In the test DB the seeded
+ * scripts are inserted by migrations that just ran, so their created_at is
+ * also recent — the cleanup would wipe them. Stamp the seeds in the past so
+ * the heuristic distinguishes seeds from test-created rows.
+ */
+/**
+ * Re-seeds the canonical mi-dinero bank + active script with stable fixed IDs.
+ * Idempotent. Stamped in the past so tests that delete by `created_at > now() - 1h`
+ * leave them untouched.
+ */
+async function ensureSeeds(): Promise<void> {
+  const client = new pg.Client({ connectionString: baseUrl })
+  await client.connect()
+  try {
+    await client.query(
+      `INSERT INTO banks (id, code, name, status, created_at)
+       VALUES ('a1000000-0000-0000-0000-000000000001', 'mi-dinero', 'Mi Dinero', 'ready', '2020-01-01'::timestamptz)
+       ON CONFLICT (code) DO NOTHING`
+    )
+    await client.query(
+      `INSERT INTO bank_scripts (id, bank, flow_type, version, status, origin, selector_map, bank_id, created_at)
+       SELECT 'b2010000-0000-0000-0000-000000000001', 'mi-dinero', 'extract_transactions', '2.0.1',
+              'active', 'system', '{}'::jsonb, b.id, '2020-01-01'::timestamptz
+         FROM banks b WHERE b.code = 'mi-dinero'
+       ON CONFLICT (id) DO NOTHING`
+    )
+    await client.query(`UPDATE banks SET created_at = '2020-01-01'::timestamptz WHERE created_at > '2020-01-02'::timestamptz`)
+    await client.query(`UPDATE bank_scripts SET created_at = '2020-01-01'::timestamptz WHERE created_at > '2020-01-02'::timestamptz`)
+  } finally {
+    await client.end()
+  }
+}
+
+// Global setup: create the test database (if missing) and run migrations once.
+await ensureDatabase()
+await runMigrations()
+await ensureSeeds()

--- a/tests/integration/user/ChangeOperationModeUseCase.integration.test.ts
+++ b/tests/integration/user/ChangeOperationModeUseCase.integration.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser, seedAccount } from '../helpers/seed.js'
+import { UserRepository } from '../../../src/contexts/user/infrastructure/UserRepository.js'
+import { executorFromPool } from '../../../src/contexts/user/infrastructure/Executor.js'
+import { UserDataCleanerAdapter } from '../../../src/contexts/user/infrastructure/adapters/UserDataCleanerAdapter.js'
+import { ChangeOperationModeUseCase } from '../../../src/contexts/user/application/ChangeOperationModeUseCase.js'
+import { PgUnitOfWork } from '../../../src/shared/persistence/PgUnitOfWork.js'
+import { InMemoryEventBus } from '../../../src/shared/events/InMemoryEventBus.js'
+import { NotFoundError } from '../../../src/shared/errors/index.js'
+import type { IUserDataCleaner } from '../../../src/contexts/user/domain/ports/IUserDataCleaner.js'
+import type { Tx } from '../../../src/shared/persistence/Tx.js'
+
+interface Seeded {
+  userId: string
+  accountId: string
+  txId: string
+  requestId: string
+  conciliatedId: string
+}
+
+/** Insert some bank_transactions, conciliation_requests, and conciliated_transactions for the account. */
+async function seedAccountData(userId: string, accountId: string): Promise<Seeded> {
+  const pool = getTestPool()
+  const txId = crypto.randomUUID()
+  const requestId = crypto.randomUUID()
+  const conciliatedId = crypto.randomUUID()
+
+  await pool.query(
+    `INSERT INTO bank_transactions
+       (id, account_id, external_id, reference_hash, amount, currency, received_at)
+     VALUES ($1, $2, 'ext-1', 'hash-1', 100.00, 'ARS', now())`,
+    [txId, accountId]
+  )
+  await pool.query(
+    `INSERT INTO conciliation_requests
+       (id, account_id, external_id, expected_amount, currency, status)
+     VALUES ($1, $2, 'ext-req-1', 100.00, 'ARS', 'pending')`,
+    [requestId, accountId]
+  )
+  await pool.query(
+    `INSERT INTO conciliated_transactions
+       (id, account_id, request_id, bank_transaction_id, matched_by)
+     VALUES ($1, $2, $3, $4, 'amount')`,
+    [conciliatedId, accountId, requestId, txId]
+  )
+
+  return { userId, accountId, txId, requestId, conciliatedId }
+}
+
+async function countDataFor(accountId: string): Promise<{ bt: number; cr: number; ct: number }> {
+  const pool = getTestPool()
+  const bt = await pool.query<{ n: number }>(
+    'SELECT COUNT(*)::int AS n FROM bank_transactions WHERE account_id = $1', [accountId]
+  )
+  const cr = await pool.query<{ n: number }>(
+    'SELECT COUNT(*)::int AS n FROM conciliation_requests WHERE account_id = $1', [accountId]
+  )
+  const ct = await pool.query<{ n: number }>(
+    'SELECT COUNT(*)::int AS n FROM conciliated_transactions WHERE account_id = $1', [accountId]
+  )
+  return { bt: bt.rows[0].n, cr: cr.rows[0].n, ct: ct.rows[0].n }
+}
+
+describe('ChangeOperationModeUseCase (integration)', () => {
+  beforeAll(async () => { await truncateAll() })
+  beforeEach(async () => { await truncateAll() })
+  afterAll(async () => { await closeTestPool() })
+
+  it('changes mode, wipes account data, and publishes OperationModeChanged', async () => {
+    const seededUser = await seedUser({ email: 'change-mode@test.com', operationMode: 'reconcile' })
+    const account = await seedAccount(seededUser.id)
+    const data = await seedAccountData(seededUser.id, account.id)
+
+    // Sanity: data is there before the use case runs
+    const before = await countDataFor(account.id)
+    expect(before).toEqual({ bt: 1, cr: 1, ct: 1 })
+    void data
+
+    const pool = getTestPool()
+    const repo = new UserRepository(executorFromPool(pool))
+    const uow = new PgUnitOfWork(pool)
+    const cleaner = new UserDataCleanerAdapter()
+    const eventBus = new InMemoryEventBus()
+
+    const received: Array<{ type: string; aggregateId: string; mode?: string }> = []
+    eventBus.subscribe('OperationModeChanged', async (event: any) => {
+      received.push({ type: event.eventType, aggregateId: event.aggregateId, mode: event.mode })
+    })
+
+    const useCase = new ChangeOperationModeUseCase(repo, uow, cleaner, eventBus)
+    const result = await useCase.execute({ userId: seededUser.id, mode: 'passthrough' })
+
+    expect(result.mode).toBe('passthrough')
+
+    // User mode updated in DB
+    const mode = await repo.getOperationMode(seededUser.id)
+    expect(mode).toBe('passthrough')
+
+    // Account-scoped data was wiped
+    const after = await countDataFor(account.id)
+    expect(after).toEqual({ bt: 0, cr: 0, ct: 0 })
+
+    // Event was published
+    expect(received).toHaveLength(1)
+    expect(received[0]).toEqual({
+      type: 'OperationModeChanged',
+      aggregateId: seededUser.id,
+      mode: 'passthrough',
+    })
+  })
+
+  it('throws NotFoundError when user does not exist', async () => {
+    const pool = getTestPool()
+    const repo = new UserRepository(executorFromPool(pool))
+    const uow = new PgUnitOfWork(pool)
+    const cleaner = new UserDataCleanerAdapter()
+    const eventBus = new InMemoryEventBus()
+    const useCase = new ChangeOperationModeUseCase(repo, uow, cleaner, eventBus)
+
+    await expect(
+      useCase.execute({ userId: crypto.randomUUID(), mode: 'passthrough' })
+    ).rejects.toBeInstanceOf(NotFoundError)
+  })
+
+  it('rolls back mode change AND restores wipe if the cleaner fails mid-UoW', async () => {
+    const seededUser = await seedUser({ email: 'rollback@test.com', operationMode: 'reconcile' })
+    const account = await seedAccount(seededUser.id)
+    await seedAccountData(seededUser.id, account.id)
+
+    const pool = getTestPool()
+    const repo = new UserRepository(executorFromPool(pool))
+    const uow = new PgUnitOfWork(pool)
+    const eventBus = new InMemoryEventBus()
+
+    // Cleaner that deletes user-scoped rows (in the right FK order) inside the
+    // tx and then throws. If UoW rolls back correctly, those DELETEs are undone too.
+    const failingCleaner: IUserDataCleaner = {
+      async wipeForUser(tx: Tx, userId: string): Promise<void> {
+        const scope = `account_id IN (SELECT id FROM accounts WHERE user_id = $1)`
+        await tx.query(`DELETE FROM conciliated_transactions WHERE ${scope}`, [userId])
+        await tx.query(`DELETE FROM conciliation_attempts WHERE ${scope}`, [userId])
+        await tx.query(`DELETE FROM conciliation_requests WHERE ${scope}`, [userId])
+        await tx.query(`DELETE FROM bank_transactions WHERE ${scope}`, [userId])
+        throw new Error('cleaner exploded')
+      },
+    }
+
+    const received: any[] = []
+    eventBus.subscribe('OperationModeChanged', async (e) => { received.push(e) })
+
+    const useCase = new ChangeOperationModeUseCase(repo, uow, failingCleaner, eventBus)
+    await expect(
+      useCase.execute({ userId: seededUser.id, mode: 'passthrough' })
+    ).rejects.toThrow('cleaner exploded')
+
+    // Mode change must NOT have persisted (rollback)
+    const mode = await repo.getOperationMode(seededUser.id)
+    expect(mode).toBe('reconcile')
+
+    // The delete inside the tx must also have been rolled back
+    const after = await countDataFor(account.id)
+    expect(after.bt).toBe(1)
+
+    // No event published — execute threw before publishAll
+    expect(received).toHaveLength(0)
+  })
+})

--- a/tests/integration/user/LoginUseCase.integration.test.ts
+++ b/tests/integration/user/LoginUseCase.integration.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
+import jwt from 'jsonwebtoken'
+import { truncateAll, closeTestPool, getTestPool } from '../helpers/testDb.js'
+import { seedUser } from '../helpers/seed.js'
+import { UserRepository } from '../../../src/contexts/user/infrastructure/UserRepository.js'
+import { executorFromPool } from '../../../src/contexts/user/infrastructure/Executor.js'
+import { BcryptPasswordHasher } from '../../../src/contexts/user/infrastructure/adapters/BcryptPasswordHasher.js'
+import { JwtTokenIssuer } from '../../../src/contexts/user/infrastructure/adapters/JwtTokenIssuer.js'
+import { LoginUseCase } from '../../../src/contexts/user/application/LoginUseCase.js'
+import { UnauthorizedError } from '../../../src/shared/errors/index.js'
+
+const SECRET = 'test-secret'
+
+function makeUseCase(): LoginUseCase {
+  const repo = new UserRepository(executorFromPool(getTestPool()))
+  const hasher = new BcryptPasswordHasher(4)
+  const tokenIssuer = new JwtTokenIssuer(SECRET)
+  return new LoginUseCase(repo, hasher, tokenIssuer)
+}
+
+describe('LoginUseCase (integration)', () => {
+  beforeAll(async () => { await truncateAll() })
+  beforeEach(async () => { await truncateAll() })
+  afterAll(async () => { await closeTestPool() })
+
+  it('logs in with correct credentials and returns a valid JWT', async () => {
+    const user = await seedUser({ email: 'login@test.com', password: 'secret-pw' })
+    const useCase = makeUseCase()
+
+    const result = await useCase.execute({ email: 'login@test.com', password: 'secret-pw' })
+
+    expect(result.user.id).toBe(user.id)
+    expect(result.user.email).toBe('login@test.com')
+    expect(typeof result.token).toBe('string')
+    expect(result.token.split('.').length).toBe(3) // header.payload.signature
+
+    const decoded = jwt.verify(result.token, SECRET) as jwt.JwtPayload
+    expect(decoded.sub).toBe(user.id)
+    expect(decoded.email).toBe('login@test.com')
+  })
+
+  it('rejects wrong password with UnauthorizedError', async () => {
+    await seedUser({ email: 'wrong-pw@test.com', password: 'right-pw' })
+    const useCase = makeUseCase()
+
+    await expect(
+      useCase.execute({ email: 'wrong-pw@test.com', password: 'wrong-pw' })
+    ).rejects.toBeInstanceOf(UnauthorizedError)
+  })
+
+  it('rejects unknown email with UnauthorizedError', async () => {
+    const useCase = makeUseCase()
+    await expect(
+      useCase.execute({ email: 'nobody@test.com', password: 'whatever' })
+    ).rejects.toBeInstanceOf(UnauthorizedError)
+  })
+
+  it('normalizes email casing on login', async () => {
+    await seedUser({ email: 'casing-login@test.com', password: 'pw' })
+    const useCase = makeUseCase()
+    const result = await useCase.execute({ email: 'CASING-LOGIN@TEST.COM', password: 'pw' })
+    expect(result.user.email).toBe('casing-login@test.com')
+  })
+})

--- a/tests/integration/user/RegisterUserUseCase.integration.test.ts
+++ b/tests/integration/user/RegisterUserUseCase.integration.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
+import bcrypt from 'bcrypt'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { UserRepository } from '../../../src/contexts/user/infrastructure/UserRepository.js'
+import { executorFromPool } from '../../../src/contexts/user/infrastructure/Executor.js'
+import { BcryptPasswordHasher } from '../../../src/contexts/user/infrastructure/adapters/BcryptPasswordHasher.js'
+import { RegisterUserUseCase } from '../../../src/contexts/user/application/RegisterUserUseCase.js'
+import { ConflictError } from '../../../src/shared/errors/index.js'
+
+function makeUseCase(): { useCase: RegisterUserUseCase; repo: UserRepository } {
+  const repo = new UserRepository(executorFromPool(getTestPool()))
+  const hasher = new BcryptPasswordHasher(4)
+  const useCase = new RegisterUserUseCase(repo, hasher)
+  return { useCase, repo }
+}
+
+describe('RegisterUserUseCase (integration)', () => {
+  beforeAll(async () => { await truncateAll() })
+  beforeEach(async () => { await truncateAll() })
+  afterAll(async () => { await closeTestPool() })
+
+  it('registers a user with a bcrypt-hashed password', async () => {
+    const { useCase, repo } = makeUseCase()
+    const result = await useCase.execute({ email: 'reg@test.com', password: 'plain', name: 'Reg' })
+
+    expect(result.id).toMatch(/^[0-9a-f-]{36}$/i)
+    expect(result.email).toBe('reg@test.com')
+
+    const stored = await repo.findById(result.id)
+    expect(stored).not.toBeNull()
+    expect(stored!.passwordHash).not.toBe('plain')
+    expect(stored!.passwordHash.length).toBeGreaterThan(20)
+    // Verify the stored hash actually matches the plaintext via bcrypt
+    expect(await bcrypt.compare('plain', stored!.passwordHash)).toBe(true)
+  })
+
+  it('rejects duplicate emails with ConflictError', async () => {
+    const { useCase } = makeUseCase()
+    await useCase.execute({ email: 'dupe@test.com', password: 'pw1' })
+    await expect(
+      useCase.execute({ email: 'dupe@test.com', password: 'pw2' })
+    ).rejects.toBeInstanceOf(ConflictError)
+  })
+
+  it('after register, findByEmail finds the user', async () => {
+    const { useCase, repo } = makeUseCase()
+    await useCase.execute({ email: 'found@test.com', password: 'pw' })
+    const found = await repo.findByEmail('found@test.com')
+    expect(found).not.toBeNull()
+    expect(found!.email).toBe('found@test.com')
+  })
+
+  it('treats different-case email as duplicate (because normalized)', async () => {
+    const { useCase } = makeUseCase()
+    await useCase.execute({ email: 'casing@test.com', password: 'pw1' })
+    await expect(
+      useCase.execute({ email: 'CASING@TEST.COM', password: 'pw2' })
+    ).rejects.toBeInstanceOf(ConflictError)
+  })
+})

--- a/tests/integration/user/UserRepository.integration.test.ts
+++ b/tests/integration/user/UserRepository.integration.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser } from '../helpers/seed.js'
+import { UserRepository } from '../../../src/contexts/user/infrastructure/UserRepository.js'
+import { executorFromPool } from '../../../src/contexts/user/infrastructure/Executor.js'
+import { User } from '../../../src/contexts/user/domain/User.js'
+import { txFromClient } from '../../../src/shared/persistence/Tx.js'
+
+function makeRepo(): UserRepository {
+  return new UserRepository(executorFromPool(getTestPool()))
+}
+
+describe('UserRepository (integration)', () => {
+  beforeAll(async () => { await truncateAll() })
+  beforeEach(async () => { await truncateAll() })
+  afterAll(async () => { await closeTestPool() })
+
+  describe('findById', () => {
+    it('returns user when it exists', async () => {
+      const seeded = await seedUser({ email: 'find-by-id@test.com' })
+      const repo = makeRepo()
+      const user = await repo.findById(seeded.id)
+      expect(user).not.toBeNull()
+      expect(user!.id).toBe(seeded.id)
+      expect(user!.email).toBe('find-by-id@test.com')
+    })
+
+    it('returns null when id does not exist', async () => {
+      const repo = makeRepo()
+      const user = await repo.findById(crypto.randomUUID())
+      expect(user).toBeNull()
+    })
+  })
+
+  describe('findByEmail', () => {
+    it('returns user when email exists', async () => {
+      await seedUser({ email: 'find-by-email@test.com' })
+      const repo = makeRepo()
+      const user = await repo.findByEmail('find-by-email@test.com')
+      expect(user).not.toBeNull()
+      expect(user!.email).toBe('find-by-email@test.com')
+    })
+
+    it('returns null when email does not exist', async () => {
+      const repo = makeRepo()
+      const user = await repo.findByEmail('nope@test.com')
+      expect(user).toBeNull()
+    })
+
+    it('normalizes the email by lowercasing it', async () => {
+      await seedUser({ email: 'mixedcase@test.com' })
+      const repo = makeRepo()
+      const user = await repo.findByEmail('MIXEDCASE@TEST.COM')
+      expect(user).not.toBeNull()
+      expect(user!.email).toBe('mixedcase@test.com')
+    })
+
+    it('ignores users with status=inactive', async () => {
+      const seeded = await seedUser({ email: 'inactive@test.com' })
+      await getTestPool().query(`UPDATE users SET status = 'inactive' WHERE id = $1`, [seeded.id])
+      const repo = makeRepo()
+      const user = await repo.findByEmail('inactive@test.com')
+      expect(user).toBeNull()
+    })
+  })
+
+  describe('save', () => {
+    it('creates a new user', async () => {
+      const repo = makeRepo()
+      const user = User.create(crypto.randomUUID(), 'new@test.com', 'hash-here', 'New User')
+      await repo.save(user)
+
+      const found = await repo.findById(user.id)
+      expect(found).not.toBeNull()
+      expect(found!.email).toBe('new@test.com')
+      expect(found!.passwordHash).toBe('hash-here')
+      expect(found!.name).toBe('New User')
+    })
+
+    it('updates on conflict (idempotency via ON CONFLICT)', async () => {
+      const repo = makeRepo()
+      const id = crypto.randomUUID()
+      const user = User.create(id, 'original@test.com', 'hash1')
+      await repo.save(user)
+
+      // Reconstitute with mutated fields
+      const updated = User.reconstitute(id, {
+        email: 'updated@test.com',
+        name: 'Updated Name',
+        passwordHash: 'hash2',
+        operationMode: 'reconcile',
+        status: 'active',
+        createdAt: user.createdAt,
+      })
+      await repo.save(updated)
+
+      const found = await repo.findById(id)
+      expect(found!.email).toBe('updated@test.com')
+      expect(found!.name).toBe('Updated Name')
+      expect(found!.passwordHash).toBe('hash2')
+      expect(found!.operationMode).toBe('reconcile')
+
+      // Still only one row
+      const { rows } = await getTestPool().query<{ n: number }>(
+        'SELECT COUNT(*)::int AS n FROM users WHERE id = $1', [id]
+      )
+      expect(rows[0].n).toBe(1)
+    })
+  })
+
+  describe('getOperationMode / setOperationMode', () => {
+    it('returns null when user has no operation mode yet', async () => {
+      const seeded = await seedUser({ email: 'no-mode@test.com' })
+      const repo = makeRepo()
+      const mode = await repo.getOperationMode(seeded.id)
+      expect(mode).toBeNull()
+    })
+
+    it('persists the operation mode and reads it back', async () => {
+      const seeded = await seedUser({ email: 'mode@test.com' })
+      const repo = makeRepo()
+      await repo.setOperationMode(seeded.id, 'passthrough')
+      const mode = await repo.getOperationMode(seeded.id)
+      expect(mode).toBe('passthrough')
+    })
+
+    it('returns null when user does not exist', async () => {
+      const repo = makeRepo()
+      const mode = await repo.getOperationMode(crypto.randomUUID())
+      expect(mode).toBeNull()
+    })
+  })
+
+  describe('withTx', () => {
+    it('uses the transactional executor — ROLLBACK does not persist', async () => {
+      const id = crypto.randomUUID()
+      const pool = getTestPool()
+      const client = await pool.connect()
+      try {
+        await client.query('BEGIN')
+        const tx = txFromClient(client)
+        const baseRepo = makeRepo()
+        const txRepo = baseRepo.withTx(tx)
+
+        const user = User.create(id, 'tx@test.com', 'hash')
+        await txRepo.save(user)
+
+        // Visible inside the tx
+        const inside = await txRepo.findById(id)
+        expect(inside).not.toBeNull()
+
+        // Not visible outside the tx (pool repo) before commit
+        const outside = await baseRepo.findById(id)
+        expect(outside).toBeNull()
+
+        await client.query('ROLLBACK')
+      } finally {
+        client.release()
+      }
+
+      // Confirm nothing was persisted
+      const repo = makeRepo()
+      const after = await repo.findById(id)
+      expect(after).toBeNull()
+    })
+
+    it('commits within the tx are visible afterwards', async () => {
+      const id = crypto.randomUUID()
+      const pool = getTestPool()
+      const client = await pool.connect()
+      try {
+        await client.query('BEGIN')
+        const tx = txFromClient(client)
+        const txRepo = makeRepo().withTx(tx)
+        const user = User.create(id, 'tx-commit@test.com', 'hash')
+        await txRepo.save(user)
+        await client.query('COMMIT')
+      } finally {
+        client.release()
+      }
+      const found = await makeRepo().findById(id)
+      expect(found).not.toBeNull()
+      expect(found!.email).toBe('tx-commit@test.com')
+    })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     include: ['src/**/*.test.ts', 'tests/**/*.test.ts'],
-    exclude: ['**/node_modules/**', '**/dist/**', 'client/**'],
+    exclude: ['**/node_modules/**', '**/dist/**', 'client/**', 'tests/integration/**'],
     environment: 'node',
     globals: false,
     setupFiles: ['tests/setup.ts'],

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['tests/integration/**/*.integration.test.ts'],
+    exclude: ['**/node_modules/**', '**/dist/**', 'client/**'],
+    environment: 'node',
+    globals: false,
+    setupFiles: ['tests/integration/setup.ts'],
+    // Integration tests share a single Postgres database — run them serially
+    // so truncations from one suite don't race against another.
+    fileParallelism: false,
+    testTimeout: 15_000,
+    hookTimeout: 60_000,
+  },
+})


### PR DESCRIPTION
This pull request introduces significant improvements to integration testing for the account and banking infrastructure, as well as some adjustments to conciliation status terminology and a database schema update. The main changes include the addition of comprehensive integration tests for key repositories, a new script for running integration tests, and updates to status values and database fields to ensure consistency and correctness.

**Integration Test Suite Additions:**

* Added new integration test files for `AccountRepository`, `AccountConfigRepository`, `BankCredentialsRepository`, and `BankRepository`, covering all major CRUD operations, upsert logic, and transactional behavior. These tests ensure the correctness and reliability of repository implementations against a real database. [[1]](diffhunk://#diff-1aebaccab66b1628847bd6796a68b748388c9633430258bea2168db10810e3f0R1-R156) [[2]](diffhunk://#diff-02e9855b03121fe2c46ba910cdaef81270f3d249bc8c0c65404c86561a28825cR1-R125) [[3]](diffhunk://#diff-f27ba8bd28a49f93e4440a4b43078d9955fb64773da67e8b6256e792be32bce1R1-R126) [[4]](diffhunk://#diff-52b6a32e58f532443ebce7e75069117d40dbe73d3ed3f0542cf9c9f8628764e1R1-R92)
* Introduced a smoke test (`_smoke.integration.test.ts`) to verify test database connectivity, seeding, and truncation logic between tests.

**Testing Infrastructure Enhancements:**

* Added a `test:integration` script to `package.json` for running integration tests with a dedicated configuration.

**Conciliation Status Updates:**

* Changed the conciliation attempt status from `'not_found'` to `'no_match'` in the domain interface, use case logic, and corresponding test assertions, standardizing terminology. [[1]](diffhunk://#diff-38b0921c26c7132536a79bad4bfd6edfc69ef4822bb52081dd59c8abb5befebaL6-R6) [[2]](diffhunk://#diff-f7dba4677727bc1c1963b9cbaf14cb7333fd2789b731c4bd0f5170b402d9a8e8L80-R80) [[3]](diffhunk://#diff-ce625ec4d07b5f41b4c53eacaacb93c4c3569cc4c9eec1e94a42fdbe1f36df42L69-R69)

**Database Schema and Repository Update:**

* Updated the `BankScriptRepository` to set the `bank_id` field based on the bank code lookup, improving referential integrity in the `bank_scripts` table.