### PR TITLE
Fix self-referential FK in truncateAll for integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/
 *.log
 logs/
 playwright-profiles/
+coverage/
+.vitest-reports/

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -10,6 +10,8 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+coverage
+.vitest-reports
 *.local
 
 # Editor directories and files

--- a/tests/integration/helpers/testDb.ts
+++ b/tests/integration/helpers/testDb.ts
@@ -42,6 +42,9 @@ export const CANONICAL_BANK_ID = 'a1000000-0000-0000-0000-000000000001'
 export async function truncateAll(): Promise<void> {
   const p = getTestPool()
   await p.query(`TRUNCATE ${ALL_DOMAIN_TABLES.join(', ')} RESTART IDENTITY CASCADE`)
+  // Break self-referential FKs (bank_scripts.base_script_id) so the DELETE below
+  // can drop ancestor rows without violating the constraint.
+  await p.query(`UPDATE bank_scripts SET base_script_id = NULL`)
   // Drop any test-created bank_scripts (keep only the canonical seed).
   await p.query(`DELETE FROM bank_scripts WHERE id <> $1`, [CANONICAL_SCRIPT_ID])
   // Drop any test-created banks (keep only the canonical seed).


### PR DESCRIPTION
This pull request makes improvements to the testing environment and project configuration to ensure more reliable test runs and cleaner project structure. The main changes include updating the `.gitignore` to exclude new test output directories and enhancing the `truncateAll` helper to better handle foreign key constraints during test database cleanup.

**Testing environment improvements:**

* [`tests/integration/helpers/testDb.ts`](diffhunk://#diff-d3858c49c572744249252f42a45fbaee25c76b77643a75354185e6425357e6d9R45-R47): Updated the `truncateAll` function to set `base_script_id` to `NULL` on all `bank_scripts` records before deletion, preventing foreign key constraint violations when cleaning up test data.

**Project configuration:**

* [`client/.gitignore`](diffhunk://#diff-f8fc230f40372bc0cc3003a0913de478a6b6cd220762e6896942c383730974c8R13-R14): Added `coverage` and `.vitest-reports` to the ignore list to exclude test coverage and Vitest report directories from version control.