### PR TITLE
Update documentation for persistent bank sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ReconBanker is a self-hosted reconciliation engine that scrapes bank transaction
 
 ## What it does
 
-- **Scrapes bank transactions** from customer bank accounts using Playwright browser automation (Itaú, Mi Dinero, and more)
+- **Scrapes bank transactions** from customer bank accounts using Playwright browser automation (Mi Dinero, Banco Pichincha Empresas, and more)
 - **Polls pending orders** from customer ERP or order-management systems via HTTP
 - **Reconciles transactions to orders** using a rule-based engine (exact amount + date window) and a fuzzy sender-name heuristic
 - **Notifies customers** via webhook when a match is found, including match type and transaction detail
@@ -39,6 +39,13 @@ ReconBanker is a self-hosted reconciliation engine that scrapes bank transaction
 - Manual or scheduled scraping and polling triggers
 - Script versioning: promote bank scripts from `review` → `active`
 
+### Bank session management
+
+- **One-shot scrapes** (open → scrape → close, run periodically) or long-lived **persistent sessions** (a browser monitor kept open per account), selectable per account via `session_type`
+- **Login mode** per account (`login_mode`): `simple` logs in unattended, `assisted` waits for a human to complete 2FA
+- **Skip-on-fatal**: a fatal failure (e.g. bad credentials / login failure) blocks the account from all automatic scrape/session triggers — instead of retrying and risking a bank lockout
+- **Manual restart**: a blocked account surfaces a "needs attention" badge in the UI and stays blocked until an operator restarts it
+
 ### Async job processing
 
 - Six BullMQ queues: `order-ingestion`, `bank-scrape`, `conciliation`, `tx-conciliation`, `webhook`, `bank-movement-webhook`
@@ -48,7 +55,8 @@ ReconBanker is a self-hosted reconciliation engine that scrapes bank transaction
 ### Frontend dashboard
 
 - Login / register
-- Account list and per-account config
+- Account list with a "needs attention" badge for accounts blocked by a fatal failure
+- Per-account config, including session settings (`session_type` / `login_mode`) and a restart action to unblock a fatally failed account
 - Conciliation requests with status, attempt history, and matched transaction detail
 - Bank movement passthrough mode
 - Bank and script management
@@ -144,6 +152,7 @@ For a detailed workflow see [docs/development.md](docs/development.md).
 | [docs/getting-started.md](docs/getting-started.md) | Setup, env vars, manual run guide          |
 | [docs/architecture.md](docs/architecture.md)       | Bounded contexts, DDD patterns, job queues |
 | [docs/api-reference.md](docs/api-reference.md)     | REST endpoints and request/response shapes |
+| [docs/development.md](docs/development.md)         | Common commands, migrations, adding scripts and contexts |
 | [docs/repository-map.md](docs/repository-map.md)   | Compact source tree reference              |
 
 ## License

--- a/client/README.md
+++ b/client/README.md
@@ -11,6 +11,14 @@ pnpm dev       # http://localhost:5173
 
 Requires the backend running on port 3000. See the [root README](../README.md) for full setup.
 
+## Features
+
+- Login / register, account list, and conciliation request views
+- Per-account config form, including bank **session settings** (`sessionType`: one-shot / persistent, `loginMode`: simple / assisted)
+- **Needs-attention** badge on the account list when a fatal failure has blocked an account, and a **restart** action on the account config page to unblock it
+- Bank and script management
+- Feature-scoped i18n (i18next)
+
 ## Scripts
 
 | Command | Description |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -128,6 +128,22 @@ Returns bank details including associated scripts.
 
 Returns accounts for the authenticated user.
 
+`status` reflects the account's onboarding/scrape state. `scrapeBlockedAt` is an ISO timestamp (or `null`) set when a fatal failure has blocked the account from automatic scrape/session triggers; `scrapeBlockedReason` carries the human-readable cause (or `null`). Both fields are returned in camelCase. Clear a block with `POST /accounts/:accountId/restart`.
+
+**Response** `200`
+```json
+[
+  {
+    "id": "uuid",
+    "bank": "itau",
+    "name": "Main account",
+    "status": "ready",
+    "scrapeBlockedAt": null,
+    "scrapeBlockedReason": null
+  }
+]
+```
+
 ---
 
 ### POST /accounts
@@ -148,7 +164,19 @@ Create an account for the authenticated user.
 
 ### GET /accounts/:accountId
 
-Returns account detail for the authenticated user.
+Returns account detail for the authenticated user. Same shape as a single entry in `GET /accounts`, including `scrapeBlockedAt` and `scrapeBlockedReason`.
+
+**Response** `200`
+```json
+{
+  "id": "uuid",
+  "bank": "itau",
+  "name": "Main account",
+  "status": "ready",
+  "scrapeBlockedAt": null,
+  "scrapeBlockedReason": null
+}
+```
 
 ---
 
@@ -186,9 +214,13 @@ Returns the account's reconciliation and webhook configuration, or `null` when n
   "notify_on_expired": false,
   "webhook_extra_fields": null,
   "silent_ingestion": false,
+  "session_type": "one-shot",
+  "login_mode": "simple",
   "bank_username": "user"
 }
 ```
+
+`session_type` is `one-shot` or `persistent`. `login_mode` is `simple` or `assisted`. The bank password is never returned.
 
 ---
 
@@ -212,17 +244,40 @@ Create or update account configuration.
   "bank_password": "secret",
   "notify_on_expired": false,
   "webhook_extra_fields": { "source": "reconbanker" },
-  "silent_ingestion": false
+  "silent_ingestion": false,
+  "session_type": "persistent",
+  "login_mode": "assisted"
 }
 ```
 
+Only `webhook_url` is required; all other fields are optional. Defaults applied when omitted: `retry_limit` `3`, `polling_method` `GET`, `auth_type` `bearer`, `notify_on_expired` `false`, `silent_ingestion` `false`, `session_type` `one-shot`, `login_mode` `simple`.
+
+`session_type` must be `one-shot` or `persistent`; `login_mode` must be `simple` or `assisted`. `bank_password` is accepted on write but never echoed back in the response.
+
+`polling_body` is only retained when `polling_method` is `POST`; it may be a JSON object or a JSON object encoded as a string.
+
 `webhook_extra_fields` may be a JSON object, a JSON object encoded as a string, or `null`. It cannot override reserved webhook keys such as `external_id`, `status`, `amount`, `currency`, `name`, `id`, or `received_at`.
+
+**Response** `200` — the saved config, same shape as `GET /accounts/:accountId/config`.
 
 ---
 
 ### POST /accounts/:accountId/scrape
 
-Trigger a manual bank scrape for this account.
+Trigger a manual bank scrape for this account. Requires ownership of the account.
+
+This is a deliberate human override and is **not** gated by a fatal scrape block: it enqueues a scrape even when `scrapeBlockedAt` is set, without clearing the block. Use `POST /accounts/:accountId/restart` when you want to clear the block as well.
+
+**Response** `202`
+```json
+{ "queued": true }
+```
+
+---
+
+### POST /accounts/:accountId/restart
+
+Clears a fatal scrape/session block on the account (e.g. after fixing bad credentials) and re-enqueues a scrape. Requires ownership of the account. Works for both `one-shot` and `persistent` session types.
 
 **Response** `202`
 ```json
@@ -329,6 +384,11 @@ Returns script details.
 ### POST /scripts/:scriptId/promote
 
 Promote a script from `review` to `active` status. The previously active script for that bank is deactivated.
+
+**Response** `200`
+```json
+{ "promoted": true }
+```
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,9 +10,10 @@ The backend is organized into five bounded contexts under `src/contexts/`:
 
 Manages accounts and banks.
 
-- **Account** - links a customer to a bank, holds status
+- **Account** - links a customer to a bank, holds status and a fatal-block state (`scrape_blocked_at` / `scrape_blocked_reason`)
 - **Bank** - defines a supported bank (code, name, login URL)
-- **AccountConfig** - per-account webhook URL, polling endpoint, auth settings
+- **AccountConfig** - per-account webhook URL, polling endpoint, auth settings, and bank-session behaviour (`session_type`, `login_mode`)
+- `ClearScrapeBlockUseCase` - clears an account's fatal block (ownership-checked) so automatic triggers resume
 
 ### `banking`
 
@@ -20,7 +21,9 @@ Handles bank scraping and transaction ingestion.
 
 - **BankTransaction** - a transaction scraped from a bank account
 - **ScrapeRun / ScrapeStep** - audit trail of each scraping execution
-- **ScriptEnginePort** - port abstraction; `PlaywrightRunner` is the adapter
+- **ScriptEnginePort** - port abstraction; `PlaywrightRunner` is the adapter (one-shot scraping)
+- **SessionManager** - in-process registry of long-lived persistent monitor sessions (see [Persistent bank sessions](#persistent-bank-sessions))
+- **isFatalScrapeError** - classifies a failure message as fatal (e.g. bad credentials) so it is never auto-retried; drives the skip-on-fatal block
 
 ### `conciliation`
 
@@ -37,7 +40,8 @@ Manages Playwright automation scripts.
 
 - **BankScript** - versioned script associated with a bank
 - Scripts flow from `review` → `active` via `PromoteScriptUseCase`
-- Supported banks: Itaú, Mi Dinero
+- Supported banks: Mi Dinero (one-shot), Banco Pichincha Empresas (persistent)
+- Two script contracts coexist (see [Persistent bank sessions](#persistent-bank-sessions)): legacy scripts return a transaction array and run under `PlaywrightRunner`; hook-based scripts return a `{ login, isAuthenticated, poll, keepAlive }` object and run under `PersistentPlaywrightRunner` + `runMonitor`
 
 ### `user`
 
@@ -76,7 +80,43 @@ webhook               →  NotifyWebhookUseCase
 bank-movement-webhook →  NotifyBankMovementUseCase
 ```
 
-The Scheduler (`src/shared/infrastructure/queues/Scheduler.ts`) enqueues recurring polling, scraping, and stale-request expiry jobs based on `POLLING_INTERVAL_SECONDS`, `SCRAPE_INTERVAL_SECONDS`, and `EXPIRE_STALE_REQUESTS_INTERVAL_SECONDS`.
+The Scheduler (`src/shared/infrastructure/queues/Scheduler.ts`) enqueues recurring polling, scraping, persistent-session health-check, and stale-request expiry jobs based on `POLLING_INTERVAL_SECONDS`, `SCRAPE_INTERVAL_SECONDS`, `SESSION_HEALTHCHECK_SECONDS` (default 75s), and `EXPIRE_STALE_REQUESTS_INTERVAL_SECONDS`.
+
+## Persistent bank sessions
+
+Each account chooses how its bank is scraped via two `account_config` columns added in migration `028_account_config_session_settings.sql` (read by `AccountForBankingReaderAdapter`, defaulting to `one-shot`/`simple` when no config row exists):
+
+- `session_type`: `one-shot` (open → scrape → close, periodic) or `persistent` (a long-lived browser monitor)
+- `login_mode`: `simple` (logs in unattended) or `assisted` (waits for a human to complete 2FA)
+
+### Routing
+
+`RunBankScrapeUseCase` branches on `session_type`. For `persistent` accounts it delegates to `SessionManager.ensureRunning(accountId)` and returns; for `one-shot` accounts it runs the legacy load-script → run → ingest path.
+
+### Persistent runtime
+
+- **SessionManager** (`src/contexts/banking/infrastructure/SessionManager.ts`) is an in-process registry of live sessions keyed by `accountId`. `ensureRunning` is idempotent — a no-op when a session is already live or currently starting. A `starting` map closes the TOCTOU window between the live-check and `live.set` so a concurrent call never launches a second browser against the same profile (Chromium cannot share a `userDataDir`). When a session's `done` promise settles, the slot is freed and `bank_sessions` is updated; a fatal stop reason additionally blocks the account (best-effort). `stopAll()` stops every live session.
+- **runMonitor** (`src/contexts/script-engine/infrastructure/runMonitor.ts`) drives a hook-based script: it calls `login`, polls `isAuthenticated` until an auth deadline (assisted ~300s, simple ~30s, returning `auth_timeout` on expiry), then loops calling `poll`. Dedup is seeded with `lastExternalId` and cleared on a bank-day rollover (via `getBankDay`), since `poll` only returns "today". It detects a lost session (`isAuthenticated` false → `logged_out`), honours `shouldStop` (`stop_requested`) and `maxRuntimeMs` (`max_runtime`), and invokes the optional `keepAlive` hook when a poll yields nothing or fails.
+- **PersistentPlaywrightRunner** (`src/contexts/script-engine/infrastructure/PersistentPlaywrightRunner.ts`) launches `chromium.launchPersistentContext` with a per-account profile under `playwright-profiles/<accountId>` and `headless: false`, evaluates the script body, and requires the returned object to expose a `poll()` function (otherwise it rejects). It wires the hooks into `runMonitor` and closes the context when the monitor exits.
+- The composition root (`src/composition/bankingModule.ts`) builds the `startFn` that loads credentials and the active script, computes `lastExternalId`, and starts the runner; `getBankDay` uses the `America/Guayaquil` timezone for Pichincha.
+- **bank_sessions** (migration `029_create_bank_sessions.sql`) holds one row per account (`running`/`stopped` + `stop_reason`), upserted by `BankSessionRepository`.
+
+### Script contract
+
+Hook-based scripts return `{ login, isAuthenticated, poll, keepAlive? }`; legacy scripts return a transaction array. `PersistentPlaywrightRunner` detects a hook object by checking for a `poll` function, while `PlaywrightRunner` consumes the array return. Banco Pichincha (seeded by migration `030_seed_pichincha_script.sql`, code in `scripts/bancopichincha/extract_transactions.v1.0.0.js`) is the first hook-based, persistent bank.
+
+### Lifecycle
+
+- The Scheduler's `ensurePersistentSessions` health-check (every ~75s) re-enqueues a bank-scrape job for each eligible persistent account not already running, which flows through `RunBankScrapeUseCase` → `ensureRunning` to relaunch crashed sessions.
+- On `SIGTERM`, `src/index.ts` calls `sessionManager.stopAll()` before closing workers.
+
+### Skip-on-fatal and restart
+
+A fatal failure (matched by `isFatalScrapeError` in `src/contexts/banking/domain/isFatalScrapeError.ts`, e.g. `login_failed` or "No valid credentials") must never be auto-retried, as repeated bad logins risk a bank lockout.
+
+- When a one-shot scrape or a persistent session fails fatally, the account is blocked via `AccountScrapeBlockerAdapter`, which sets `scrape_blocked_at` / `scrape_blocked_reason` (columns from migration `031_accounts_scrape_blocked.sql`). The write is idempotent — only the first (root-cause) reason is recorded.
+- Both Scheduler queries (`schedulerQueries.ts`) gate on `scrape_blocked_reason IS NULL`, so blocked accounts are excluded from one-shot scraping and persistent-session relaunch alike.
+- An operator clears the block via `POST /accounts/:id/restart`, which runs `ClearScrapeBlockUseCase` (ownership-checked) and re-enqueues a scrape. Works for both one-shot and persistent accounts.
 
 ## Domain event bus
 
@@ -111,8 +151,9 @@ Key tables:
 |---|---|
 | `users` | Authentication |
 | `banks` | Supported bank definitions (`pending`, `onboarding`, `ready`, `failed`) |
-| `accounts` | Customer bank accounts |
-| `account_config` | Per-account webhook, polling, expiry-notification, extra-field, and silent-ingestion config |
+| `accounts` | Customer bank accounts, including fatal scrape-block state (`scrape_blocked_at`, `scrape_blocked_reason`) |
+| `account_config` | Per-account webhook, polling, expiry-notification, extra-field, silent-ingestion, and bank-session (`session_type`, `login_mode`) config |
+| `bank_sessions` | Latest state of each account's persistent monitor session (`running`/`stopped`) |
 | `bank_credentials` | Encrypted login credentials per account |
 | `bank_transactions` | Scraped transactions, including exclusion and notification timestamps |
 | `bank_scripts` | Playwright scripts (versioned) |

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,8 +13,8 @@
 | `pnpm test` | Run backend unit tests |
 | `pnpm test:watch` | Run backend tests in watch mode |
 | `pnpm test:coverage` | Run backend tests with coverage |
-| `pnpm test:integration` | Run backend integration tests |
-| `pnpm typecheck` | Type-check backend source and tests |
+| `pnpm test:integration` | Run backend integration tests (separate `vitest.integration.config.ts`, run serially, need a Postgres test DB — see [below](#integration-tests)) |
+| `pnpm typecheck` | Type-check backend source and tests (`tsc --noEmit` + `tsc -p tsconfig.test.json`) |
 
 ### Frontend (run from `client/`)
 
@@ -36,6 +36,34 @@
 | `docker compose up -d` | Start PostgreSQL and Redis |
 | `docker compose down` | Stop services |
 | `docker compose down -v` | Stop services and delete volumes |
+
+## Integration tests
+
+`pnpm test:integration` uses `vitest.integration.config.ts` (separate from the unit-test
+config) and runs the suites serially. The setup file (`tests/integration/setup.ts`):
+
+1. Resolves a test database from `DATABASE_URL_TEST`, or derives a `reconbanker_test`
+   database from `DATABASE_URL` (default `postgres://reconbanker:reconbanker@localhost:5432/reconbanker_test`).
+2. Creates that database if it does not exist.
+3. Runs all migrations against it (`pnpm migrate`).
+4. Seeds canonical fixtures (`mi-dinero` bank + active script) stamped in the past.
+
+The Docker Compose Postgres (below) is enough; no manual test-DB setup is required.
+
+## Bank scraping & persistent sessions
+
+Real bank scrapes and persistent bank sessions run through Playwright. The runners
+(`PlaywrightRunner`, `PersistentPlaywrightRunner`) launch Chromium with `headless: false`,
+so running these locally requires:
+
+- The Chromium browser installed: `npx playwright install chromium`
+- A display / X server (note: WSL2 needs WSLg or an external X server)
+- Migrations `028`–`031` applied (`pnpm migrate`)
+
+Persistent sessions store a per-account browser profile under `PLAYWRIGHT_PROFILES_DIR`
+(default `./playwright-profiles`, gitignored). Tuning env vars: `SESSION_HEALTHCHECK_SECONDS`
+(default 75) and `PERSISTENT_POLL_INTERVAL_MS` (default 60000). See `docs/getting-started.md`
+for the full env reference.
 
 ## Adding a database migration
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,6 +5,8 @@
 - [Node.js](https://nodejs.org/) >= 20
 - [pnpm](https://pnpm.io/) >= 10 - `npm install -g pnpm`
 - [Docker](https://www.docker.com/) with Compose v2
+- A Playwright Chromium browser, only if you run **real** bank scrapes or persistent
+  bank sessions locally (see [Bank scraping & persistent sessions](#bank-scraping--persistent-sessions))
 
 ## One-command setup
 
@@ -109,7 +111,55 @@ If you need to override the frontend API base URL, define `VITE_API_BASE_URL` in
 | `SCRAPE_INTERVAL_SECONDS` | No | `1200` | Interval for running bank scraping jobs |
 | `EXPIRE_STALE_REQUESTS_INTERVAL_SECONDS` | No | `3600` | Interval for expiring stale conciliation requests |
 | `BANK_SCRAPE_CONCURRENCY` | No | `2` | Maximum number of bank scraping jobs, and Playwright browsers, to run at the same time |
+| `PLAYWRIGHT_PROFILES_DIR` | No | `./playwright-profiles` | Directory where persistent bank sessions store per-account browser profiles (gitignored) |
+| `SESSION_HEALTHCHECK_SECONDS` | No | `75` | Interval at which the scheduler health-checks live persistent bank sessions |
+| `PERSISTENT_POLL_INTERVAL_MS` | No | `60000` | How often a running persistent session polls the bank for new transactions |
 | `VITE_API_BASE_URL` | No | `/api` | Frontend API base URL (read by Vite from `client/.env*` or exported shell env); set only when the API is served from a different origin |
+
+> The persistent-session variables (`PLAYWRIGHT_PROFILES_DIR`, `SESSION_HEALTHCHECK_SECONDS`,
+> `PERSISTENT_POLL_INTERVAL_MS`) all have sensible defaults and are not listed in `.env.example`.
+> Set them only to override the defaults.
+
+## Bank scraping & persistent sessions
+
+The backend uses [Playwright](https://playwright.dev/) (already a dependency, no extra
+install for normal app development) to drive real bank scrapes and the persistent bank
+sessions introduced by that feature. To run those flows locally against a real browser:
+
+1. Install the Chromium browser Playwright drives:
+
+   ```bash
+   npx playwright install chromium
+   ```
+
+2. Provide a display. Both `PlaywrightRunner` and `PersistentPlaywrightRunner` launch
+   Chromium with `headless: false`, so a running X server / desktop session is required.
+   On **WSL2** there is no display by default — use WSLg (Windows 11) or a separate X
+   server, otherwise the browser launch fails.
+
+3. Apply migrations up to and including `028`–`031`, which add the persistent-session
+   schema and seeds (`pnpm migrate` applies all of these).
+
+Per-account browser profiles are stored under `PLAYWRIGHT_PROFILES_DIR`
+(default `./playwright-profiles`, gitignored). See the env reference above for
+`SESSION_HEALTHCHECK_SECONDS` and `PERSISTENT_POLL_INTERVAL_MS`.
+
+## Running tests
+
+```bash
+# Unit tests (vitest)
+pnpm test
+
+# Integration tests — separate config, run serially, need a Postgres test DB
+pnpm test:integration
+```
+
+`pnpm test:integration` uses `vitest.integration.config.ts`. Its setup
+(`tests/integration/setup.ts`) connects to `DATABASE_URL_TEST` if set, otherwise derives
+a `reconbanker_test` database from `DATABASE_URL` (falling back to
+`postgres://reconbanker:reconbanker@localhost:5432/reconbanker_test`). It creates that
+database if missing, runs all migrations against it, and seeds canonical fixtures, so the
+Docker Compose Postgres started above is sufficient — no manual test-DB creation needed.
 
 ## Production build
 

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -3,7 +3,7 @@
 ```text
 reconbanker/
 ├── src/                                      # Backend source
-│   ├── index.ts                              # App bootstrap: server, workers, scheduler, event handlers
+│   ├── index.ts                              # App bootstrap: server, workers, scheduler, sessions, event handlers
 │   ├── api/
 │   │   ├── server.ts                         # Express app, CORS, static client serving, route binding
 │   │   ├── http/
@@ -15,7 +15,7 @@ reconbanker/
 │   │   └── routes/
 │   │       ├── auth.routes.ts                # POST /api/auth/register, /api/auth/login
 │   │       ├── user.routes.ts                # /api/me and operation mode
-│   │       ├── accounts.routes.ts            # /api/accounts CRUD, config, scrape trigger
+│   │       ├── accounts.routes.ts            # /api/accounts CRUD, config, scrape trigger, scrape-block restart
 │   │       ├── bank-movements.routes.ts      # /api/accounts/:accountId/movements
 │   │       ├── banks.routes.ts               # /api/banks CRUD + scripts
 │   │       ├── conciliation.routes.ts        # /api/conciliation list, run, poll, notify
@@ -30,33 +30,33 @@ reconbanker/
 │   │   └── userModule.ts
 │   ├── contexts/
 │   │   ├── account/                          # Account & Bank bounded context
-│   │   │   ├── domain/                       # Account, Bank, AccountConfig, credentials, repositories
-│   │   │   ├── infrastructure/               # PostgreSQL repositories and executor
-│   │   │   └── application/                  # Account, bank, config, and delete use cases
-│   │   ├── banking/                          # Bank scraping and movement notification context
-│   │   │   ├── domain/                       # BankTransaction, scrape run, script engine port
-│   │   │   ├── infrastructure/               # Repositories, read model, script adapter, executor
-│   │   │   └── application/                  # Scrape, list movements, notify/re-notify use cases
+│   │   │   ├── domain/                       # Account, Bank, AccountConfig, credentials, repository ports
+│   │   │   ├── infrastructure/               # PostgreSQL repositories, mappers, executor, reader adapters
+│   │   │   └── application/                  # Account/bank/config use cases, ClearScrapeBlockUseCase (restart)
+│   │   ├── banking/                          # Bank scraping, persistent sessions, movement notification
+│   │   │   ├── domain/                       # BankTransaction, repo & session ports, isFatalScrapeError, scrape blocker port
+│   │   │   ├── infrastructure/               # Repos, read model, SessionManager, BankSessionRepository, script & blocker adapters
+│   │   │   └── application/                  # RunBankScrape, IngestTransactions, list movements, notify/re-notify use cases
 │   │   ├── conciliation/                     # Reconciliation bounded context
-│   │   │   ├── domain/                       # ConciliationRequest, engine, match result, repositories
-│   │   │   ├── infrastructure/               # Repositories, read model, executor
+│   │   │   ├── domain/                       # ConciliationRequest, engine, match result, rules/heuristics, repositories
+│   │   │   ├── infrastructure/               # Repositories, read model, executor, reader adapters
 │   │   │   └── application/                  # Poll, run, transaction ingestion, webhook, expiry use cases
-│   │   ├── script-engine/                    # Playwright script management
+│   │   ├── script-engine/                    # Playwright script management and execution
 │   │   │   ├── domain/                       # BankScript and repository port
-│   │   │   ├── infrastructure/               # PlaywrightRunner, ScriptLoader, scripts/, repository
+│   │   │   ├── infrastructure/               # PlaywrightRunner, PersistentPlaywrightRunner, runMonitor, ScriptLoader, scripts/, repo
 │   │   │   └── application/                  # List, detail, promote script use cases
 │   │   └── user/                             # Authentication and user preferences
-│   │       ├── domain/                       # User and repository port
-│   │       ├── infrastructure/               # User repository and executor
+│   │       ├── domain/                       # User and repository/hasher/token/cleaner ports
+│   │       ├── infrastructure/               # User repository, executor, bcrypt/JWT/cleaner adapters
 │   │       └── application/                  # Register, login, current user, operation mode use cases
 │   └── shared/
 │       ├── domain/                           # Entity, AggregateRoot, ValueObject
 │       ├── errors/                           # Application/domain error classes
 │       ├── events/                           # Event bus abstractions and domain event types
 │       ├── infrastructure/
-│       │   ├── db/                           # PostgreSQL pool, migration runner, 27 SQL migrations
+│       │   ├── db/                           # PostgreSQL pool, migration runner, 31 SQL migrations
 │       │   ├── logger/                       # Winston logger implementation
-│       │   ├── queues/                       # BullMQ queues, scheduler, workers
+│       │   ├── queues/                       # BullMQ queues, Scheduler, schedulerQueries (scrape-gating SQL), workers
 │       │   └── webhooks/                     # Webhook sender
 │       ├── logger/                           # Logger port
 │       └── persistence/                      # Unit of work and transaction helpers
@@ -68,20 +68,47 @@ reconbanker/
 │       ├── features/
 │       │   ├── user/                         # Login, register, auth provider, user settings, mode guard
 │       │   ├── dashboard/                    # Dashboard screen and i18n namespace
-│       │   ├── account/                      # Accounts, banks, account config APIs/pages/hooks
+│       │   ├── account/                      # Accounts/banks pages, config + session-settings form, scrape-block restart button/badge, APIs/hooks
 │       │   ├── banking/                      # Bank movements screen and notification APIs
 │       │   ├── conciliation/                 # Conciliation list/detail actions and mode-gated route
 │       │   └── script-engine/                # Script list/detail/promote UI
 │       └── shared/
+│           ├── hooks/                        # Shared React hooks (e.g. use-mobile)
 │           ├── http/                         # Axios client
 │           ├── i18n/                         # i18next setup and common namespace
 │           ├── layout/                       # Shells, sidebar/header, language selector
 │           ├── lib/                          # Shared utility helpers
 │           └── ui/                           # shadcn/ui primitives
+├── tests/                                    # Backend tests (unit colocated in src/; integration + smoke here)
+│   ├── helpers/                              # In-memory repository/UoW fakes for unit tests
+│   ├── integration/                          # DB-backed integration tests (account, banking, conciliation, script-engine, shared, user)
+│   └── smoke/                                # Server-boot smoke test
 ├── docs/                                     # Project documentation
 ├── docker-compose.yml                        # PostgreSQL 16 + Redis 7
 ├── setup.sh                                  # One-command setup script
 ├── package.json                              # Backend scripts + dependencies
 ├── pnpm-workspace.yaml                       # Monorepo workspace config
 └── .env.example                              # Environment variable template
+```
+
+## Persistent sessions & skip-on-fatal — key files
+
+```text
+src/contexts/banking/domain/isFatalScrapeError.ts            # Classifies fatal (no-retry) vs transient scrape errors
+src/contexts/banking/domain/ports/IAccountScrapeBlocker.ts   # Port to block an account after a fatal failure
+src/contexts/banking/domain/IBankSessionRepository.ts        # Port for persistent bank_sessions state
+src/contexts/banking/infrastructure/SessionManager.ts        # In-process registry of live persistent monitor sessions
+src/contexts/banking/infrastructure/BankSessionRepository.ts # bank_sessions running/stopped persistence
+src/contexts/banking/infrastructure/adapters/AccountScrapeBlockerAdapter.ts # Sets accounts.scrape_blocked_reason
+src/contexts/banking/application/RunBankScrapeUseCase.ts     # One-shot scrape; blocks account on fatal error
+src/contexts/banking/application/IngestTransactionsUseCase.ts # Dedup + persist + publish (shared by one-shot and monitor)
+src/contexts/account/application/ClearScrapeBlockUseCase.ts  # Clears scrape block (restart endpoint)
+src/contexts/script-engine/infrastructure/runMonitor.ts      # Long-lived login/poll/keepAlive monitor loop
+src/contexts/script-engine/infrastructure/PersistentPlaywrightRunner.ts # Persistent-context runner driving runMonitor
+src/contexts/script-engine/infrastructure/scripts/bancopichincha/extract_transactions.v1.0.0.js # Pichincha hook script
+src/shared/infrastructure/queues/schedulerQueries.ts         # Scrape-eligibility SQL (filters scrape_blocked_reason)
+src/shared/infrastructure/db/migrations/028_account_config_session_settings.sql
+src/shared/infrastructure/db/migrations/029_create_bank_sessions.sql
+src/shared/infrastructure/db/migrations/030_seed_pichincha_script.sql
+src/shared/infrastructure/db/migrations/031_accounts_scrape_blocked.sql
 ```


### PR DESCRIPTION
This pull request introduces comprehensive documentation updates to cover new features around persistent bank sessions, fatal scrape blocking, and enhanced account/session management. The changes clarify the architecture, API, and frontend behavior to align with recent backend and frontend enhancements, especially the support for persistent browser sessions, session and login modes, and operator control over blocked accounts.

**Key documentation updates:**

### Persistent sessions & session management

* Added detailed explanations of persistent bank sessions, including the `SessionManager`, session lifecycle, and the distinction between `one-shot` and `persistent` scraping, as well as `simple` vs. `assisted` login modes. This includes new sections in `docs/architecture.md`, `README.md`, and `docs/development.md`. [[1]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L79-R119) [[2]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L13-R26) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R42-R48) [[4]](diffhunk://#diff-c4577d0b3a9c55c4e75639bb45f3dd659e83bc31b7a30943fda6ef84f7cef47aR14-R21) [[5]](diffhunk://#diff-97db29a7915320e63d41d38a0440360a87055ee8ed03757aa263116dbbb4aabeR40-R67)
* Described the new database tables and config fields supporting persistent sessions (`session_type`, `login_mode`, and `bank_sessions`) in the architecture and API docs. [[1]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L114-R156) [[2]](diffhunk://#diff-b1e6394ff90bfe7ea652fe504ea12eae43c8fecaa0090581cb857aa3e014ba5cR217-R224) [[3]](diffhunk://#diff-b1e6394ff90bfe7ea652fe504ea12eae43c8fecaa0090581cb857aa3e014ba5cL215-R280)

### Fatal scrape block and operator restart

* Documented the "skip-on-fatal" behavior: accounts are blocked from auto-scraping after fatal errors, with fields `scrapeBlockedAt` and `scrapeBlockedReason` surfaced in the API and UI. Operators can manually clear the block via a new `POST /accounts/:accountId/restart` endpoint. [[1]](diffhunk://#diff-b1e6394ff90bfe7ea652fe504ea12eae43c8fecaa0090581cb857aa3e014ba5cR131-R146) [[2]](diffhunk://#diff-b1e6394ff90bfe7ea652fe504ea12eae43c8fecaa0090581cb857aa3e014ba5cL151-R179) [[3]](diffhunk://#diff-b1e6394ff90bfe7ea652fe504ea12eae43c8fecaa0090581cb857aa3e014ba5cL215-R280) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L51-R59)

### API reference and frontend updates

* Updated the API reference to reflect new fields, endpoints, and behaviors for accounts, account config, manual scrapes, and script promotion. [[1]](diffhunk://#diff-b1e6394ff90bfe7ea652fe504ea12eae43c8fecaa0090581cb857aa3e014ba5cR131-R146) [[2]](diffhunk://#diff-b1e6394ff90bfe7ea652fe504ea12eae43c8fecaa0090581cb857aa3e014ba5cL151-R179) [[3]](diffhunk://#diff-b1e6394ff90bfe7ea652fe504ea12eae43c8fecaa0090581cb857aa3e014ba5cR217-R224) [[4]](diffhunk://#diff-b1e6394ff90bfe7ea652fe504ea12eae43c8fecaa0090581cb857aa3e014ba5cL215-R280) [[5]](diffhunk://#diff-b1e6394ff90bfe7ea652fe504ea12eae43c8fecaa0090581cb857aa3e014ba5cR388-R392)
* Updated frontend documentation to highlight new features such as the "needs attention" badge, session settings in account config, and the restart action. [[1]](diffhunk://#diff-c4577d0b3a9c55c4e75639bb45f3dd659e83bc31b7a30943fda6ef84f7cef47aR14-R21) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L51-R59)

### Development and testing improvements

* Expanded development docs to cover integration tests (using a dedicated test DB and Playwright setup), and clarified requirements for running persistent sessions locally. [[1]](diffhunk://#diff-97db29a7915320e63d41d38a0440360a87055ee8ed03757aa263116dbbb4aabeL16-R17) [[2]](diffhunk://#diff-97db29a7915320e63d41d38a0440360a87055ee8ed03757aa263116dbbb4aabeR40-R67) [[3]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3R8-R9)

### Miscellaneous

* Updated supported banks and script contracts in the main and architecture READMEs to reflect new persistent-session support and the addition of Banco Pichincha Empresas. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R19) [[2]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L40-R44)

These updates ensure that the documentation accurately reflects the current system capabilities and guides users and developers through new operational and development workflows.