### PR TITLE
Add migration and persistence for account session settings

### DIFF
--- a/src/api/routes/accounts.routes.ts
+++ b/src/api/routes/accounts.routes.ts
@@ -34,6 +34,8 @@ const upsertConfigSchema = z.object({
   notify_on_expired: z.boolean().optional(),
   webhook_extra_fields: z.union([z.record(z.string(), z.unknown()), z.string(), z.null()]).optional(),
   silent_ingestion: z.boolean().optional(),
+  session_type: z.enum(['one-shot', 'persistent']).optional(),
+  login_mode: z.enum(['simple', 'assisted']).optional(),
 })
 
 const RESERVED_WEBHOOK_KEYS = ['external_id', 'status', 'amount', 'currency', 'name', 'id', 'received_at']
@@ -89,6 +91,8 @@ function toJson(config: AccountConfigDto) {
     notify_on_expired: config.notifyOnExpired,
     webhook_extra_fields: config.webhookExtraFields,
     silent_ingestion: config.silentIngestion,
+    session_type: config.sessionType,
+    login_mode: config.loginMode,
     bank_username: config.bankUsername,
   }
 }
@@ -159,6 +163,8 @@ export function buildAccountsRouter(account: AccountModule): Router {
       notifyOnExpired: body.notify_on_expired ?? false,
       webhookExtraFields: parseExtraFields(body.webhook_extra_fields),
       silentIngestion: body.silent_ingestion ?? false,
+      sessionType: body.session_type ?? 'one-shot',
+      loginMode: body.login_mode ?? 'simple',
       bankUsername: body.bank_username ?? null,
       bankPassword: body.bank_password ?? null,
     })

--- a/src/composition/bankingModule.ts
+++ b/src/composition/bankingModule.ts
@@ -44,7 +44,7 @@ export function buildBankingModule(container: ContainerBase): BankingModule {
   const configRepo = container.account.accountConfigRepository
   const userRepo = container.user.userRepository
 
-  const accountReader = new AccountForBankingReaderAdapter(accountRepo)
+  const accountReader = new AccountForBankingReaderAdapter(accountRepo, configRepo)
   const configReader = new NotificationConfigReaderAdapter(configRepo)
   const userModeReader = new UserOperationModeReaderAdapter(userRepo)
   const scriptEngine = new ScriptEngineAdapter()

--- a/src/contexts/account/application/UpsertAccountConfigUseCase.test.ts
+++ b/src/contexts/account/application/UpsertAccountConfigUseCase.test.ts
@@ -37,6 +37,8 @@ const baseInput = {
   notifyOnExpired: false,
   webhookExtraFields: null,
   silentIngestion: false,
+  sessionType: 'one-shot' as const,
+  loginMode: 'simple' as const,
   bankUsername: null,
   bankPassword: null,
 }

--- a/src/contexts/account/application/UpsertAccountConfigUseCase.ts
+++ b/src/contexts/account/application/UpsertAccountConfigUseCase.ts
@@ -45,6 +45,8 @@ export class UpsertAccountConfigUseCase {
       notifyOnExpired: input.notifyOnExpired,
       webhookExtraFields: input.webhookExtraFields,
       silentIngestion: input.silentIngestion,
+      sessionType: input.sessionType,
+      loginMode: input.loginMode,
     })
 
     if (input.bankUsername && input.bankPassword) {

--- a/src/contexts/account/application/dto/AccountConfigDto.ts
+++ b/src/contexts/account/application/dto/AccountConfigDto.ts
@@ -1,4 +1,4 @@
-import type { AccountConfig, AuthType, PollingMethod } from '../../domain/AccountConfig.js'
+import type { AccountConfig, AuthType, PollingMethod, SessionType, LoginMode } from '../../domain/AccountConfig.js'
 
 export interface AccountConfigDto extends AccountConfig {
   bankUsername: string | null
@@ -19,6 +19,8 @@ export interface UpsertAccountConfigInput {
   notifyOnExpired: boolean
   webhookExtraFields: Record<string, unknown> | null
   silentIngestion: boolean
+  sessionType: SessionType
+  loginMode: LoginMode
   bankUsername: string | null
   bankPassword: string | null
 }

--- a/src/contexts/account/domain/AccountConfig.ts
+++ b/src/contexts/account/domain/AccountConfig.ts
@@ -1,5 +1,7 @@
 export type AuthType = 'bearer' | 'api_key'
 export type PollingMethod = 'GET' | 'POST'
+export type SessionType = 'one-shot' | 'persistent'
+export type LoginMode = 'simple' | 'assisted'
 
 export interface AccountConfig {
   id: string
@@ -16,6 +18,8 @@ export interface AccountConfig {
   notifyOnExpired: boolean
   webhookExtraFields: Record<string, unknown> | null
   silentIngestion: boolean
+  sessionType: SessionType
+  loginMode: LoginMode
 }
 
 export interface AccountConfigInput {
@@ -32,4 +36,6 @@ export interface AccountConfigInput {
   notifyOnExpired: boolean
   webhookExtraFields: Record<string, unknown> | null
   silentIngestion: boolean
+  sessionType: SessionType
+  loginMode: LoginMode
 }

--- a/src/contexts/account/infrastructure/AccountConfigRepository.ts
+++ b/src/contexts/account/infrastructure/AccountConfigRepository.ts
@@ -23,8 +23,9 @@ export class AccountConfigRepository implements IAccountConfigRepository {
       `INSERT INTO account_config
          (id, account_id, pending_orders_endpoint, webhook_url,
           retry_limit, polling_method, polling_body, auth_type, auth_token,
-          webhook_auth_type, webhook_auth_token, notify_on_expired, webhook_extra_fields, silent_ingestion)
-       VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+          webhook_auth_type, webhook_auth_token, notify_on_expired, webhook_extra_fields, silent_ingestion,
+          session_type, login_mode)
+       VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
        ON CONFLICT (account_id) DO UPDATE SET
          pending_orders_endpoint = $2,
          webhook_url             = $3,
@@ -38,6 +39,8 @@ export class AccountConfigRepository implements IAccountConfigRepository {
          notify_on_expired       = $11,
          webhook_extra_fields    = $12,
          silent_ingestion        = $13,
+         session_type            = $14,
+         login_mode              = $15,
          updated_at              = now()
        RETURNING *`,
       [
@@ -54,6 +57,8 @@ export class AccountConfigRepository implements IAccountConfigRepository {
         input.notifyOnExpired,
         input.webhookExtraFields,
         input.silentIngestion,
+        input.sessionType,
+        input.loginMode,
       ]
     )
     return AccountConfigRowMapper.toDto(rows[0])

--- a/src/contexts/account/infrastructure/mappers/AccountConfigRowMapper.ts
+++ b/src/contexts/account/infrastructure/mappers/AccountConfigRowMapper.ts
@@ -1,4 +1,4 @@
-import { AccountConfig, AuthType, PollingMethod } from '../../domain/AccountConfig.js'
+import { AccountConfig, AuthType, PollingMethod, SessionType, LoginMode } from '../../domain/AccountConfig.js'
 
 export interface AccountConfigRow {
   id: string
@@ -15,6 +15,8 @@ export interface AccountConfigRow {
   notify_on_expired: boolean
   webhook_extra_fields: Record<string, unknown> | null
   silent_ingestion: boolean | null
+  session_type: SessionType
+  login_mode: LoginMode
 }
 
 export const AccountConfigRowMapper = {
@@ -34,6 +36,8 @@ export const AccountConfigRowMapper = {
       notifyOnExpired: row.notify_on_expired,
       webhookExtraFields: row.webhook_extra_fields,
       silentIngestion: row.silent_ingestion ?? false,
+      sessionType: row.session_type,
+      loginMode: row.login_mode,
     }
   },
 }

--- a/src/contexts/banking/application/NotifyBankMovementUseCase.test.ts
+++ b/src/contexts/banking/application/NotifyBankMovementUseCase.test.ts
@@ -22,7 +22,7 @@ function buildSut(opts: {
   const sendWebhookFn = vi.fn().mockResolvedValue(undefined)
   const useCase = new NotifyBankMovementUseCase({
     bankTxRepo,
-    accountReader: { findById: async () => ({ id: 'acc-1', userId: 'user-1', bank: 'b' }) },
+    accountReader: { findById: async () => ({ id: 'acc-1', userId: 'user-1', bank: 'b', sessionType: 'one-shot', loginMode: 'simple' }) },
     configReader: {
       findByAccountId: async () => ({
         accountId: 'acc-1',
@@ -73,7 +73,7 @@ describe('NotifyBankMovementUseCase', () => {
     const sendWebhookFn = vi.fn().mockRejectedValue(new Error('5xx'))
     const useCase = new NotifyBankMovementUseCase({
       bankTxRepo,
-      accountReader: { findById: async () => ({ id: 'acc-1', userId: 'user-1', bank: 'b' }) },
+      accountReader: { findById: async () => ({ id: 'acc-1', userId: 'user-1', bank: 'b', sessionType: 'one-shot', loginMode: 'simple' }) },
       configReader: {
         findByAccountId: async () => ({
           accountId: 'acc-1', webhookUrl: 'https://hook',

--- a/src/contexts/banking/application/RunBankScrapeUseCase.test.ts
+++ b/src/contexts/banking/application/RunBankScrapeUseCase.test.ts
@@ -18,7 +18,7 @@ function buildSut(transactions: ScrapedTransaction[], opts: { hasScript?: boolea
   }
   const accountReader = {
     findById: async (accountId: string) =>
-      opts.hasAccount === false ? null : { id: accountId, userId: 'user-1', bank: 'test-bank' },
+      opts.hasAccount === false ? null : { id: accountId, userId: 'user-1', bank: 'test-bank', sessionType: 'one-shot' as const, loginMode: 'simple' as const },
   }
   const useCase = new RunBankScrapeUseCase({
     accountReader, txRepo, scrapeRunRepo, scriptEngine, eventBus,
@@ -63,7 +63,7 @@ describe('RunBankScrapeUseCase', () => {
     const failHandler = vi.fn().mockResolvedValue(undefined)
     eventBus.subscribe('ScrapeRunFailed', failHandler)
     const useCase = new RunBankScrapeUseCase({
-      accountReader: { findById: async () => ({ id: 'acc-1', userId: 'user-1', bank: 'b' }) },
+      accountReader: { findById: async () => ({ id: 'acc-1', userId: 'user-1', bank: 'b', sessionType: 'one-shot', loginMode: 'simple' }) },
       txRepo, scrapeRunRepo,
       scriptEngine: {
         loadActiveScript: async () => ({ id: 'script-1', codeSnapshot: '' }),

--- a/src/contexts/banking/domain/ports/IAccountForBankingReader.ts
+++ b/src/contexts/banking/domain/ports/IAccountForBankingReader.ts
@@ -1,7 +1,12 @@
+export type SessionType = 'one-shot' | 'persistent'
+export type LoginMode = 'simple' | 'assisted'
+
 export interface AccountForBanking {
   id: string
   userId: string
   bank: string
+  sessionType: SessionType
+  loginMode: LoginMode
 }
 
 export interface IAccountForBankingReader {

--- a/src/contexts/banking/infrastructure/adapters/AccountForBankingReaderAdapter.ts
+++ b/src/contexts/banking/infrastructure/adapters/AccountForBankingReaderAdapter.ts
@@ -1,15 +1,26 @@
 import type { IAccountRepository } from '../../../account/domain/IAccountRepository.js'
+import type { IAccountConfigRepository } from '../../../account/domain/IAccountConfigRepository.js'
 import {
   IAccountForBankingReader,
   AccountForBanking,
 } from '../../domain/ports/IAccountForBankingReader.js'
 
 export class AccountForBankingReaderAdapter implements IAccountForBankingReader {
-  constructor(private readonly accountRepo: IAccountRepository) {}
+  constructor(
+    private readonly accountRepo: IAccountRepository,
+    private readonly configRepo: IAccountConfigRepository,
+  ) {}
 
   async findById(accountId: string): Promise<AccountForBanking | null> {
     const account = await this.accountRepo.findById(accountId)
     if (!account) return null
-    return { id: account.id, userId: account.userId, bank: account.bank }
+    const config = await this.configRepo.findByAccountId(accountId)
+    return {
+      id: account.id,
+      userId: account.userId,
+      bank: account.bank,
+      sessionType: config?.sessionType ?? 'one-shot',
+      loginMode: config?.loginMode ?? 'simple',
+    }
   }
 }

--- a/src/shared/infrastructure/db/migrations/028_account_config_session_settings.sql
+++ b/src/shared/infrastructure/db/migrations/028_account_config_session_settings.sql
@@ -1,0 +1,9 @@
+-- Per-account session behaviour for bank scraping.
+--   session_type: 'one-shot' (open→scrape→close, periodic) | 'persistent' (long-lived monitor)
+--   login_mode:   'simple'   (logs in unattended)          | 'assisted' (waits for human 2FA)
+-- Defaults keep every existing account on the current one-shot/simple behaviour.
+ALTER TABLE account_config
+  ADD COLUMN session_type TEXT NOT NULL DEFAULT 'one-shot'
+    CHECK (session_type IN ('one-shot', 'persistent')),
+  ADD COLUMN login_mode TEXT NOT NULL DEFAULT 'simple'
+    CHECK (login_mode IN ('simple', 'assisted'));

--- a/tests/integration/account/AccountConfigRepository.integration.test.ts
+++ b/tests/integration/account/AccountConfigRepository.integration.test.ts
@@ -29,6 +29,8 @@ describe('AccountConfigRepository (integration)', () => {
       notifyOnExpired: true,
       webhookExtraFields: { custom: { nested: true }, list: [1, 2, 3] },
       silentIngestion: true,
+      sessionType: 'one-shot',
+      loginMode: 'simple',
       ...overrides,
     }
   }

--- a/tests/integration/account/UpsertAccountConfigUseCase.integration.test.ts
+++ b/tests/integration/account/UpsertAccountConfigUseCase.integration.test.ts
@@ -39,6 +39,8 @@ function baseInput(accountId: string, userId: string, overrides: Partial<UpsertA
     notifyOnExpired: false,
     webhookExtraFields: null,
     silentIngestion: false,
+    sessionType: 'one-shot',
+    loginMode: 'simple',
     bankUsername: null,
     bankPassword: null,
     ...overrides,

--- a/tests/integration/banking/NotifyBankMovementUseCase.integration.test.ts
+++ b/tests/integration/banking/NotifyBankMovementUseCase.integration.test.ts
@@ -74,7 +74,7 @@ function buildUseCase(sendWebhookFn: any) {
   const pool = getTestPool()
   return new NotifyBankMovementUseCase({
     bankTxRepo: txRepo,
-    accountReader: new AccountForBankingReaderAdapter(new AccountRepository(accountExec(pool))),
+    accountReader: new AccountForBankingReaderAdapter(new AccountRepository(accountExec(pool)), new AccountConfigRepository(accountExec(pool))),
     configReader: new NotificationConfigReaderAdapter(new AccountConfigRepository(accountExec(pool))),
     userModeReader: new UserOperationModeReaderAdapter(new UserRepository(userExec(pool))),
     sendWebhookFn,


### PR DESCRIPTION
This pull request introduces support for per-account session behavior and login mode settings for bank scraping. Two new fields, `sessionType` and `loginMode`, are added throughout the backend, including the API, domain models, persistence layer, and tests. These changes allow each account to specify whether it uses a "one-shot" or "persistent" session and whether login is "simple" or "assisted," with sensible defaults for backward compatibility.

**API and Schema Changes:**
- Added `session_type` and `login_mode` fields to the account configuration API schema, DTOs, and JSON serialization/deserialization logic. [[1]](diffhunk://#diff-b91cc4eea65dab509e3aad90e0ee32cd45d0225aa075b988a9fc01183c309b58R37-R38) [[2]](diffhunk://#diff-b91cc4eea65dab509e3aad90e0ee32cd45d0225aa075b988a9fc01183c309b58R94-R95) [[3]](diffhunk://#diff-b91cc4eea65dab509e3aad90e0ee32cd45d0225aa075b988a9fc01183c309b58R166-R167) [[4]](diffhunk://#diff-c85b52f15288d36706ec24a04f504bb899d69d670e42d81f6165607c2affa137R22-R23)

**Domain Model Updates:**
- Introduced `SessionType` and `LoginMode` types, and added them to the `AccountConfig` and related interfaces. [[1]](diffhunk://#diff-72952d52facec97c0a2335c9f473254269ef2d38df1e52743898e5bcc099ce2dR3-R4) [[2]](diffhunk://#diff-72952d52facec97c0a2335c9f473254269ef2d38df1e52743898e5bcc099ce2dR21-R22) [[3]](diffhunk://#diff-72952d52facec97c0a2335c9f473254269ef2d38df1e52743898e5bcc099ce2dR39-R40) [[4]](diffhunk://#diff-38d8f9f4c416369050ba3d10393d74aac84565f6ed4adee1500fe8b3aeba0598R1-R9)

**Persistence Layer and Migration:**
- Updated the database schema and repository logic to store and retrieve the new fields, including a migration to add `session_type` and `login_mode` columns with default values. [[1]](diffhunk://#diff-fb92107c8601907a476febf640ab6fedef1126050ec8e7868f7de4b71c788cebL26-R28) [[2]](diffhunk://#diff-fb92107c8601907a476febf640ab6fedef1126050ec8e7868f7de4b71c788cebR42-R43) [[3]](diffhunk://#diff-fb92107c8601907a476febf640ab6fedef1126050ec8e7868f7de4b71c788cebR60-R61) [[4]](diffhunk://#diff-5182f8ccf2e4ab9ad38eb80c561ecd4a9b752e82bd4bf8875d8a76c548506f45R18-R19) [[5]](diffhunk://#diff-5182f8ccf2e4ab9ad38eb80c561ecd4a9b752e82bd4bf8875d8a76c548506f45R39-R40) [[6]](diffhunk://#diff-cfc7d0e347bffb437a2b3e8c300d533f125d0d6fc2fd350ead4cd56aaaf3b818R1-R9)

**Service and Adapter Adjustments:**
- Modified the `AccountForBankingReaderAdapter` and related service constructors to fetch and provide the new fields, ensuring they are available in banking use cases. [[1]](diffhunk://#diff-93dfb40cd08a9f395f236e8a8580922b5839775a6ea28d999b9ea6994466b2daR2-R24) [[2]](diffhunk://#diff-c336d18a9dc427759b01ea8093ee7e38a127a559447db4917739776ea1b55ca4L47-R47)

**Test Coverage:**
- Updated and extended tests to cover the new fields, ensuring correct handling and defaulting in both unit and integration tests. [[1]](diffhunk://#diff-c8345cd82caeb950d872cf5282711d6f4f638d8929f839ff0e031bf0d1845c25R40-R41) [[2]](diffhunk://#diff-b1a8c6cc259ea6f1661e73b9a1bd13761122cb35cb57165432b166e56a1c3306L25-R25) [[3]](diffhunk://#diff-b1a8c6cc259ea6f1661e73b9a1bd13761122cb35cb57165432b166e56a1c3306L76-R76) [[4]](diffhunk://#diff-646ff91ffc18c7a31838d6fe6c704ba4414a9a64608c985ac2457107fd0088e5L21-R21) [[5]](diffhunk://#diff-646ff91ffc18c7a31838d6fe6c704ba4414a9a64608c985ac2457107fd0088e5L66-R66) [[6]](diffhunk://#diff-02e9855b03121fe2c46ba910cdaef81270f3d249bc8c0c65404c86561a28825cR32-R33) [[7]](diffhunk://#diff-36e2bb41d517dc2793ed5871beecdd1dce041158815f8b230ca82c91bcbf3d21R42-R43) [[8]](diffhunk://#diff-3e439cb9c1c9914606296d1f88f52c9f06309103eb7263705fa88afa540c22d9L77-R77)

These changes make session and login behavior explicit and configurable per account, improving flexibility for different bank integration scenarios.