### PR TITLE
Refactor AccountConfig layout and enhance UX with new components

### DIFF
--- a/client/src/features/account/i18n/en.json
+++ b/client/src/features/account/i18n/en.json
@@ -54,6 +54,8 @@
     "auth": "Authentication",
     "authType": "Auth type",
     "tokenKey": "Token / API Key",
+    "authHintPollingAndWebhook": "Used to call the pending-orders endpoint and also sent in the Authorization header of outgoing webhooks.",
+    "authHintWebhookOnly": "If set, sent in the Authorization header of outgoing webhooks so your endpoint can verify the request.",
     "orderIngestion": "Order ingestion",
     "endpointFormat": "Expected endpoint format",
     "endpointFormatDesc": "The endpoint must return a JSON array with the following schema:",
@@ -80,10 +82,9 @@
     "notificationsActive": "Notifications active",
     "notificationsSilenced": "Notifications silenced",
     "tabs": {
-      "credentials": "Credentials",
-      "session": "Session",
-      "webhooks": "Webhooks",
-      "authOrders": "Auth & Orders"
+      "credentialsSession": "Credentials & session",
+      "webhook": "Webhook",
+      "orders": "Orders"
     },
     "session": "Session",
     "sessionType": "Session type",

--- a/client/src/features/account/i18n/es.json
+++ b/client/src/features/account/i18n/es.json
@@ -54,6 +54,8 @@
     "auth": "Autenticación",
     "authType": "Tipo de auth",
     "tokenKey": "Token / API Key",
+    "authHintPollingAndWebhook": "Se usa para llamar al endpoint de órdenes pendientes y también se envía en el header Authorization de los webhooks salientes.",
+    "authHintWebhookOnly": "Si lo configurás, se envía en el header Authorization de los webhooks salientes para que tu endpoint pueda verificar la request.",
     "orderIngestion": "Ingesta de órdenes",
     "endpointFormat": "Formato esperado del endpoint",
     "endpointFormatDesc": "El endpoint debe devolver un array JSON con el siguiente esquema:",
@@ -80,10 +82,9 @@
     "notificationsActive": "Notificaciones activas",
     "notificationsSilenced": "Notificaciones silenciadas",
     "tabs": {
-      "credentials": "Credenciales",
-      "session": "Sesión",
-      "webhooks": "Webhooks",
-      "authOrders": "Auth y Órdenes"
+      "credentialsSession": "Credenciales y sesión",
+      "webhook": "Webhook",
+      "orders": "Órdenes"
     },
     "session": "Sesión",
     "sessionType": "Tipo de sesión",

--- a/client/src/features/account/pages/AccountConfig.test.tsx
+++ b/client/src/features/account/pages/AccountConfig.test.tsx
@@ -8,14 +8,15 @@ import { accountHandlers } from '../../../../tests/msw/handlers/account'
 import { userHandlers } from '../../../../tests/msw/handlers/user'
 import { renderWithProviders } from '../../../../tests/utils/render'
 import i18n from '@/shared/i18n'
+import { AccountConfig } from './AccountConfig'
 import {
-  AccountConfig,
   validateAccountConfigForm,
   mapServerErrorToField,
   FIELD_TO_TAB,
   FIELD_ORDER,
+  resolveTabForField,
   type AccountConfigForm,
-} from './AccountConfig'
+} from './accountConfigForm'
 
 function makeForm(overrides: Partial<AccountConfigForm> = {}): AccountConfigForm {
   return {
@@ -217,21 +218,26 @@ describe('mapServerErrorToField', () => {
   })
 })
 
-describe('FIELD_TO_TAB / FIELD_ORDER constants', () => {
-  it('routes credentials fields to the credentials tab', () => {
-    expect(FIELD_TO_TAB.bankUsername).toBe('credentials')
-    expect(FIELD_TO_TAB.bankPassword).toBe('credentials')
+describe('FIELD_TO_TAB / FIELD_ORDER / resolveTabForField', () => {
+  it('routes credentials fields to the credentials-session tab', () => {
+    expect(FIELD_TO_TAB.bankUsername).toBe('credentials-session')
+    expect(FIELD_TO_TAB.bankPassword).toBe('credentials-session')
   })
 
-  it('routes webhook fields to the webhooks tab', () => {
-    expect(FIELD_TO_TAB.webhookUrl).toBe('webhooks')
-    expect(FIELD_TO_TAB.webhookExtraFields).toBe('webhooks')
+  it('routes webhook fields to the webhook tab', () => {
+    expect(FIELD_TO_TAB.webhookUrl).toBe('webhook')
+    expect(FIELD_TO_TAB.webhookExtraFields).toBe('webhook')
   })
 
-  it('routes auth/orders fields to the auth-orders tab', () => {
-    expect(FIELD_TO_TAB.authToken).toBe('auth-orders')
-    expect(FIELD_TO_TAB.pendingOrdersEndpoint).toBe('auth-orders')
-    expect(FIELD_TO_TAB.pollingBody).toBe('auth-orders')
+  it('routes order ingestion fields to the orders tab', () => {
+    expect(FIELD_TO_TAB.pendingOrdersEndpoint).toBe('orders')
+    expect(FIELD_TO_TAB.pollingBody).toBe('orders')
+  })
+
+  it('resolves authToken to orders in reconcile mode and webhook in passthrough', () => {
+    expect(resolveTabForField('authToken', 'reconcile')).toBe('orders')
+    expect(resolveTabForField('authToken', 'passthrough')).toBe('webhook')
+    expect(resolveTabForField('authToken', null)).toBe('webhook')
   })
 
   it('puts bankUsername first in FIELD_ORDER', () => {
@@ -441,8 +447,8 @@ describe('AccountConfig page', () => {
     await waitFor(() => {
       expect(screen.getByDisplayValue('alice')).toBeInTheDocument()
     })
-    // Switch to the Webhooks tab and verify webhookUrl hydrated.
-    await user.click(screen.getByRole('tab', { name: /Webhooks/i }))
+    // Switch to the Webhook tab and verify webhookUrl hydrated.
+    await user.click(screen.getByRole('tab', { name: /^Webhook$/i }))
     await waitFor(() => {
       expect(screen.getByDisplayValue('https://hook.example.com/x')).toBeInTheDocument()
     })
@@ -454,7 +460,7 @@ describe('AccountConfig page', () => {
     await waitFor(() => {
       expect(screen.getByText('Configuración de cuenta')).toBeInTheDocument()
     })
-    await user.click(screen.getByRole('tab', { name: /Webhooks/i }))
+    await user.click(screen.getByRole('tab', { name: /^Webhook$/i }))
     // Initial state: silentIngestion=false → button label is "Notificaciones activas".
     const bellBtn = await screen.findByRole('button', { name: /Notificaciones activas/i })
     expect(bellBtn).toHaveAttribute('aria-pressed', 'false')
@@ -465,31 +471,29 @@ describe('AccountConfig page', () => {
     })
   })
 
-  it('switches between tabs when their triggers are clicked', async () => {
+  it('shows credentials and session in the same tab and switches to the Webhook tab', async () => {
     const user = userEvent.setup()
     renderAccountConfig()
     await waitFor(() => {
       expect(screen.getByText('Credenciales bancarias')).toBeInTheDocument()
     })
-    await user.click(screen.getByRole('tab', { name: /^Sesión$/i }))
-    await waitFor(() => {
-      expect(screen.getByText('Tipo de sesión')).toBeInTheDocument()
-    })
-    await user.click(screen.getByRole('tab', { name: /Webhooks/i }))
+    // Session card is in the same tab as credentials, both visible without switching.
+    expect(screen.getByText('Tipo de sesión')).toBeInTheDocument()
+    await user.click(screen.getByRole('tab', { name: /^Webhook$/i }))
     await waitFor(() => {
       expect(screen.getByText('Webhook URL (notificaciones)')).toBeInTheDocument()
     })
   })
 
-  it('does not show the Auth & Orders tab in passthrough mode', async () => {
+  it('does not show the Orders tab in passthrough mode', async () => {
     renderAccountConfig()
     await waitFor(() => {
       expect(screen.getByText('Configuración de cuenta')).toBeInTheDocument()
     })
-    expect(screen.queryByRole('tab', { name: /Auth y Órdenes/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('tab', { name: /^Órdenes$/i })).not.toBeInTheDocument()
   })
 
-  it('shows the Auth & Orders tab in reconcile mode', async () => {
+  it('shows the Orders tab in reconcile mode', async () => {
     server.use(
       http.get('/api/me', () =>
         HttpResponse.json({
@@ -502,7 +506,23 @@ describe('AccountConfig page', () => {
     )
     renderAccountConfig()
     await waitFor(() => {
-      expect(screen.getByRole('tab', { name: /Auth y Órdenes/i })).toBeInTheDocument()
+      expect(screen.getByRole('tab', { name: /^Órdenes$/i })).toBeInTheDocument()
+    })
+  })
+
+  it('shows the authentication card inside the Webhook tab in passthrough mode', async () => {
+    const user = userEvent.setup()
+    renderAccountConfig()
+    await waitFor(() => {
+      expect(screen.getByText('Configuración de cuenta')).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('tab', { name: /^Webhook$/i }))
+    await waitFor(() => {
+      // Auth card title + webhook-only helper text live inside the Webhook tab.
+      expect(screen.getByText('Autenticación')).toBeInTheDocument()
+      expect(
+        screen.getByText(/se envía en el header Authorization de los webhooks salientes/i),
+      ).toBeInTheDocument()
     })
   })
 
@@ -512,9 +532,8 @@ describe('AccountConfig page', () => {
     await waitFor(() => {
       expect(screen.getByText('Configuración de cuenta')).toBeInTheDocument()
     })
-    await user.click(screen.getByRole('tab', { name: /^Sesión$/i }))
 
-    // "Persistente" is the not-default session option.
+    // "Persistente" is the not-default session option, already visible in the default tab.
     const persistent = await screen.findByText('Persistente')
     // Walk up to find the Radio.Root container (rendered as a button by default).
     const card = persistent.closest('[data-slot]') ?? persistent.closest('button')

--- a/client/src/features/account/pages/AccountConfig.tsx
+++ b/client/src/features/account/pages/AccountConfig.tsx
@@ -11,152 +11,22 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shared/ui/di
 import { cn } from '@/shared/lib/utils'
 import { Radio } from '@base-ui/react/radio'
 import { RadioGroup } from '@base-ui/react/radio-group'
-import { ArrowLeft, Save, Info, Trash2, AlertTriangle, RotateCcw, ShieldAlert, Check, Bell, BellOff, TrendingDown, Lock, FileCheck, Settings as SettingsIcon, Terminal, KeyRound, Activity, Webhook, ShieldCheck } from 'lucide-react'
+import { ArrowLeft, Save, Info, Trash2, AlertTriangle, RotateCcw, ShieldAlert, Check, Bell, BellOff, TrendingDown, Lock, FileCheck, Settings as SettingsIcon, Terminal, KeyRound, Webhook, ListChecks } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useUser } from '@/features/user/hooks/useUser'
 import { useAccount, useDeleteAccount, useRestartAccount } from '../hooks/useAccounts'
 import { useAccountConfig, useUpsertAccountConfig } from '../hooks/useAccountConfig'
 import type { AuthType, PollingMethod, SessionType, LoginMode } from '../types'
+import {
+  FIELD_ORDER,
+  mapServerErrorToField,
+  resolveTabForField,
+  validateAccountConfigForm,
+  type AccountConfigForm,
+  type FormErrors,
+} from './accountConfigForm'
 
-interface AccountConfigForm {
-  pendingOrdersEndpoint: string
-  webhookUrl: string
-  pollingMethod: PollingMethod
-  pollingBody: string
-  authType: AuthType
-  authToken: string
-  bankUsername: string
-  bankPassword: string
-  webhookExtraFields: string
-  silentIngestion: boolean
-  sessionType: SessionType
-  loginMode: LoginMode
-}
-
-export type { AccountConfigForm }
-export type FormErrors = Partial<Record<keyof AccountConfigForm, string>>
 type TranslateFn = ReturnType<typeof useTranslation>['t']
-
-export const RESERVED_WEBHOOK_KEYS = ['external_id', 'status', 'amount', 'currency', 'name', 'id', 'received_at']
-
-export const FIELD_TO_TAB: Partial<Record<keyof AccountConfigForm, string>> = {
-  bankUsername: 'credentials',
-  bankPassword: 'credentials',
-  webhookUrl: 'webhooks',
-  webhookExtraFields: 'webhooks',
-  authToken: 'auth-orders',
-  pendingOrdersEndpoint: 'auth-orders',
-  pollingBody: 'auth-orders',
-}
-
-// Stable order — used to determine which tab to switch to (first error wins).
-export const FIELD_ORDER: (keyof AccountConfigForm)[] = [
-  'bankUsername',
-  'bankPassword',
-  'webhookUrl',
-  'webhookExtraFields',
-  'pendingOrdersEndpoint',
-  'authToken',
-  'pollingBody',
-]
-
-function isValidUrl(value: string): boolean {
-  try {
-    // eslint-disable-next-line no-new
-    new URL(value)
-    return true
-  } catch {
-    return false
-  }
-}
-
-interface ValidationContext {
-  mode: string | null | undefined
-  hasSavedCredential: boolean
-  t: TranslateFn
-}
-
-export function validateAccountConfigForm(form: AccountConfigForm, ctx: ValidationContext): FormErrors {
-  const { mode, hasSavedCredential, t } = ctx
-  const errors: FormErrors = {}
-
-  // Bank credentials
-  if (form.bankUsername.trim() === '') {
-    errors.bankUsername = t('accountConfig.errors.required')
-  }
-  if (!hasSavedCredential && form.bankPassword === '') {
-    errors.bankPassword = t('accountConfig.errors.required')
-  }
-
-  // Webhook URL — backend min(1) and URL format
-  const webhookUrl = form.webhookUrl.trim()
-  if (webhookUrl === '') {
-    errors.webhookUrl = t('accountConfig.errors.required')
-  } else if (!isValidUrl(webhookUrl)) {
-    errors.webhookUrl = t('accountConfig.errors.invalidUrl')
-  }
-
-  // Webhook extra fields (optional, but must be valid JSON object with no reserved keys)
-  const extraRaw = form.webhookExtraFields.trim()
-  if (extraRaw !== '') {
-    let parsed: unknown
-    try {
-      parsed = JSON.parse(extraRaw)
-    } catch {
-      errors.webhookExtraFields = t('accountConfig.errors.invalidJson')
-    }
-    if (errors.webhookExtraFields === undefined) {
-      if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-        errors.webhookExtraFields = t('accountConfig.errors.mustBeObject')
-      } else {
-        const conflicts = Object.keys(parsed as object).filter(k => RESERVED_WEBHOOK_KEYS.includes(k))
-        if (conflicts.length > 0) {
-          errors.webhookExtraFields = t('accountConfig.errors.reservedKeys', { keys: conflicts.join(', ') })
-        }
-      }
-    }
-  }
-
-  // Reconcile-mode requirements: pending orders endpoint + auth token
-  if (mode === 'reconcile') {
-    const endpoint = form.pendingOrdersEndpoint.trim()
-    if (endpoint === '') {
-      errors.pendingOrdersEndpoint = t('accountConfig.errors.pendingEndpointRequired')
-    } else if (!isValidUrl(endpoint)) {
-      errors.pendingOrdersEndpoint = t('accountConfig.errors.invalidUrl')
-    }
-
-    if (form.authToken.trim() === '') {
-      errors.authToken = t('accountConfig.errors.required')
-    }
-  }
-
-  // Polling body — only validate when POST + non-empty
-  if (form.pollingMethod === 'POST') {
-    const body = form.pollingBody.trim()
-    if (body !== '') {
-      try {
-        JSON.parse(body)
-      } catch {
-        errors.pollingBody = t('accountConfig.errors.invalidJson')
-      }
-    }
-  }
-
-  return errors
-}
-
-export function mapServerErrorToField(message: string): keyof AccountConfigForm | null {
-  const m = message.toLowerCase()
-  if (m.includes('webhook_extra_fields') || m.includes('extra_fields')) return 'webhookExtraFields'
-  if (m.includes('webhook_url') || m.includes('webhook url')) return 'webhookUrl'
-  if (m.includes('polling_body')) return 'pollingBody'
-  if (m.includes('pending_orders_endpoint') || m.includes('pending orders')) return 'pendingOrdersEndpoint'
-  if (m.includes('auth_token')) return 'authToken'
-  if (m.includes('bank_password')) return 'bankPassword'
-  if (m.includes('bank_username')) return 'bankUsername'
-  return null
-}
 
 export function AccountConfig() {
   const { accountId } = useParams<{ accountId: string }>()
@@ -184,7 +54,7 @@ export function AccountConfig() {
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [deleteConfirmName, setDeleteConfirmName] = useState('')
   const [deleteError, setDeleteError] = useState<string | null>(null)
-  const [activeTab, setActiveTab] = useState<string>('credentials')
+  const [activeTab, setActiveTab] = useState<string>('credentials-session')
 
   const { data: account } = useAccount(accountId)
   const { data, isLoading } = useAccountConfig(accountId)
@@ -260,7 +130,7 @@ export function AccountConfig() {
       setErrors(next)
       const firstField = FIELD_ORDER.find(k => next[k] !== undefined)
       if (firstField) {
-        const targetTab = FIELD_TO_TAB[firstField]
+        const targetTab = resolveTabForField(firstField, mode)
         if (targetTab && targetTab !== activeTab) setActiveTab(targetTab)
       }
       return
@@ -302,7 +172,7 @@ export function AccountConfig() {
           const field = mapServerErrorToField(message)
           if (field) {
             setErrors(prev => ({ ...prev, [field]: message }))
-            const targetTab = FIELD_TO_TAB[field]
+            const targetTab = resolveTabForField(field, mode)
             if (targetTab && targetTab !== activeTab) setActiveTab(targetTab)
           } else {
             setServerError(message)
@@ -404,28 +274,24 @@ export function AccountConfig() {
 
       <Tabs value={activeTab} onValueChange={setActiveTab} className="gap-6">
         <TabsList className="h-10 w-fit gap-1 p-1">
-          <TabsTrigger value="credentials" className="flex-none gap-2 px-4">
+          <TabsTrigger value="credentials-session" className="flex-none gap-2 px-4">
             <KeyRound className="size-4" />
-            {t('accountConfig.tabs.credentials')}
+            {t('accountConfig.tabs.credentialsSession')}
           </TabsTrigger>
-          <TabsTrigger value="session" className="flex-none gap-2 px-4">
-            <Activity className="size-4" />
-            {t('accountConfig.tabs.session')}
-          </TabsTrigger>
-          <TabsTrigger value="webhooks" className="flex-none gap-2 px-4">
+          <TabsTrigger value="webhook" className="flex-none gap-2 px-4">
             <Webhook className="size-4" />
-            {t('accountConfig.tabs.webhooks')}
+            {t('accountConfig.tabs.webhook')}
           </TabsTrigger>
           {mode === 'reconcile' && (
-            <TabsTrigger value="auth-orders" className="flex-none gap-2 px-4">
-              <ShieldCheck className="size-4" />
-              {t('accountConfig.tabs.authOrders')}
+            <TabsTrigger value="orders" className="flex-none gap-2 px-4">
+              <ListChecks className="size-4" />
+              {t('accountConfig.tabs.orders')}
             </TabsTrigger>
           )}
         </TabsList>
 
-        {/* Bank credentials */}
-        <TabsContent value="credentials" className="space-y-6">
+        {/* Bank credentials + session behaviour */}
+        <TabsContent value="credentials-session" className="space-y-6">
           <Card>
             <CardHeader><CardTitle>{t('accountConfig.bankCredentials')}</CardTitle></CardHeader>
             <CardContent className="space-y-4">
@@ -445,10 +311,7 @@ export function AccountConfig() {
               </div>
             </CardContent>
           </Card>
-        </TabsContent>
 
-        {/* Session behaviour */}
-        <TabsContent value="session" className="space-y-6">
           <Card>
             <CardHeader><CardTitle>{t('accountConfig.session')}</CardTitle></CardHeader>
             <CardContent className="space-y-5">
@@ -494,8 +357,8 @@ export function AccountConfig() {
           </Card>
         </TabsContent>
 
-        {/* Webhooks */}
-        <TabsContent value="webhooks" className="space-y-6">
+        {/* Webhook */}
+        <TabsContent value="webhook" className="space-y-6">
           <Card>
             <CardHeader>
               <CardTitle>{t('accountConfig.webhooks')}</CardTitle>
@@ -582,39 +445,22 @@ export function AccountConfig() {
               </div>
             </CardContent>
           </Card>
+
+          {mode !== 'reconcile' && (
+            <AuthCard
+              form={form}
+              errors={errors}
+              t={t}
+              field={field}
+              setForm={setForm}
+              hintKey="accountConfig.authHintWebhookOnly"
+            />
+          )}
         </TabsContent>
 
-        {/* Auth & Orders (reconcile mode only) */}
+        {/* Orders (reconcile mode only) */}
         {mode === 'reconcile' && (
-          <TabsContent value="auth-orders" className="space-y-6">
-            <Card>
-              <CardHeader><CardTitle>{t('accountConfig.auth')}</CardTitle></CardHeader>
-              <CardContent className="space-y-4">
-                <div className="space-y-2">
-                  <Label>{t('accountConfig.authType')}</Label>
-                  <Select
-                    value={form.authType}
-                    onValueChange={v => setForm(f => ({ ...f, authType: v as AuthType }))}
-                  >
-                    <SelectTrigger>
-                      <SelectValue>{form.authType === 'bearer' ? 'Bearer token' : 'API Key'}</SelectValue>
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="bearer">Bearer token</SelectItem>
-                      <SelectItem value="api_key">API Key</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-2">
-                  <Label>{t('accountConfig.tokenKey')}</Label>
-                  <Input type="password" {...field('authToken')} />
-                  {errors.authToken && (
-                    <p className="text-xs text-destructive">{errors.authToken}</p>
-                  )}
-                </div>
-              </CardContent>
-            </Card>
-
+          <TabsContent value="orders" className="space-y-6">
             <Card>
               <CardHeader><CardTitle>{t('accountConfig.orderIngestion')}</CardTitle></CardHeader>
               <CardContent className="space-y-4">
@@ -678,6 +524,15 @@ export function AccountConfig() {
                 )}
               </CardContent>
             </Card>
+
+            <AuthCard
+              form={form}
+              errors={errors}
+              t={t}
+              field={field}
+              setForm={setForm}
+              hintKey="accountConfig.authHintPollingAndWebhook"
+            />
           </TabsContent>
         )}
       </Tabs>
@@ -842,5 +697,51 @@ function OptionCard({ value, title, description }: {
       </div>
       <p className="text-xs text-muted-foreground">{description}</p>
     </Radio.Root>
+  )
+}
+
+interface AuthCardProps {
+  form: AccountConfigForm
+  errors: FormErrors
+  t: TranslateFn
+  field: <K extends keyof AccountConfigForm>(key: K) => {
+    value: string
+    'aria-invalid': true | undefined
+    onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void
+  }
+  setForm: React.Dispatch<React.SetStateAction<AccountConfigForm>>
+  hintKey: string
+}
+
+function AuthCard({ form, errors, t, field, setForm, hintKey }: AuthCardProps) {
+  return (
+    <Card>
+      <CardHeader><CardTitle>{t('accountConfig.auth')}</CardTitle></CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-xs text-muted-foreground">{t(hintKey)}</p>
+        <div className="space-y-2">
+          <Label>{t('accountConfig.authType')}</Label>
+          <Select
+            value={form.authType}
+            onValueChange={v => setForm(f => ({ ...f, authType: v as AuthType }))}
+          >
+            <SelectTrigger>
+              <SelectValue>{form.authType === 'bearer' ? 'Bearer token' : 'API Key'}</SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="bearer">Bearer token</SelectItem>
+              <SelectItem value="api_key">API Key</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-2">
+          <Label>{t('accountConfig.tokenKey')}</Label>
+          <Input type="password" {...field('authToken')} />
+          {errors.authToken && (
+            <p className="text-xs text-destructive">{errors.authToken}</p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
   )
 }

--- a/client/src/features/account/pages/AccountConfig.tsx
+++ b/client/src/features/account/pages/AccountConfig.tsx
@@ -456,17 +456,6 @@ export function AccountConfig() {
               </div>
             </CardContent>
           </Card>
-
-          {mode !== 'reconcile' && (
-            <AuthCard
-              form={form}
-              errors={errors}
-              t={t}
-              field={field}
-              setForm={setForm}
-              hintKey="accountConfig.authHintWebhookOnly"
-            />
-          )}
         </TabsContent>
 
         {/* Orders (reconcile mode only) */}

--- a/client/src/features/account/pages/AccountConfig.tsx
+++ b/client/src/features/account/pages/AccountConfig.tsx
@@ -340,7 +340,8 @@ export function AccountConfig() {
   if (isLoading) return <div className="p-8 text-muted-foreground text-sm">{t('accountConfig.loading')}</div>
 
   return (
-    <div className="px-6 lg:px-8 py-8 space-y-6 pb-28">
+    <div className="flex min-h-full flex-col">
+      <div className="flex flex-1 flex-col gap-6 px-6 pt-8 pb-6 lg:px-8">
       <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-3 min-w-0">
           <Button variant="ghost" size="sm" onClick={() => navigate('/accounts')}>
@@ -354,10 +355,9 @@ export function AccountConfig() {
         </div>
         <Button
           variant="destructive"
-          size="sm"
           onClick={() => openDeleteDialog(true)}
           disabled={!account}
-          className="gap-2 shrink-0"
+          className="h-9 shrink-0 gap-2 px-4"
         >
           <Trash2 className="size-4" />
           {t('accountConfig.danger.deleteButton')}
@@ -681,9 +681,9 @@ export function AccountConfig() {
           </TabsContent>
         )}
       </Tabs>
+      </div>
 
-      {/* Sticky save bar — stays visible regardless of active tab */}
-      <div className="sticky bottom-0 -mx-6 lg:-mx-8 mt-2 border-t border-border/60 bg-background/80 px-6 lg:px-8 py-3 supports-backdrop-filter:backdrop-blur">
+      <div className="sticky bottom-0 z-10 shrink-0 border-t border-border/60 bg-background/95 px-6 py-4 lg:px-8 supports-backdrop-filter:backdrop-blur">
         {serverError && (
           <div className="mb-3 relative overflow-hidden rounded-md border border-destructive/30 bg-destructive/5">
             <div className="absolute inset-y-0 left-0 w-1 bg-destructive" />
@@ -702,7 +702,12 @@ export function AccountConfig() {
           </div>
         )}
         <div className="flex justify-end">
-          <Button onClick={handleSave} disabled={save.isPending} className="gap-2">
+          <Button
+            onClick={handleSave}
+            disabled={save.isPending}
+            size="lg"
+            className="h-10 min-w-44 gap-2 px-6 font-medium"
+          >
             <Save className="size-4" />
             {save.isPending ? t('accountConfig.saving') : saved ? t('accountConfig.saved') : t('accountConfig.save')}
           </Button>

--- a/client/src/features/account/pages/AccountConfig.tsx
+++ b/client/src/features/account/pages/AccountConfig.tsx
@@ -461,6 +461,15 @@ export function AccountConfig() {
         {/* Orders (reconcile mode only) */}
         {mode === 'reconcile' && (
           <TabsContent value="orders" className="space-y-6">
+            <AuthCard
+              form={form}
+              errors={errors}
+              t={t}
+              field={field}
+              setForm={setForm}
+              hintKey="accountConfig.authHintPollingAndWebhook"
+            />
+
             <Card>
               <CardHeader><CardTitle>{t('accountConfig.orderIngestion')}</CardTitle></CardHeader>
               <CardContent className="space-y-4">

--- a/client/src/features/account/pages/AccountConfig.tsx
+++ b/client/src/features/account/pages/AccountConfig.tsx
@@ -533,15 +533,6 @@ export function AccountConfig() {
                 )}
               </CardContent>
             </Card>
-
-            <AuthCard
-              form={form}
-              errors={errors}
-              t={t}
-              field={field}
-              setForm={setForm}
-              hintKey="accountConfig.authHintPollingAndWebhook"
-            />
           </TabsContent>
         )}
       </Tabs>

--- a/client/src/features/account/pages/AccountConfig.tsx
+++ b/client/src/features/account/pages/AccountConfig.tsx
@@ -278,16 +278,16 @@ export function AccountConfig() {
             <KeyRound className="size-4" />
             {t('accountConfig.tabs.credentialsSession')}
           </TabsTrigger>
-          <TabsTrigger value="webhook" className="flex-none gap-2 px-4">
-            <Webhook className="size-4" />
-            {t('accountConfig.tabs.webhook')}
-          </TabsTrigger>
           {mode === 'reconcile' && (
             <TabsTrigger value="orders" className="flex-none gap-2 px-4">
               <ListChecks className="size-4" />
               {t('accountConfig.tabs.orders')}
             </TabsTrigger>
           )}
+          <TabsTrigger value="webhook" className="flex-none gap-2 px-4">
+            <Webhook className="size-4" />
+            {t('accountConfig.tabs.webhook')}
+          </TabsTrigger>
         </TabsList>
 
         {/* Bank credentials + session behaviour */}
@@ -359,6 +359,17 @@ export function AccountConfig() {
 
         {/* Webhook */}
         <TabsContent value="webhook" className="space-y-6">
+          {mode !== 'reconcile' && (
+            <AuthCard
+              form={form}
+              errors={errors}
+              t={t}
+              field={field}
+              setForm={setForm}
+              hintKey="accountConfig.authHintWebhookOnly"
+            />
+          )}
+
           <Card>
             <CardHeader>
               <CardTitle>{t('accountConfig.webhooks')}</CardTitle>

--- a/client/src/features/account/pages/accountConfigForm.ts
+++ b/client/src/features/account/pages/accountConfigForm.ts
@@ -1,0 +1,148 @@
+import type { AuthType, PollingMethod, SessionType, LoginMode } from '../types'
+
+export interface AccountConfigForm {
+  pendingOrdersEndpoint: string
+  webhookUrl: string
+  pollingMethod: PollingMethod
+  pollingBody: string
+  authType: AuthType
+  authToken: string
+  bankUsername: string
+  bankPassword: string
+  webhookExtraFields: string
+  silentIngestion: boolean
+  sessionType: SessionType
+  loginMode: LoginMode
+}
+
+export type FormErrors = Partial<Record<keyof AccountConfigForm, string>>
+
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string
+
+export const RESERVED_WEBHOOK_KEYS = ['external_id', 'status', 'amount', 'currency', 'name', 'id', 'received_at']
+
+export const FIELD_TO_TAB: Partial<Record<keyof AccountConfigForm, string>> = {
+  bankUsername: 'credentials-session',
+  bankPassword: 'credentials-session',
+  webhookUrl: 'webhook',
+  webhookExtraFields: 'webhook',
+  pendingOrdersEndpoint: 'orders',
+  pollingBody: 'orders',
+  // authToken renders in 'orders' (reconcile) or 'webhook' (passthrough); resolved via resolveTabForField below.
+}
+
+// Stable order — used to determine which tab to switch to (first error wins).
+export const FIELD_ORDER: (keyof AccountConfigForm)[] = [
+  'bankUsername',
+  'bankPassword',
+  'webhookUrl',
+  'webhookExtraFields',
+  'pendingOrdersEndpoint',
+  'authToken',
+  'pollingBody',
+]
+
+export function resolveTabForField(
+  field: keyof AccountConfigForm,
+  mode: string | null | undefined,
+): string | undefined {
+  if (field === 'authToken') return mode === 'reconcile' ? 'orders' : 'webhook'
+  return FIELD_TO_TAB[field]
+}
+
+function isValidUrl(value: string): boolean {
+  try {
+    new URL(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+interface ValidationContext {
+  mode: string | null | undefined
+  hasSavedCredential: boolean
+  t: TranslateFn
+}
+
+export function validateAccountConfigForm(form: AccountConfigForm, ctx: ValidationContext): FormErrors {
+  const { mode, hasSavedCredential, t } = ctx
+  const errors: FormErrors = {}
+
+  // Bank credentials
+  if (form.bankUsername.trim() === '') {
+    errors.bankUsername = t('accountConfig.errors.required')
+  }
+  if (!hasSavedCredential && form.bankPassword === '') {
+    errors.bankPassword = t('accountConfig.errors.required')
+  }
+
+  // Webhook URL — backend min(1) and URL format
+  const webhookUrl = form.webhookUrl.trim()
+  if (webhookUrl === '') {
+    errors.webhookUrl = t('accountConfig.errors.required')
+  } else if (!isValidUrl(webhookUrl)) {
+    errors.webhookUrl = t('accountConfig.errors.invalidUrl')
+  }
+
+  // Webhook extra fields (optional, but must be valid JSON object with no reserved keys)
+  const extraRaw = form.webhookExtraFields.trim()
+  if (extraRaw !== '') {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(extraRaw)
+    } catch {
+      errors.webhookExtraFields = t('accountConfig.errors.invalidJson')
+    }
+    if (errors.webhookExtraFields === undefined) {
+      if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        errors.webhookExtraFields = t('accountConfig.errors.mustBeObject')
+      } else {
+        const conflicts = Object.keys(parsed as object).filter(k => RESERVED_WEBHOOK_KEYS.includes(k))
+        if (conflicts.length > 0) {
+          errors.webhookExtraFields = t('accountConfig.errors.reservedKeys', { keys: conflicts.join(', ') })
+        }
+      }
+    }
+  }
+
+  // Reconcile-mode requirements: pending orders endpoint + auth token
+  if (mode === 'reconcile') {
+    const endpoint = form.pendingOrdersEndpoint.trim()
+    if (endpoint === '') {
+      errors.pendingOrdersEndpoint = t('accountConfig.errors.pendingEndpointRequired')
+    } else if (!isValidUrl(endpoint)) {
+      errors.pendingOrdersEndpoint = t('accountConfig.errors.invalidUrl')
+    }
+
+    if (form.authToken.trim() === '') {
+      errors.authToken = t('accountConfig.errors.required')
+    }
+  }
+
+  // Polling body — only validate when POST + non-empty
+  if (form.pollingMethod === 'POST') {
+    const body = form.pollingBody.trim()
+    if (body !== '') {
+      try {
+        JSON.parse(body)
+      } catch {
+        errors.pollingBody = t('accountConfig.errors.invalidJson')
+      }
+    }
+  }
+
+  return errors
+}
+
+export function mapServerErrorToField(message: string): keyof AccountConfigForm | null {
+  const m = message.toLowerCase()
+  if (m.includes('webhook_extra_fields') || m.includes('extra_fields')) return 'webhookExtraFields'
+  if (m.includes('webhook_url') || m.includes('webhook url')) return 'webhookUrl'
+  if (m.includes('polling_body')) return 'pollingBody'
+  if (m.includes('pending_orders_endpoint') || m.includes('pending orders')) return 'pendingOrdersEndpoint'
+  if (m.includes('auth_token')) return 'authToken'
+  if (m.includes('bank_password')) return 'bankPassword'
+  if (m.includes('bank_username')) return 'bankUsername'
+  return null
+}

--- a/client/src/shared/layout/AppLayout.tsx
+++ b/client/src/shared/layout/AppLayout.tsx
@@ -321,7 +321,7 @@ export function AppLayout() {
       </aside>
 
       {/* Main content */}
-      <main className="relative z-10 flex-1 overflow-auto" style={{ color: 'oklch(0.9 0 0)' }}>
+      <main className="relative z-10 flex flex-1 flex-col overflow-auto" style={{ color: 'oklch(0.9 0 0)' }}>
         <Outlet />
       </main>
 


### PR DESCRIPTION
This pull request refactors the Account Configuration UI to simplify and clarify the tab structure, improve field-to-tab mapping logic, and update translations and tests accordingly. The main changes include merging credentials and session into a single tab, splitting webhooks and orders into their own tabs, and updating logic to dynamically determine which tab a field belongs to. Translations and tests were updated to match the new tab structure.

**Tab Structure and UI Refactor:**

* Merged the "Credentials" and "Session" sections into a single `credentials-session` tab, removed the separate "Session" tab, and updated the UI to reflect this change. The "Webhooks" tab is now "Webhook", and "Auth & Orders" is now "Orders". Tabs are shown/hidden based on the account mode (e.g., "Orders" only in reconcile mode). (`AccountConfig.tsx`, `en.json`, `es.json`) [[1]](diffhunk://#diff-58b1d62fc78d2527bd3ffde2cedddb4f7ffff29f8d456912dcffbe5e4e778900L187-R57) [[2]](diffhunk://#diff-58b1d62fc78d2527bd3ffde2cedddb4f7ffff29f8d456912dcffbe5e4e778900L407-R294) [[3]](diffhunk://#diff-58b1d62fc78d2527bd3ffde2cedddb4f7ffff29f8d456912dcffbe5e4e778900L448-L451) [[4]](diffhunk://#diff-92e95284f49083690b86157bdf68a5ba3f982526f36953c8e63aa5b44d7d8bb4L83-R87) [[5]](diffhunk://#diff-2128e1b47ab9484707b0bb69ced285c7894778d62b5343101a187e0f813cdf47L83-R87)

**Field-to-Tab Mapping Logic:**

* Replaced the static `FIELD_TO_TAB` mapping with a dynamic `resolveTabForField` function, which determines the correct tab for a field based on the current mode (e.g., "authToken" appears in "Orders" for reconcile mode and in "Webhook" for passthrough). Updated error handling and tab switching logic to use this function. (`accountConfigForm`, `AccountConfig.tsx`, tests) [[1]](diffhunk://#diff-58b1d62fc78d2527bd3ffde2cedddb4f7ffff29f8d456912dcffbe5e4e778900L263-R133) [[2]](diffhunk://#diff-58b1d62fc78d2527bd3ffde2cedddb4f7ffff29f8d456912dcffbe5e4e778900L305-R175) [[3]](diffhunk://#diff-d3617f22fac17376550ce714cd158fdde27e75a57d282c287ffb6e6b79abb105L220-R240)

**Translations:**

* Updated English and Spanish translations to match the new tab names and added helper texts for authentication fields, clarifying their usage in different modes. (`en.json`, `es.json`) [[1]](diffhunk://#diff-92e95284f49083690b86157bdf68a5ba3f982526f36953c8e63aa5b44d7d8bb4R57-R58) [[2]](diffhunk://#diff-2128e1b47ab9484707b0bb69ced285c7894778d62b5343101a187e0f813cdf47R57-R58)

**Test Updates:**

* Refactored tests to use the new tab names, validate the new tab structure and field-to-tab mappings, and ensure that the UI and validation logic behave as expected in both reconcile and passthrough modes. (`AccountConfig.test.tsx`) [[1]](diffhunk://#diff-d3617f22fac17376550ce714cd158fdde27e75a57d282c287ffb6e6b79abb105L444-R451) [[2]](diffhunk://#diff-d3617f22fac17376550ce714cd158fdde27e75a57d282c287ffb6e6b79abb105L457-R463) [[3]](diffhunk://#diff-d3617f22fac17376550ce714cd158fdde27e75a57d282c287ffb6e6b79abb105L468-R496) [[4]](diffhunk://#diff-d3617f22fac17376550ce714cd158fdde27e75a57d282c287ffb6e6b79abb105L505-R525) [[5]](diffhunk://#diff-d3617f22fac17376550ce714cd158fdde27e75a57d282c287ffb6e6b79abb105L515-R536)

**Code Organization:**

* Moved form logic (types, validation, mapping) from `AccountConfig.tsx` into a new `accountConfigForm` module for better separation of concerns and maintainability. (`AccountConfig.tsx`, `accountConfigForm`) [[1]](diffhunk://#diff-d3617f22fac17376550ce714cd158fdde27e75a57d282c287ffb6e6b79abb105R11-R19) [[2]](diffhunk://#diff-58b1d62fc78d2527bd3ffde2cedddb4f7ffff29f8d456912dcffbe5e4e778900L14-L160)

These changes collectively simplify the configuration experience and make the UI and codebase more maintainable and intuitive.