### PR TITLE
Add Vitest config and tests for shared errors and domain events

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:all": "vitest run --config vitest.all.config.ts",
+    "test:all:coverage": "vitest run --config vitest.all.config.ts --coverage",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json",
     "dev": "tsx watch src/index.ts",
     "build": "tsc && cp -r src/contexts/script-engine/infrastructure/scripts dist/contexts/script-engine/infrastructure/scripts",

--- a/src/shared/domain/base.test.ts
+++ b/src/shared/domain/base.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { AggregateRoot } from './AggregateRoot.js'
+import { Entity } from './Entity.js'
+import { ValueObject } from './ValueObject.js'
+import type { DomainEvent } from '../events/DomainEvent.js'
+
+class TestEntity extends Entity<string> {}
+
+class TestValueObject extends ValueObject<{ a: number; b: string }> {
+  get a() {
+    return this.props.a
+  }
+}
+
+class TestAggregate extends AggregateRoot<string> {
+  emit(event: DomainEvent) {
+    this.addDomainEvent(event)
+  }
+}
+
+const fakeEvent = (type = 'Test'): DomainEvent => ({
+  eventType: type,
+  occurredAt: new Date(),
+  aggregateId: 'agg-1',
+})
+
+describe('Entity', () => {
+  it('exposes id', () => {
+    const e = new TestEntity('id-1')
+    expect(e.id).toBe('id-1')
+  })
+
+  it('is equal to another entity with the same id', () => {
+    const a = new TestEntity('x')
+    const b = new TestEntity('x')
+    expect(a.equals(b)).toBe(true)
+  })
+
+  it('is not equal to an entity with a different id', () => {
+    const a = new TestEntity('x')
+    const b = new TestEntity('y')
+    expect(a.equals(b)).toBe(false)
+  })
+})
+
+describe('ValueObject', () => {
+  it('freezes props after construction', () => {
+    const vo = new TestValueObject({ a: 1, b: 'x' })
+    expect(Object.isFrozen((vo as unknown as { props: object }).props)).toBe(true)
+  })
+
+  it('is equal when props are structurally equal', () => {
+    const a = new TestValueObject({ a: 1, b: 'x' })
+    const b = new TestValueObject({ a: 1, b: 'x' })
+    expect(a.equals(b)).toBe(true)
+  })
+
+  it('is not equal when props differ', () => {
+    const a = new TestValueObject({ a: 1, b: 'x' })
+    const b = new TestValueObject({ a: 2, b: 'x' })
+    expect(a.equals(b)).toBe(false)
+  })
+})
+
+describe('AggregateRoot', () => {
+  it('starts with no domain events', () => {
+    const agg = new TestAggregate('id-1')
+    expect(agg.domainEvents).toEqual([])
+  })
+
+  it('accumulates emitted events', () => {
+    const agg = new TestAggregate('id-1')
+    const e1 = fakeEvent('A')
+    const e2 = fakeEvent('B')
+    agg.emit(e1)
+    agg.emit(e2)
+    expect(agg.domainEvents).toEqual([e1, e2])
+  })
+
+  it('clears accumulated events', () => {
+    const agg = new TestAggregate('id-1')
+    agg.emit(fakeEvent())
+    agg.clearDomainEvents()
+    expect(agg.domainEvents).toEqual([])
+  })
+})

--- a/src/shared/errors/errors.test.ts
+++ b/src/shared/errors/errors.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { ConflictError } from './ConflictError.js'
+import { DomainError } from './DomainError.js'
+import { ForbiddenError } from './ForbiddenError.js'
+import { NotFoundError } from './NotFoundError.js'
+import { UnauthorizedError } from './UnauthorizedError.js'
+import { ValidationError } from './ValidationError.js'
+
+describe('shared errors', () => {
+  const cases = [
+    { Cls: ConflictError, code: 'CONFLICT', statusCode: 409 },
+    { Cls: ForbiddenError, code: 'FORBIDDEN', statusCode: 403 },
+    { Cls: NotFoundError, code: 'NOT_FOUND', statusCode: 404 },
+    { Cls: UnauthorizedError, code: 'UNAUTHORIZED', statusCode: 401 },
+    { Cls: ValidationError, code: 'VALIDATION_ERROR', statusCode: 400 },
+  ] as const
+
+  for (const { Cls, code, statusCode } of cases) {
+    describe(Cls.name, () => {
+      it('captures message and is throwable', () => {
+        const err = new Cls('boom')
+        expect(err).toBeInstanceOf(DomainError)
+        expect(err).toBeInstanceOf(Error)
+        expect(err.message).toBe('boom')
+        expect(err.name).toBe(Cls.name)
+        expect(err.code).toBe(code)
+        expect(err.statusCode).toBe(statusCode)
+        expect(err.details).toBeUndefined()
+      })
+
+      it('preserves optional details', () => {
+        const details = { field: 'email' }
+        const err = new Cls('bad', details)
+        expect(err.details).toEqual(details)
+      })
+
+      it('is throwable and catchable as DomainError', () => {
+        expect(() => {
+          throw new Cls('explode')
+        }).toThrow(DomainError)
+      })
+    })
+  }
+})

--- a/src/shared/events/EventBus.test.ts
+++ b/src/shared/events/EventBus.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { EventBus, InMemoryEventBus } from './EventBus.js'
+
+describe('EventBus barrel', () => {
+  it('exports a default in-memory singleton', () => {
+    expect(EventBus).toBeInstanceOf(InMemoryEventBus)
+  })
+
+  it('re-exports InMemoryEventBus', () => {
+    expect(InMemoryEventBus).toBeTypeOf('function')
+  })
+})

--- a/src/shared/events/events/domainEvents.test.ts
+++ b/src/shared/events/events/domainEvents.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { AccountCreatedEvent } from './AccountCreated.event.js'
+import { ConciliationCancelledEvent } from './ConciliationCancelled.event.js'
+import { ConciliationExpiredEvent } from './ConciliationExpired.event.js'
+import { ConciliationFailedEvent } from './ConciliationFailed.event.js'
+import { ConciliationMatchedEvent } from './ConciliationMatched.event.js'
+import { OperationModeChangedEvent } from './OperationModeChanged.event.js'
+import { ScrapeRunFailedEvent } from './ScrapeRunFailed.event.js'
+import { ScriptPromotedEvent } from './ScriptPromoted.event.js'
+import { TransactionIngestedEvent } from './TransactionIngested.event.js'
+
+describe('domain events', () => {
+  it('AccountCreatedEvent captures fields', () => {
+    const e = new AccountCreatedEvent('acc-1', 'mi-dinero', 'My Account')
+    expect(e.eventType).toBe('AccountCreated')
+    expect(e.aggregateId).toBe('acc-1')
+    expect(e.bank).toBe('mi-dinero')
+    expect(e.name).toBe('My Account')
+    expect(e.occurredAt).toBeInstanceOf(Date)
+  })
+
+  it('AccountCreatedEvent allows undefined name', () => {
+    const e = new AccountCreatedEvent('acc-1', 'mi-dinero', undefined)
+    expect(e.name).toBeUndefined()
+  })
+
+  it('ConciliationCancelledEvent captures fields', () => {
+    const e = new ConciliationCancelledEvent('req-1', 'acc-1')
+    expect(e.eventType).toBe('ConciliationCancelled')
+    expect(e.aggregateId).toBe('req-1')
+    expect(e.accountId).toBe('acc-1')
+    expect(e.occurredAt).toBeInstanceOf(Date)
+  })
+
+  it('ConciliationExpiredEvent captures fields', () => {
+    const e = new ConciliationExpiredEvent('req-1', 'acc-1')
+    expect(e.eventType).toBe('ConciliationExpired')
+    expect(e.aggregateId).toBe('req-1')
+    expect(e.accountId).toBe('acc-1')
+  })
+
+  it('ConciliationFailedEvent captures failureType', () => {
+    const e = new ConciliationFailedEvent('req-1', 'acc-1', 'not_found')
+    expect(e.eventType).toBe('ConciliationFailed')
+    expect(e.failureType).toBe('not_found')
+  })
+
+  it('ConciliationMatchedEvent captures bankTransactionId', () => {
+    const e = new ConciliationMatchedEvent('req-1', 'acc-1', 'tx-1')
+    expect(e.eventType).toBe('ConciliationMatched')
+    expect(e.bankTransactionId).toBe('tx-1')
+  })
+
+  it('OperationModeChangedEvent captures mode', () => {
+    const e = new OperationModeChangedEvent('user-1', 'passthrough')
+    expect(e.eventType).toBe('OperationModeChanged')
+    expect(e.mode).toBe('passthrough')
+  })
+
+  it('ScrapeRunFailedEvent captures all fields', () => {
+    const e = new ScrapeRunFailedEvent('run-1', 'acc-1', 'script-1', 'auth_failed', 'bad creds')
+    expect(e.eventType).toBe('ScrapeRunFailed')
+    expect(e.scriptId).toBe('script-1')
+    expect(e.failureType).toBe('auth_failed')
+    expect(e.errorMessage).toBe('bad creds')
+  })
+
+  it('ScriptPromotedEvent captures version metadata', () => {
+    const e = new ScriptPromotedEvent('script-1', 'mi-dinero', 'extract_transactions', '2.0.1')
+    expect(e.eventType).toBe('ScriptPromoted')
+    expect(e.bank).toBe('mi-dinero')
+    expect(e.flowType).toBe('extract_transactions')
+    expect(e.version).toBe('2.0.1')
+  })
+
+  it('TransactionIngestedEvent captures amount/currency/receivedAt', () => {
+    const receivedAt = new Date('2024-01-15T10:00:00Z')
+    const e = new TransactionIngestedEvent('tx-1', 'acc-1', 1500, 'ARS', receivedAt)
+    expect(e.eventType).toBe('TransactionIngested')
+    expect(e.amount).toBe(1500)
+    expect(e.currency).toBe('ARS')
+    expect(e.receivedAt).toBe(receivedAt)
+  })
+})

--- a/vitest.all.config.ts
+++ b/vitest.all.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config'
+
+// Aggregates unit and integration test projects under a single run so coverage
+// numbers reflect the union of both suites. Each project keeps its own setup
+// and execution semantics (the unit suite runs in parallel; the integration
+// suite is serial against a real Postgres). Run with:
+//   pnpm test:all
+//   pnpm test:all -- --coverage
+export default defineConfig({
+  test: {
+    projects: ['./vitest.config.ts', './vitest.integration.config.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: [
+        'src/**/*.test.ts',
+        'src/**/index.ts',
+        'src/shared/infrastructure/db/migrations/**',
+      ],
+      reporter: ['text', 'text-summary', 'html'],
+    },
+  },
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
+    name: 'unit',
     include: ['src/**/*.test.ts', 'tests/**/*.test.ts'],
     exclude: ['**/node_modules/**', '**/dist/**', 'client/**', 'tests/integration/**'],
     environment: 'node',

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
+    name: 'integration',
     include: ['tests/integration/**/*.integration.test.ts'],
     exclude: ['**/node_modules/**', '**/dist/**', 'client/**'],
     environment: 'node',


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the shared domain, error, and event modules, and introduces improved test aggregation and coverage reporting. It also updates test configuration files to better distinguish between unit and integration test suites.

**Test Coverage and Configuration Improvements:**

* Added new scripts `test:all` and `test:all:coverage` to `package.json` for running all tests (unit and integration) together with unified coverage reporting.
* Introduced `vitest.all.config.ts` to aggregate both unit and integration test projects, ensuring combined coverage statistics and consistent reporting.
* Updated `vitest.config.ts` and `vitest.integration.config.ts` to assign explicit names to the unit and integration test projects, improving clarity in test outputs. [[1]](diffhunk://#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92R5) [[2]](diffhunk://#diff-3c8d49f04351b39c4c3cc793ee7c14a0abf725bb74155b3a617ca6b75162fa11R5)

**New and Expanded Test Suites:**

* Added `src/shared/domain/base.test.ts` to cover core domain primitives (`Entity`, `ValueObject`, `AggregateRoot`) with equality, immutability, and domain event emission tests.
* Added `src/shared/errors/errors.test.ts` to verify behavior and properties of custom error classes, including correct inheritance, status codes, and details handling.
* Added `src/shared/events/EventBus.test.ts` to ensure correct export and singleton behavior of the event bus module.
* Added `src/shared/events/events/domainEvents.test.ts` to test all domain event classes for correct field assignment and instantiation.