### PR TITLE
Persist and enhance webhook delivery attempts with dead-lettering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,9 @@ PLAYWRIGHT_HEADLESS=true
 # --- Outbound HTTP timeouts (ms, optional) ---
 # WEBHOOK_TIMEOUT_MS=15000
 # POLLING_TIMEOUT_MS=15000
+
+# --- Webhook delivery retries (optional) ---
+# Attempts and exponential backoff base for the webhook queues. Defaults below
+# span ~6 hours of retries before a delivery is dead-lettered.
+# WEBHOOK_QUEUE_ATTEMPTS=12
+# WEBHOOK_QUEUE_BACKOFF_MS=10000

--- a/src/api/routes/bank-movements.routes.ts
+++ b/src/api/routes/bank-movements.routes.ts
@@ -43,6 +43,14 @@ export function buildBankMovementsRouter(deps: BankMovementsRouterDeps): Router 
     res.json(movements)
   }))
 
+  router.get('/dead-letters', controller(async (req: AuthRequest, res) => {
+    const userId = requireUserId(req)
+    const { accountId } = validateParams(req, paramsSchema)
+    if (!(await ownsAccount(accountId, userId))) throw new ForbiddenError('Account not found')
+    const deadLetters = await deps.banking.listWebhookDeadLetters.execute(accountId)
+    res.json(deadLetters)
+  }))
+
   router.post('/:movementId/notify', controller(async (req: AuthRequest, res) => {
     const userId = requireUserId(req)
     const { accountId, movementId } = validateParams(req, paramsWithMovementSchema)

--- a/src/composition/bankingModule.test.ts
+++ b/src/composition/bankingModule.test.ts
@@ -96,6 +96,18 @@ describe('buildBankingModule', () => {
     )
   })
 
+  it('enqueueNotify removes a stale job before re-adding so a re-drive is not a no-op', async () => {
+    const mod = buildBankingModule(makeContainer())
+    const queue = (Queues as any).bankMovementWebhook
+    await (mod.reNotifyBankMovement as any).deps.enqueueNotify('tx-1')
+    // remove(jobId) must precede add(jobId): a failed job kept by removeOnFail:false
+    // would otherwise make the re-add a silent no-op.
+    expect(queue.remove).toHaveBeenCalledWith('bank-movement-webhook_tx-1')
+    const removeOrder = queue.remove.mock.invocationCallOrder[0]
+    const addOrder = queue.add.mock.invocationCallOrder[0]
+    expect(removeOrder).toBeLessThan(addOrder)
+  })
+
   it('ensureSession closure delegates to sessionManager.ensureRunning', async () => {
     const c = makeContainer()
     const mod = buildBankingModule(c)

--- a/src/composition/bankingModule.test.ts
+++ b/src/composition/bankingModule.test.ts
@@ -55,6 +55,7 @@ function makeContainer() {
     logger,
     eventBus: { publish: vi.fn(), subscribe: vi.fn() } as any,
     unitOfWork: { run: async (fn: any) => fn({}) } as any,
+    webhookLog: { record: vi.fn() } as any,
     account: {
       accountRepository,
       accountConfigRepository,

--- a/src/composition/bankingModule.test.ts
+++ b/src/composition/bankingModule.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 vi.mock('../shared/infrastructure/queues/QueueRegistry.js', () => {
-  const make = () => ({ add: vi.fn().mockResolvedValue(undefined) })
+  const make = () => ({ add: vi.fn().mockResolvedValue(undefined), remove: vi.fn().mockResolvedValue(undefined) })
   return {
     redis: {} as any,
     Queues: {
@@ -37,6 +37,7 @@ import { RunBankScrapeUseCase } from '../contexts/banking/application/RunBankScr
 import { NotifyBankMovementUseCase } from '../contexts/banking/application/NotifyBankMovementUseCase.js'
 import { ListBankMovementsUseCase } from '../contexts/banking/application/ListBankMovementsUseCase.js'
 import { ReNotifyBankMovementUseCase } from '../contexts/banking/application/ReNotifyBankMovementUseCase.js'
+import { ListWebhookDeadLettersUseCase } from '../contexts/banking/application/ListWebhookDeadLettersUseCase.js'
 import { db } from '../shared/infrastructure/db/client.js'
 import { ScriptLoader } from '../contexts/script-engine/infrastructure/ScriptLoader.js'
 import { PersistentPlaywrightRunner } from '../contexts/script-engine/infrastructure/PersistentPlaywrightRunner.js'
@@ -56,6 +57,7 @@ function makeContainer() {
     eventBus: { publish: vi.fn(), subscribe: vi.fn() } as any,
     unitOfWork: { run: async (fn: any) => fn({}) } as any,
     webhookLog: { record: vi.fn() } as any,
+    webhookDeadLetters: { record: vi.fn(), listUnresolved: vi.fn(), markResolved: vi.fn() } as any,
     account: {
       accountRepository,
       accountConfigRepository,
@@ -79,6 +81,7 @@ describe('buildBankingModule', () => {
     expect(mod.notifyBankMovement).toBeInstanceOf(NotifyBankMovementUseCase)
     expect(mod.listBankMovements).toBeInstanceOf(ListBankMovementsUseCase)
     expect(mod.reNotifyBankMovement).toBeInstanceOf(ReNotifyBankMovementUseCase)
+    expect(mod.listWebhookDeadLetters).toBeInstanceOf(ListWebhookDeadLettersUseCase)
     expect(mod.bankTransactionRepository).toBeDefined()
     expect(mod.sessionManager).toBeDefined()
   })

--- a/src/composition/bankingModule.ts
+++ b/src/composition/bankingModule.ts
@@ -3,6 +3,7 @@ import type { ILogger } from '../shared/logger/ILogger.js'
 import type { IEventBus } from '../shared/events/IEventBus.js'
 import { credentialsCipher } from '../shared/infrastructure/crypto/CredentialsCipher.js'
 import type { IWebhookNotificationLog } from '../shared/infrastructure/webhooks/IWebhookNotificationLog.js'
+import type { IWebhookDeadLetterStore } from '../shared/infrastructure/webhooks/IWebhookDeadLetterStore.js'
 import { executorFromPool } from '../contexts/banking/infrastructure/Executor.js'
 import { BankTransactionRepository } from '../contexts/banking/infrastructure/BankTransactionRepository.js'
 import { ScrapeRunRepository } from '../contexts/banking/infrastructure/ScrapeRunRepository.js'
@@ -24,6 +25,7 @@ import { db } from '../shared/infrastructure/db/client.js'
 import { NotifyBankMovementUseCase } from '../contexts/banking/application/NotifyBankMovementUseCase.js'
 import { ListBankMovementsUseCase } from '../contexts/banking/application/ListBankMovementsUseCase.js'
 import { ReNotifyBankMovementUseCase } from '../contexts/banking/application/ReNotifyBankMovementUseCase.js'
+import { ListWebhookDeadLettersUseCase } from '../contexts/banking/application/ListWebhookDeadLettersUseCase.js'
 import { Queues } from '../shared/infrastructure/queues/QueueRegistry.js'
 
 interface ContainerBase {
@@ -31,6 +33,7 @@ interface ContainerBase {
   logger: ILogger
   eventBus: IEventBus
   webhookLog: IWebhookNotificationLog
+  webhookDeadLetters: IWebhookDeadLetterStore
   account: AccountModule
   user: UserModule
 }
@@ -40,6 +43,7 @@ export interface BankingModule {
   notifyBankMovement: NotifyBankMovementUseCase
   listBankMovements: ListBankMovementsUseCase
   reNotifyBankMovement: ReNotifyBankMovementUseCase
+  listWebhookDeadLetters: ListWebhookDeadLettersUseCase
   bankTransactionRepository: BankTransactionRepository
   sessionManager: SessionManager
 }
@@ -102,10 +106,15 @@ export function buildBankingModule(container: ContainerBase): BankingModule {
   const sessionManager = new SessionManager(startFn, bankSessionRepo, scrapeBlocker)
 
   const enqueueNotify = async (bankTransactionId: string) => {
+    const jobId = `bank-movement-webhook_${bankTransactionId}`
+    // A prior failed delivery is retained in the queue (removeOnFail: false), and
+    // BullMQ treats a re-add with an existing jobId as a no-op. Drop the stale job
+    // first so a re-drive genuinely re-enqueues instead of silently doing nothing.
+    await Queues.bankMovementWebhook.remove(jobId)
     await Queues.bankMovementWebhook.add(
       'notify',
       { bankTransactionId },
-      { jobId: `bank-movement-webhook_${bankTransactionId}`, removeOnComplete: true }
+      { jobId, removeOnComplete: true }
     )
   }
 
@@ -122,6 +131,9 @@ export function buildBankingModule(container: ContainerBase): BankingModule {
     listBankMovements: new ListBankMovementsUseCase(readModel),
     reNotifyBankMovement: new ReNotifyBankMovementUseCase({
       bankTxRepo, enqueueNotify,
+    }),
+    listWebhookDeadLetters: new ListWebhookDeadLettersUseCase({
+      deadLetters: container.webhookDeadLetters,
     }),
     bankTransactionRepository: bankTxRepo,
     sessionManager,

--- a/src/composition/bankingModule.ts
+++ b/src/composition/bankingModule.ts
@@ -2,6 +2,7 @@ import type pg from 'pg'
 import type { ILogger } from '../shared/logger/ILogger.js'
 import type { IEventBus } from '../shared/events/IEventBus.js'
 import { credentialsCipher } from '../shared/infrastructure/crypto/CredentialsCipher.js'
+import type { IWebhookNotificationLog } from '../shared/infrastructure/webhooks/IWebhookNotificationLog.js'
 import { executorFromPool } from '../contexts/banking/infrastructure/Executor.js'
 import { BankTransactionRepository } from '../contexts/banking/infrastructure/BankTransactionRepository.js'
 import { ScrapeRunRepository } from '../contexts/banking/infrastructure/ScrapeRunRepository.js'
@@ -29,6 +30,7 @@ interface ContainerBase {
   pool: pg.Pool
   logger: ILogger
   eventBus: IEventBus
+  webhookLog: IWebhookNotificationLog
   account: AccountModule
   user: UserModule
 }
@@ -115,6 +117,7 @@ export function buildBankingModule(container: ContainerBase): BankingModule {
     }),
     notifyBankMovement: new NotifyBankMovementUseCase({
       bankTxRepo, accountReader, configReader, userModeReader,
+      webhookLog: container.webhookLog,
     }),
     listBankMovements: new ListBankMovementsUseCase(readModel),
     reNotifyBankMovement: new ReNotifyBankMovementUseCase({

--- a/src/composition/conciliationModule.ts
+++ b/src/composition/conciliationModule.ts
@@ -2,6 +2,7 @@ import type pg from 'pg'
 import type { ILogger } from '../shared/logger/ILogger.js'
 import type { IEventBus } from '../shared/events/IEventBus.js'
 import type { IUnitOfWork } from '../shared/persistence/IUnitOfWork.js'
+import type { IWebhookNotificationLog } from '../shared/infrastructure/webhooks/IWebhookNotificationLog.js'
 import type { BankingModule } from './bankingModule.js'
 import type { AccountModule } from './accountModule.js'
 import type { UserModule } from './userModule.js'
@@ -12,6 +13,7 @@ interface ContainerBase {
   logger: ILogger
   eventBus: IEventBus
   unitOfWork: IUnitOfWork
+  webhookLog: IWebhookNotificationLog
   banking: BankingModule
   account: AccountModule
   user: UserModule
@@ -113,6 +115,7 @@ export function buildConciliationModule(container: ContainerBase): ConciliationM
     }),
     notifyWebhook: new NotifyWebhookUseCase({
       requestRepo, matchRepo, configReader,
+      webhookLog: container.webhookLog,
     }),
     expireStaleRequests: new ExpireStaleRequestsUseCase({
       requestRepo, configReader, eventBus: container.eventBus,

--- a/src/composition/conciliationModule.ts
+++ b/src/composition/conciliationModule.ts
@@ -50,6 +50,7 @@ export interface ConciliationModule {
   listConciliationRequests: ListConciliationRequestsUseCase
   getConciliationRequestDetail: GetConciliationRequestDetailUseCase
   ownershipChecker: ConciliationOwnershipCheckerAdapter
+  requestRepository: ConciliationRequestRepository
 }
 
 export function buildConciliationModule(container: ContainerBase): ConciliationModule {
@@ -127,5 +128,6 @@ export function buildConciliationModule(container: ContainerBase): ConciliationM
     listConciliationRequests: new ListConciliationRequestsUseCase(readModel),
     getConciliationRequestDetail: new GetConciliationRequestDetailUseCase(readModel),
     ownershipChecker,
+    requestRepository: requestRepo,
   }
 }

--- a/src/composition/container.ts
+++ b/src/composition/container.ts
@@ -7,6 +7,8 @@ import { InMemoryEventBus } from '../shared/events/InMemoryEventBus.js'
 import type { IEventBus } from '../shared/events/IEventBus.js'
 import { PgUnitOfWork } from '../shared/persistence/PgUnitOfWork.js'
 import type { IUnitOfWork } from '../shared/persistence/IUnitOfWork.js'
+import { WebhookNotificationLogRepository } from '../shared/infrastructure/webhooks/WebhookNotificationLogRepository.js'
+import type { IWebhookNotificationLog } from '../shared/infrastructure/webhooks/IWebhookNotificationLog.js'
 import { buildUserModule, type UserModule } from './userModule.js'
 import { buildAccountModule, type AccountModule } from './accountModule.js'
 import { buildBankingModule, type BankingModule } from './bankingModule.js'
@@ -19,6 +21,7 @@ export interface Container {
   logger: ILogger
   eventBus: IEventBus
   unitOfWork: IUnitOfWork
+  webhookLog: IWebhookNotificationLog
   user: UserModule
   account: AccountModule
   banking: BankingModule
@@ -38,9 +41,12 @@ export function buildContainer(overrides: ContainerOverrides = {}): Container {
   const logger = overrides.logger ?? defaultLogger
   const eventBus = overrides.eventBus ?? new InMemoryEventBus(logger)
   const unitOfWork = new PgUnitOfWork(pool)
+  const webhookLog = new WebhookNotificationLogRepository({
+    query: (text, params) => pool.query(text, params as any),
+  })
 
   // Modules are wired sequentially; downstream modules pull from already-built ones.
-  const container = { pool, logger, eventBus, unitOfWork, redis: overrides.redis } as unknown as Container
+  const container = { pool, logger, eventBus, unitOfWork, redis: overrides.redis, webhookLog } as unknown as Container
   container.user = buildUserModule(container)
   container.account = buildAccountModule(container)
   container.banking = buildBankingModule(container)

--- a/src/composition/container.ts
+++ b/src/composition/container.ts
@@ -9,6 +9,8 @@ import { PgUnitOfWork } from '../shared/persistence/PgUnitOfWork.js'
 import type { IUnitOfWork } from '../shared/persistence/IUnitOfWork.js'
 import { WebhookNotificationLogRepository } from '../shared/infrastructure/webhooks/WebhookNotificationLogRepository.js'
 import type { IWebhookNotificationLog } from '../shared/infrastructure/webhooks/IWebhookNotificationLog.js'
+import { WebhookDeadLetterRepository } from '../shared/infrastructure/webhooks/WebhookDeadLetterRepository.js'
+import type { IWebhookDeadLetterStore } from '../shared/infrastructure/webhooks/IWebhookDeadLetterStore.js'
 import { buildUserModule, type UserModule } from './userModule.js'
 import { buildAccountModule, type AccountModule } from './accountModule.js'
 import { buildBankingModule, type BankingModule } from './bankingModule.js'
@@ -22,6 +24,7 @@ export interface Container {
   eventBus: IEventBus
   unitOfWork: IUnitOfWork
   webhookLog: IWebhookNotificationLog
+  webhookDeadLetters: IWebhookDeadLetterStore
   user: UserModule
   account: AccountModule
   banking: BankingModule
@@ -44,9 +47,12 @@ export function buildContainer(overrides: ContainerOverrides = {}): Container {
   const webhookLog = new WebhookNotificationLogRepository({
     query: (text, params) => pool.query(text, params as any),
   })
+  const webhookDeadLetters = new WebhookDeadLetterRepository({
+    query: (text, params) => pool.query(text, params as any),
+  })
 
   // Modules are wired sequentially; downstream modules pull from already-built ones.
-  const container = { pool, logger, eventBus, unitOfWork, redis: overrides.redis, webhookLog } as unknown as Container
+  const container = { pool, logger, eventBus, unitOfWork, redis: overrides.redis, webhookLog, webhookDeadLetters } as unknown as Container
   container.user = buildUserModule(container)
   container.account = buildAccountModule(container)
   container.banking = buildBankingModule(container)

--- a/src/contexts/banking/application/ListWebhookDeadLettersUseCase.ts
+++ b/src/contexts/banking/application/ListWebhookDeadLettersUseCase.ts
@@ -1,0 +1,22 @@
+import type {
+  IWebhookDeadLetterStore,
+  WebhookDeadLetterRecord,
+} from '../../../shared/infrastructure/webhooks/IWebhookDeadLetterStore.js'
+
+export interface ListWebhookDeadLettersDeps {
+  deadLetters: IWebhookDeadLetterStore
+}
+
+/**
+ * Lists the bank-movement webhook deliveries that exhausted all retries and
+ * have not yet been re-driven successfully — the operator's view of which
+ * movements were lost and need a manual re-send.
+ */
+export class ListWebhookDeadLettersUseCase {
+  constructor(private readonly deps: ListWebhookDeadLettersDeps) {}
+
+  async execute(accountId: string): Promise<WebhookDeadLetterRecord[]> {
+    const unresolved = await this.deps.deadLetters.listUnresolved(accountId)
+    return unresolved.filter((d) => d.subjectType === 'bank_transaction')
+  }
+}

--- a/src/contexts/banking/application/NotifyBankMovementUseCase.test.ts
+++ b/src/contexts/banking/application/NotifyBankMovementUseCase.test.ts
@@ -9,6 +9,10 @@ import { NotifyBankMovementUseCase } from './NotifyBankMovementUseCase.js'
 import { InMemoryBankTransactionRepository } from '../../../../tests/helpers/inMemoryBankRepos.js'
 import { BankTransaction } from '../domain/BankTransaction.js'
 
+function makeLog() {
+  return { record: vi.fn().mockResolvedValue(undefined) }
+}
+
 function txFixture(id = 'tx-1') {
   return BankTransaction.create(id, {
     accountId: 'acc-1', externalId: 'ext-1', referenceHash: 'h', amount: 100,
@@ -25,7 +29,8 @@ function buildSut(opts: {
   const bankTxRepo = new InMemoryBankTransactionRepository()
   const tx = txFixture()
   bankTxRepo.store.set(tx.id, tx)
-  const sendWebhookFn = vi.fn().mockResolvedValue(undefined)
+  const sendWebhookFn = vi.fn().mockResolvedValue({ status: 200, body: '' })
+  const webhookLog = makeLog()
   const useCase = new NotifyBankMovementUseCase({
     bankTxRepo,
     accountReader: { findById: async () => ({ id: 'acc-1', userId: 'user-1', bank: 'b', sessionType: 'one-shot' as const, loginMode: 'simple' as const }) },
@@ -40,9 +45,10 @@ function buildSut(opts: {
       }),
     },
     userModeReader: { getOperationMode: async () => opts.mode ?? 'passthrough' },
+    webhookLog,
     sendWebhookFn,
   })
-  return { useCase, bankTxRepo, sendWebhookFn, tx }
+  return { useCase, bankTxRepo, sendWebhookFn, webhookLog, tx }
 }
 
 describe('NotifyBankMovementUseCase', () => {
@@ -53,10 +59,54 @@ describe('NotifyBankMovementUseCase', () => {
     expect(bankTxRepo.notified.has(tx.id)).toBe(true)
   })
 
+  it('records a webhook_notifications entry on success with subject context', async () => {
+    const { useCase, webhookLog, tx } = buildSut()
+    await useCase.execute({ bankTransactionId: tx.id, attempt: 2 })
+    expect(webhookLog.record).toHaveBeenCalledTimes(1)
+    expect(webhookLog.record).toHaveBeenCalledWith(expect.objectContaining({
+      accountId: 'acc-1',
+      subjectType: 'bank_transaction',
+      subjectId: tx.id,
+      attempt: 2,
+      responseStatus: 200,
+      errorMessage: null,
+    }))
+  })
+
+  it('records a failure entry, releases the claim, and rethrows', async () => {
+    const bankTxRepo = new InMemoryBankTransactionRepository()
+    const tx = txFixture()
+    bankTxRepo.store.set(tx.id, tx)
+    const err = Object.assign(new Error('Webhook failed: 500'), { status: 500, body: 'boom' })
+    const sendWebhookFn = vi.fn().mockRejectedValue(err)
+    const webhookLog = makeLog()
+    const useCase = new NotifyBankMovementUseCase({
+      bankTxRepo,
+      accountReader: { findById: async () => ({ id: 'acc-1', userId: 'user-1', bank: 'b', sessionType: 'one-shot' as const, loginMode: 'simple' as const }) },
+      configReader: { findByAccountId: async () => ({
+        accountId: 'acc-1', webhookUrl: 'https://hook',
+        webhookAuthType: null, webhookAuthToken: null,
+        authType: 'bearer', authToken: 'tok',
+        webhookExtraFields: null, silentIngestion: false,
+      }) },
+      userModeReader: { getOperationMode: async () => 'passthrough' as const },
+      webhookLog,
+      sendWebhookFn,
+    })
+    await expect(useCase.execute({ bankTransactionId: tx.id })).rejects.toThrow('Webhook failed: 500')
+    expect(webhookLog.record).toHaveBeenCalledWith(expect.objectContaining({
+      subjectType: 'bank_transaction', subjectId: tx.id,
+      responseStatus: 500, responseBody: 'boom', errorMessage: 'Webhook failed: 500',
+      attempt: 1,
+    }))
+    expect(bankTxRepo.notified.has(tx.id)).toBe(false)
+  })
+
   it('does nothing when mode is reconcile', async () => {
-    const { useCase, sendWebhookFn, tx } = buildSut({ mode: 'reconcile' })
+    const { useCase, sendWebhookFn, webhookLog, tx } = buildSut({ mode: 'reconcile' })
     await useCase.execute({ bankTransactionId: tx.id })
     expect(sendWebhookFn).not.toHaveBeenCalled()
+    expect(webhookLog.record).not.toHaveBeenCalled()
   })
 
   it('does nothing when webhook url is missing', async () => {
@@ -66,33 +116,11 @@ describe('NotifyBankMovementUseCase', () => {
   })
 
   it('skips sending when silentIngestion is true but still claims notification', async () => {
-    const { useCase, bankTxRepo, sendWebhookFn, tx } = buildSut({ silentIngestion: true })
+    const { useCase, bankTxRepo, sendWebhookFn, webhookLog, tx } = buildSut({ silentIngestion: true })
     await useCase.execute({ bankTransactionId: tx.id })
     expect(sendWebhookFn).not.toHaveBeenCalled()
+    expect(webhookLog.record).not.toHaveBeenCalled()
     expect(bankTxRepo.notified.has(tx.id)).toBe(true)
-  })
-
-  it('releases the notification claim if sending fails', async () => {
-    const bankTxRepo = new InMemoryBankTransactionRepository()
-    const tx = txFixture()
-    bankTxRepo.store.set(tx.id, tx)
-    const sendWebhookFn = vi.fn().mockRejectedValue(new Error('5xx'))
-    const useCase = new NotifyBankMovementUseCase({
-      bankTxRepo,
-      accountReader: { findById: async () => ({ id: 'acc-1', userId: 'user-1', bank: 'b', sessionType: 'one-shot' as const, loginMode: 'simple' as const }) },
-      configReader: {
-        findByAccountId: async () => ({
-          accountId: 'acc-1', webhookUrl: 'https://hook',
-          webhookAuthType: null, webhookAuthToken: null,
-          authType: 'bearer', authToken: 'tok',
-          webhookExtraFields: null, silentIngestion: false,
-        }),
-      },
-      userModeReader: { getOperationMode: async () => 'passthrough' },
-      sendWebhookFn,
-    })
-    await expect(useCase.execute({ bankTransactionId: tx.id })).rejects.toThrow('5xx')
-    expect(bankTxRepo.notified.has(tx.id)).toBe(false)
   })
 
   it('does not double-send if claim is already taken', async () => {
@@ -104,12 +132,13 @@ describe('NotifyBankMovementUseCase', () => {
 
   it('returns early when the bank transaction does not exist', async () => {
     const bankTxRepo = new InMemoryBankTransactionRepository()
-    const sendWebhookFn = vi.fn().mockResolvedValue(undefined)
+    const sendWebhookFn = vi.fn().mockResolvedValue({ status: 200, body: '' })
     const useCase = new NotifyBankMovementUseCase({
       bankTxRepo,
       accountReader: { findById: async () => null },
       configReader: { findByAccountId: async () => null },
       userModeReader: { getOperationMode: async () => 'passthrough' as const },
+      webhookLog: makeLog(),
       sendWebhookFn,
     })
     await useCase.execute({ bankTransactionId: 'missing' })
@@ -120,12 +149,13 @@ describe('NotifyBankMovementUseCase', () => {
     const bankTxRepo = new InMemoryBankTransactionRepository()
     const tx = txFixture()
     bankTxRepo.store.set(tx.id, tx)
-    const sendWebhookFn = vi.fn().mockResolvedValue(undefined)
+    const sendWebhookFn = vi.fn().mockResolvedValue({ status: 200, body: '' })
     const useCase = new NotifyBankMovementUseCase({
       bankTxRepo,
       accountReader: { findById: async () => ({ id: 'acc-1', userId: 'u', bank: 'b', sessionType: 'one-shot' as const, loginMode: 'simple' as const }) },
       configReader: { findByAccountId: async () => null },
       userModeReader: { getOperationMode: async () => 'passthrough' as const },
+      webhookLog: makeLog(),
       sendWebhookFn,
     })
     await useCase.execute({ bankTransactionId: tx.id })
@@ -136,7 +166,7 @@ describe('NotifyBankMovementUseCase', () => {
     const bankTxRepo = new InMemoryBankTransactionRepository()
     const tx = txFixture()
     bankTxRepo.store.set(tx.id, tx)
-    const sendWebhookFn = vi.fn().mockResolvedValue(undefined)
+    const sendWebhookFn = vi.fn().mockResolvedValue({ status: 200, body: '' })
     const useCase = new NotifyBankMovementUseCase({
       bankTxRepo,
       accountReader: { findById: async () => null },
@@ -147,6 +177,7 @@ describe('NotifyBankMovementUseCase', () => {
         webhookExtraFields: null, silentIngestion: false,
       }) },
       userModeReader: { getOperationMode: async () => 'passthrough' as const },
+      webhookLog: makeLog(),
       sendWebhookFn,
     })
     await useCase.execute({ bankTransactionId: tx.id })
@@ -161,7 +192,7 @@ describe('NotifyBankMovementUseCase', () => {
       scriptId: 'script-1', rawPayload: {},
     })
     bankTxRepo.store.set(tx.id, tx)
-    const sendWebhookFn = vi.fn().mockResolvedValue(undefined)
+    const sendWebhookFn = vi.fn().mockResolvedValue({ status: 200, body: '' })
     const useCase = new NotifyBankMovementUseCase({
       bankTxRepo,
       accountReader: { findById: async () => ({ id: 'acc-1', userId: 'u', bank: 'b', sessionType: 'one-shot' as const, loginMode: 'simple' as const }) },
@@ -172,6 +203,7 @@ describe('NotifyBankMovementUseCase', () => {
         webhookExtraFields: null, silentIngestion: false,
       }) },
       userModeReader: { getOperationMode: async () => 'passthrough' as const },
+      webhookLog: makeLog(),
       sendWebhookFn,
     })
     await useCase.execute({ bankTransactionId: tx.id })
@@ -188,7 +220,7 @@ describe('NotifyBankMovementUseCase', () => {
       scriptId: 'script-1', ingestedAt: new Date(), rawPayload: {},
     })
     bankTxRepo.store.set(tx.id, tx)
-    const sendWebhookFn = vi.fn().mockResolvedValue(undefined)
+    const sendWebhookFn = vi.fn().mockResolvedValue({ status: 200, body: '' })
     const useCase = new NotifyBankMovementUseCase({
       bankTxRepo,
       accountReader: { findById: async () => ({ id: 'acc-1', userId: 'u', bank: 'b', sessionType: 'one-shot' as const, loginMode: 'simple' as const }) },
@@ -201,6 +233,7 @@ describe('NotifyBankMovementUseCase', () => {
         silentIngestion: false,
       }) },
       userModeReader: { getOperationMode: async () => 'passthrough' as const },
+      webhookLog: makeLog(),
       sendWebhookFn,
     })
     await useCase.execute({ bankTransactionId: tx.id })
@@ -213,7 +246,7 @@ describe('NotifyBankMovementUseCase', () => {
 
   it('uses the default sendWebhook when no sendWebhookFn is provided', async () => {
     sendWebhookMock.mockReset()
-    sendWebhookMock.mockResolvedValue(undefined)
+    sendWebhookMock.mockResolvedValue({ status: 200, body: '' })
     const bankTxRepo = new InMemoryBankTransactionRepository()
     const tx = txFixture('tx-default')
     bankTxRepo.store.set(tx.id, tx)
@@ -227,6 +260,7 @@ describe('NotifyBankMovementUseCase', () => {
         webhookExtraFields: null, silentIngestion: false,
       }) },
       userModeReader: { getOperationMode: async () => 'passthrough' as const },
+      webhookLog: makeLog(),
     })
     await useCase.execute({ bankTransactionId: tx.id })
     expect(sendWebhookMock).toHaveBeenCalledTimes(1)
@@ -236,7 +270,7 @@ describe('NotifyBankMovementUseCase', () => {
     const bankTxRepo = new InMemoryBankTransactionRepository()
     const tx = txFixture('tx-4')
     bankTxRepo.store.set(tx.id, tx)
-    const sendWebhookFn = vi.fn().mockResolvedValue(undefined)
+    const sendWebhookFn = vi.fn().mockResolvedValue({ status: 200, body: '' })
     const useCase = new NotifyBankMovementUseCase({
       bankTxRepo,
       accountReader: { findById: async () => ({ id: 'acc-1', userId: 'u', bank: 'b', sessionType: 'one-shot' as const, loginMode: 'simple' as const }) },
@@ -248,6 +282,7 @@ describe('NotifyBankMovementUseCase', () => {
         silentIngestion: false,
       }) },
       userModeReader: { getOperationMode: async () => 'passthrough' as const },
+      webhookLog: makeLog(),
       sendWebhookFn,
     })
     await useCase.execute({ bankTransactionId: tx.id })

--- a/src/contexts/banking/application/NotifyBankMovementUseCase.ts
+++ b/src/contexts/banking/application/NotifyBankMovementUseCase.ts
@@ -1,25 +1,27 @@
 import { sendWebhook } from '../../../shared/infrastructure/webhooks/WebhookSender.js'
+import { makeLoggingWebhookSender } from '../../../shared/infrastructure/webhooks/LoggingWebhookSender.js'
+import { IWebhookNotificationLog } from '../../../shared/infrastructure/webhooks/IWebhookNotificationLog.js'
 import { IBankTransactionRepository } from '../domain/IBankTransactionRepository.js'
 import { IAccountForBankingReader } from '../domain/ports/IAccountForBankingReader.js'
 import { INotificationConfigReader } from '../domain/ports/INotificationConfigReader.js'
 import { IUserOperationModeReader } from '../domain/ports/IUserOperationModeReader.js'
 
-interface JobData { bankTransactionId: string }
+interface JobData { bankTransactionId: string; attempt?: number }
 
 export interface NotifyBankMovementDeps {
   bankTxRepo: IBankTransactionRepository
   accountReader: IAccountForBankingReader
   configReader: INotificationConfigReader
   userModeReader: IUserOperationModeReader
+  webhookLog: IWebhookNotificationLog
   sendWebhookFn?: typeof sendWebhook
 }
 
 export class NotifyBankMovementUseCase {
   constructor(private readonly deps: NotifyBankMovementDeps) {}
 
-  async execute({ bankTransactionId }: JobData): Promise<void> {
-    const { bankTxRepo, accountReader, configReader, userModeReader } = this.deps
-    const send = this.deps.sendWebhookFn ?? sendWebhook
+  async execute({ bankTransactionId, attempt = 1 }: JobData): Promise<void> {
+    const { bankTxRepo, accountReader, configReader, userModeReader, webhookLog } = this.deps
 
     const tx = await bankTxRepo.findById(bankTransactionId)
     if (!tx) return
@@ -58,6 +60,12 @@ export class NotifyBankMovementUseCase {
         if (!(k in payload)) payload[k] = v
       }
     }
+
+    const send = makeLoggingWebhookSender(
+      webhookLog,
+      { accountId: tx.accountId, subjectType: 'bank_transaction', subjectId: tx.id, attempt },
+      this.deps.sendWebhookFn,
+    )
 
     try {
       await send({ url: config.webhookUrl, payload, authType, authToken: token })

--- a/src/contexts/conciliation/application/NotifyWebhookUseCase.test.ts
+++ b/src/contexts/conciliation/application/NotifyWebhookUseCase.test.ts
@@ -41,8 +41,9 @@ function buildDeps(opts: {
     findWebhookConfigForRequest: vi.fn().mockResolvedValue(opts.config ?? null),
     shouldNotifyOnExpired: vi.fn(),
   }
-  const sendWebhookFn = vi.fn().mockResolvedValue(undefined)
-  return { requestRepo, matchRepo, configReader, sendWebhookFn }
+  const sendWebhookFn = vi.fn().mockResolvedValue({ status: 200, body: '' })
+  const webhookLog = { record: vi.fn().mockResolvedValue(undefined) }
+  return { requestRepo, matchRepo, configReader, webhookLog, sendWebhookFn }
 }
 
 describe('NotifyWebhookUseCase', () => {
@@ -113,6 +114,39 @@ describe('NotifyWebhookUseCase', () => {
     expect(callArg.payload.custom).toBe('value')
     expect(deps.matchRepo.findPrimaryByRequest).toHaveBeenCalledWith('req-1')
     expect(deps.matchRepo.markNotified).toHaveBeenCalledWith('match-1')
+    expect(deps.webhookLog.record).toHaveBeenCalledWith(expect.objectContaining({
+      accountId: 'acc-1',
+      subjectType: 'conciliation_request',
+      subjectId: 'req-1',
+      responseStatus: 200,
+      errorMessage: null,
+      attempt: 1,
+    }))
+  })
+
+  it('records a failure entry, does not mark notified, and rethrows', async () => {
+    const req = buildRequest({ status: 'matched' })
+    const deps = buildDeps({
+      request: req,
+      config: {
+        webhookUrl: 'https://hook.example/x',
+        webhookAuthToken: null, authToken: null,
+        webhookAuthType: null, authType: null,
+        webhookExtraFields: null,
+      },
+      primary: { id: 'match-1' },
+    })
+    const err = Object.assign(new Error('Webhook failed: 503'), { status: 503, body: 'down' })
+    deps.sendWebhookFn.mockRejectedValue(err)
+    const useCase = new NotifyWebhookUseCase(deps as any)
+
+    await expect(useCase.execute({ requestId: 'req-1', attempt: 3 })).rejects.toThrow('Webhook failed: 503')
+    expect(deps.webhookLog.record).toHaveBeenCalledWith(expect.objectContaining({
+      subjectType: 'conciliation_request', subjectId: 'req-1',
+      responseStatus: 503, responseBody: 'down', errorMessage: 'Webhook failed: 503',
+      attempt: 3,
+    }))
+    expect(deps.matchRepo.markNotified).not.toHaveBeenCalled()
   })
 
   it('does not call matchRepo or markNotified for ambiguous status', async () => {

--- a/src/contexts/conciliation/application/NotifyWebhookUseCase.ts
+++ b/src/contexts/conciliation/application/NotifyWebhookUseCase.ts
@@ -2,8 +2,10 @@ import { IAccountConfigReader } from '../domain/ports/IAccountConfigReader.js'
 import { IConciliationRequestRepository } from '../domain/IConciliationRequestRepository.js'
 import { IConciliatedTransactionRepository } from '../domain/IConciliatedTransactionRepository.js'
 import { sendWebhook } from '../../../shared/infrastructure/webhooks/WebhookSender.js'
+import { makeLoggingWebhookSender } from '../../../shared/infrastructure/webhooks/LoggingWebhookSender.js'
+import { IWebhookNotificationLog } from '../../../shared/infrastructure/webhooks/IWebhookNotificationLog.js'
 
-interface JobData { requestId: string }
+interface JobData { requestId: string; attempt?: number }
 
 const NOTIFIABLE_STATUSES = new Set(['matched', 'ambiguous', 'expired'])
 
@@ -11,15 +13,15 @@ export interface NotifyWebhookDeps {
   requestRepo: IConciliationRequestRepository
   matchRepo: IConciliatedTransactionRepository
   configReader: IAccountConfigReader
+  webhookLog: IWebhookNotificationLog
   sendWebhookFn?: typeof sendWebhook
 }
 
 export class NotifyWebhookUseCase {
   constructor(private readonly deps: NotifyWebhookDeps) {}
 
-  async execute({ requestId }: JobData): Promise<void> {
-    const { requestRepo, matchRepo, configReader } = this.deps
-    const send = this.deps.sendWebhookFn ?? sendWebhook
+  async execute({ requestId, attempt = 1 }: JobData): Promise<void> {
+    const { requestRepo, matchRepo, configReader, webhookLog } = this.deps
 
     const request = await requestRepo.findById(requestId)
     if (!request) return
@@ -49,6 +51,12 @@ export class NotifyWebhookUseCase {
         if (!(k in payload)) payload[k] = v
       }
     }
+
+    const send = makeLoggingWebhookSender(
+      webhookLog,
+      { accountId: request.accountId, subjectType: 'conciliation_request', subjectId: request.id, attempt },
+      this.deps.sendWebhookFn,
+    )
 
     await send({
       url: config.webhookUrl,

--- a/src/contexts/user/infrastructure/adapters/UserDataCleanerAdapter.test.ts
+++ b/src/contexts/user/infrastructure/adapters/UserDataCleanerAdapter.test.ts
@@ -2,28 +2,31 @@ import { describe, it, expect, vi } from 'vitest'
 import { UserDataCleanerAdapter } from './UserDataCleanerAdapter.js'
 
 describe('UserDataCleanerAdapter', () => {
-  it('issues five scoped DELETEs with the userId in the right order', async () => {
+  it('issues six scoped DELETEs with the userId in the right order', async () => {
     const tx = { query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }) }
     const adapter = new UserDataCleanerAdapter()
 
     await adapter.wipeForUser(tx as any, 'u-1')
 
-    expect(tx.query).toHaveBeenCalledTimes(5)
+    expect(tx.query).toHaveBeenCalledTimes(6)
     const calls = tx.query.mock.calls
-    expect(calls[0][0]).toContain('DELETE FROM webhook_notifications')
+    expect(calls[0][0]).toContain('DELETE FROM webhook_dead_letters')
     expect(calls[0][0]).toContain('account_id IN (SELECT id FROM accounts WHERE user_id = $1)')
     expect(calls[0][1]).toEqual(['u-1'])
 
-    expect(calls[1][0]).toContain('DELETE FROM conciliated_transactions')
+    expect(calls[1][0]).toContain('DELETE FROM webhook_notifications')
     expect(calls[1][1]).toEqual(['u-1'])
 
-    expect(calls[2][0]).toContain('DELETE FROM conciliation_attempts')
+    expect(calls[2][0]).toContain('DELETE FROM conciliated_transactions')
     expect(calls[2][1]).toEqual(['u-1'])
 
-    expect(calls[3][0]).toContain('DELETE FROM conciliation_requests')
+    expect(calls[3][0]).toContain('DELETE FROM conciliation_attempts')
     expect(calls[3][1]).toEqual(['u-1'])
 
-    expect(calls[4][0]).toContain('DELETE FROM bank_transactions')
+    expect(calls[4][0]).toContain('DELETE FROM conciliation_requests')
     expect(calls[4][1]).toEqual(['u-1'])
+
+    expect(calls[5][0]).toContain('DELETE FROM bank_transactions')
+    expect(calls[5][1]).toEqual(['u-1'])
   })
 })

--- a/src/contexts/user/infrastructure/adapters/UserDataCleanerAdapter.test.ts
+++ b/src/contexts/user/infrastructure/adapters/UserDataCleanerAdapter.test.ts
@@ -2,25 +2,28 @@ import { describe, it, expect, vi } from 'vitest'
 import { UserDataCleanerAdapter } from './UserDataCleanerAdapter.js'
 
 describe('UserDataCleanerAdapter', () => {
-  it('issues four scoped DELETEs with the userId in the right order', async () => {
+  it('issues five scoped DELETEs with the userId in the right order', async () => {
     const tx = { query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }) }
     const adapter = new UserDataCleanerAdapter()
 
     await adapter.wipeForUser(tx as any, 'u-1')
 
-    expect(tx.query).toHaveBeenCalledTimes(4)
+    expect(tx.query).toHaveBeenCalledTimes(5)
     const calls = tx.query.mock.calls
-    expect(calls[0][0]).toContain('DELETE FROM conciliated_transactions')
+    expect(calls[0][0]).toContain('DELETE FROM webhook_notifications')
     expect(calls[0][0]).toContain('account_id IN (SELECT id FROM accounts WHERE user_id = $1)')
     expect(calls[0][1]).toEqual(['u-1'])
 
-    expect(calls[1][0]).toContain('DELETE FROM conciliation_attempts')
+    expect(calls[1][0]).toContain('DELETE FROM conciliated_transactions')
     expect(calls[1][1]).toEqual(['u-1'])
 
-    expect(calls[2][0]).toContain('DELETE FROM conciliation_requests')
+    expect(calls[2][0]).toContain('DELETE FROM conciliation_attempts')
     expect(calls[2][1]).toEqual(['u-1'])
 
-    expect(calls[3][0]).toContain('DELETE FROM bank_transactions')
+    expect(calls[3][0]).toContain('DELETE FROM conciliation_requests')
     expect(calls[3][1]).toEqual(['u-1'])
+
+    expect(calls[4][0]).toContain('DELETE FROM bank_transactions')
+    expect(calls[4][1]).toEqual(['u-1'])
   })
 })

--- a/src/contexts/user/infrastructure/adapters/UserDataCleanerAdapter.ts
+++ b/src/contexts/user/infrastructure/adapters/UserDataCleanerAdapter.ts
@@ -9,6 +9,7 @@ import type { Tx } from '../../../../shared/persistence/Tx.js'
 export class UserDataCleanerAdapter implements IUserDataCleaner {
   async wipeForUser(tx: Tx, userId: string): Promise<void> {
     const scope = `account_id IN (SELECT id FROM accounts WHERE user_id = $1)`
+    await tx.query(`DELETE FROM webhook_notifications WHERE ${scope}`, [userId])
     await tx.query(`DELETE FROM conciliated_transactions WHERE ${scope}`, [userId])
     await tx.query(`DELETE FROM conciliation_attempts WHERE ${scope}`, [userId])
     await tx.query(`DELETE FROM conciliation_requests WHERE ${scope}`, [userId])

--- a/src/contexts/user/infrastructure/adapters/UserDataCleanerAdapter.ts
+++ b/src/contexts/user/infrastructure/adapters/UserDataCleanerAdapter.ts
@@ -9,6 +9,7 @@ import type { Tx } from '../../../../shared/persistence/Tx.js'
 export class UserDataCleanerAdapter implements IUserDataCleaner {
   async wipeForUser(tx: Tx, userId: string): Promise<void> {
     const scope = `account_id IN (SELECT id FROM accounts WHERE user_id = $1)`
+    await tx.query(`DELETE FROM webhook_dead_letters WHERE ${scope}`, [userId])
     await tx.query(`DELETE FROM webhook_notifications WHERE ${scope}`, [userId])
     await tx.query(`DELETE FROM conciliated_transactions WHERE ${scope}`, [userId])
     await tx.query(`DELETE FROM conciliation_attempts WHERE ${scope}`, [userId])

--- a/src/shared/infrastructure/db/migrations/034_create_webhook_notifications.sql
+++ b/src/shared/infrastructure/db/migrations/034_create_webhook_notifications.sql
@@ -1,0 +1,26 @@
+-- Append-only audit log of every webhook delivery attempt, across all flows
+-- (passthrough bank movements and conciliation). The business-state flags
+-- (bank_transactions.notified_at, conciliated_transactions.is_notified) remain
+-- the source of truth; this table is pure observability.
+CREATE TABLE IF NOT EXISTS webhook_notifications (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id      UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  subject_type    TEXT NOT NULL CHECK (subject_type IN ('bank_transaction', 'conciliation_request')),
+  subject_id      UUID NOT NULL,
+  url             TEXT NOT NULL,
+  request_payload JSONB NOT NULL,
+  response_status INTEGER,            -- null when no HTTP response was received (network error)
+  response_body   JSONB,             -- response captured as JSON; null on transport failure
+  error_message   TEXT,              -- non-null on failure
+  attempt         INTEGER NOT NULL,  -- BullMQ attempt number (1-based)
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_notifications_account_created
+  ON webhook_notifications (account_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_notifications_subject
+  ON webhook_notifications (subject_type, subject_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_notifications_status
+  ON webhook_notifications (response_status);

--- a/src/shared/infrastructure/db/migrations/035_create_webhook_dead_letters.sql
+++ b/src/shared/infrastructure/db/migrations/035_create_webhook_dead_letters.sql
@@ -1,0 +1,26 @@
+-- Durable record of webhook deliveries that exhausted all retry attempts.
+-- One row per failed subject (bank movement or conciliation request); mutable
+-- (resolved_at flips when a later re-drive succeeds). This is the queryable
+-- answer to "which notifications were lost?" — the per-attempt detail lives in
+-- webhook_notifications, the business-state flags remain the source of truth.
+CREATE TABLE IF NOT EXISTS webhook_dead_letters (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id    UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  subject_type  TEXT NOT NULL CHECK (subject_type IN ('bank_transaction', 'conciliation_request')),
+  subject_id    UUID NOT NULL,
+  url           TEXT,
+  last_status   INTEGER,            -- null when no HTTP response was received (network error)
+  last_error    TEXT,
+  attempts      INTEGER NOT NULL,   -- total attempts made before exhaustion
+  failed_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  resolved_at   TIMESTAMPTZ         -- null until an operator re-drive (or later retry) succeeds
+);
+
+-- One live dead-letter per subject: a repeated final failure of the same subject
+-- updates the existing row in place rather than piling up duplicates. Resolving a
+-- row frees the slot so a fresh failure can be recorded again.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_webhook_dead_letters_subject_unresolved
+  ON webhook_dead_letters (subject_type, subject_id) WHERE resolved_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_webhook_dead_letters_unresolved
+  ON webhook_dead_letters (account_id, failed_at DESC) WHERE resolved_at IS NULL;

--- a/src/shared/infrastructure/queues/QueueRegistry.test.ts
+++ b/src/shared/infrastructure/queues/QueueRegistry.test.ts
@@ -6,9 +6,11 @@ interface QueueOpts {
     attempts: number
     backoff: { type: string; delay: number }
     removeOnComplete: boolean
-    removeOnFail: number
+    removeOnFail: number | boolean
   }
 }
+
+const WEBHOOK_QUEUES = new Set(['webhook', 'bank-movement-webhook'])
 
 const QueueCtor = vi.fn(function (this: unknown, name: string, _opts?: QueueOpts) {
   return { name }
@@ -66,15 +68,38 @@ describe('QueueRegistry', () => {
     expect(mod.Queues.bankMovementWebhook).toBeDefined()
 
     for (const call of QueueCtor.mock.calls) {
+      const name = call[0] as string
       const opts = call[1] as QueueOpts | undefined
       expect(opts).toBeDefined()
       expect(opts!.connection).toBe(mod.redis)
-      expect(opts!.defaultJobOptions).toEqual({
-        attempts: 3,
-        backoff: { type: 'exponential', delay: 5_000 },
-        removeOnComplete: true,
-        removeOnFail: 100,
-      })
+      if (WEBHOOK_QUEUES.has(name)) {
+        // Webhook queues retry far longer and keep failed jobs for dead-lettering.
+        expect(opts!.defaultJobOptions).toEqual({
+          attempts: 12,
+          backoff: { type: 'exponential', delay: 10_000 },
+          removeOnComplete: true,
+          removeOnFail: false,
+        })
+      } else {
+        expect(opts!.defaultJobOptions).toEqual({
+          attempts: 3,
+          backoff: { type: 'exponential', delay: 5_000 },
+          removeOnComplete: true,
+          removeOnFail: 100,
+        })
+      }
     }
+  })
+
+  it('honors WEBHOOK_QUEUE_ATTEMPTS and WEBHOOK_QUEUE_BACKOFF_MS overrides', async () => {
+    vi.stubEnv('REDIS_URL', 'redis://localhost:6379')
+    vi.stubEnv('WEBHOOK_QUEUE_ATTEMPTS', '5')
+    vi.stubEnv('WEBHOOK_QUEUE_BACKOFF_MS', '2000')
+    await import('./QueueRegistry.js')
+
+    const webhookCall = QueueCtor.mock.calls.find((c) => c[0] === 'bank-movement-webhook')
+    const opts = webhookCall![1] as QueueOpts
+    expect(opts.defaultJobOptions.attempts).toBe(5)
+    expect(opts.defaultJobOptions.backoff.delay).toBe(2000)
   })
 })

--- a/src/shared/infrastructure/queues/QueueRegistry.ts
+++ b/src/shared/infrastructure/queues/QueueRegistry.ts
@@ -14,11 +14,23 @@ const defaultJobOptions = {
   removeOnFail: 100,
 }
 
+// Webhook deliveries hit third-party endpoints that can be down for minutes or
+// hours, so they retry far longer than the in-process default: ~12 attempts on
+// exponential backoff from 10s spans roughly 6 hours. Failed jobs are kept
+// (removeOnFail: false) so the worker's `failed` handler can dead-letter the
+// final attempt; the durable record then lives in webhook_dead_letters.
+const webhookJobOptions = {
+  attempts: Number(process.env.WEBHOOK_QUEUE_ATTEMPTS ?? 12),
+  backoff: { type: 'exponential' as const, delay: Number(process.env.WEBHOOK_QUEUE_BACKOFF_MS ?? 10_000) },
+  removeOnComplete: true,
+  removeOnFail: false,
+}
+
 export const Queues = {
   orderIngestion: new Queue('order-ingestion', { connection: redis, defaultJobOptions }),
   bankScrape:     new Queue('bank-scrape',     { connection: redis, defaultJobOptions }),
   conciliation:   new Queue('conciliation',    { connection: redis, defaultJobOptions }),
   txConciliation: new Queue('tx-conciliation', { connection: redis, defaultJobOptions }),
-  webhook:        new Queue('webhook',         { connection: redis, defaultJobOptions }),
-  bankMovementWebhook: new Queue('bank-movement-webhook', { connection: redis, defaultJobOptions }),
+  webhook:        new Queue('webhook',         { connection: redis, defaultJobOptions: webhookJobOptions }),
+  bankMovementWebhook: new Queue('bank-movement-webhook', { connection: redis, defaultJobOptions: webhookJobOptions }),
 }

--- a/src/shared/infrastructure/queues/workers/conciliation.worker.test.ts
+++ b/src/shared/infrastructure/queues/workers/conciliation.worker.test.ts
@@ -90,10 +90,10 @@ describe('createConciliationWorkers', () => {
     expect(conciliation.processIncomingTransaction.execute).toHaveBeenCalledWith({ b: 2 })
 
     await created[2].processor({ data: { c: 3 } })
-    expect(conciliation.notifyWebhook.execute).toHaveBeenCalledWith({ c: 3 })
+    expect(conciliation.notifyWebhook.execute).toHaveBeenCalledWith({ c: 3, attempt: 1 })
 
-    await created[3].processor({ data: { d: 4 } })
-    expect(banking.notifyBankMovement.execute).toHaveBeenCalledWith({ d: 4 })
+    await created[3].processor({ data: { d: 4 }, attemptsMade: 1 })
+    expect(banking.notifyBankMovement.execute).toHaveBeenCalledWith({ d: 4, attempt: 2 })
 
     // Event handlers
     const conciliationLog = childLogs.get('[conciliation]')!

--- a/src/shared/infrastructure/queues/workers/conciliation.worker.test.ts
+++ b/src/shared/infrastructure/queues/workers/conciliation.worker.test.ts
@@ -52,15 +52,19 @@ function makeContainer() {
     runConciliation: { execute: vi.fn(async () => {}) },
     processIncomingTransaction: { execute: vi.fn(async () => {}) },
     notifyWebhook: { execute: vi.fn(async () => {}) },
+    requestRepository: { findById: vi.fn(async () => ({ id: 'req-1', accountId: 'acc-1' })) },
   }
   const banking = {
     notifyBankMovement: { execute: vi.fn(async () => {}) },
+    bankTransactionRepository: { findById: vi.fn(async () => ({ id: 'tx-1', accountId: 'acc-1' })) },
   }
+  const webhookDeadLetters = { record: vi.fn(async () => {}), markResolved: vi.fn(async () => {}) }
   return {
-    container: { logger, conciliation, banking } as never,
+    container: { logger, conciliation, banking, webhookDeadLetters } as never,
     childLogs,
     conciliation,
     banking,
+    webhookDeadLetters,
   }
 }
 
@@ -95,32 +99,74 @@ describe('createConciliationWorkers', () => {
     await created[3].processor({ data: { d: 4 }, attemptsMade: 1 })
     expect(banking.notifyBankMovement.execute).toHaveBeenCalledWith({ d: 4, attempt: 2 })
 
-    // Event handlers
+    // Non-webhook workers still just log their events
     const conciliationLog = childLogs.get('[conciliation]')!
-    created[0].handlers.get('completed')!({ id: 'c1' })
+    await created[0].handlers.get('completed')!({ id: 'c1' })
     expect(conciliationLog.info).toHaveBeenCalledWith('job c1 completed')
-    created[0].handlers.get('failed')!({ id: 'c1', attemptsMade: 2 }, new Error('e1'))
+    await created[0].handlers.get('failed')!({ id: 'c1', attemptsMade: 2 }, new Error('e1'))
     expect(conciliationLog.error).toHaveBeenCalledWith('job c1 failed (attempt 2)', { error: 'e1' })
-    // failed with undefined job
-    created[0].handlers.get('failed')!(undefined, new Error('e2'))
+    await created[0].handlers.get('failed')!(undefined, new Error('e2'))
     expect(conciliationLog.error).toHaveBeenCalledWith('job undefined failed (attempt undefined)', { error: 'e2' })
 
     const txLog = childLogs.get('[tx-conciliation]')!
-    created[1].handlers.get('completed')!({ id: 't1' })
+    await created[1].handlers.get('completed')!({ id: 't1' })
     expect(txLog.info).toHaveBeenCalledWith('job t1 completed')
-    created[1].handlers.get('failed')!({ id: 't1', attemptsMade: 1 }, new Error('te'))
+    await created[1].handlers.get('failed')!({ id: 't1', attemptsMade: 1 }, new Error('te'))
     expect(txLog.error).toHaveBeenCalledWith('job t1 failed (attempt 1)', { error: 'te' })
+  })
 
-    const webhookLog = childLogs.get('[webhook]')!
-    created[2].handlers.get('completed')!({ id: 'w1' })
-    expect(webhookLog.info).toHaveBeenCalledWith('job w1 completed')
-    created[2].handlers.get('failed')!({ id: 'w1', attemptsMade: 3 }, new Error('we'))
-    expect(webhookLog.error).toHaveBeenCalledWith('job w1 failed (attempt 3)', { error: 'we' })
+  it('dead-letters a bank-movement webhook only on its final attempt', async () => {
+    const { container, banking, webhookDeadLetters } = makeContainer()
+    createConciliationWorkers(container)
+    const failed = created[3].handlers.get('failed')!
 
-    const bmwLog = childLogs.get('[bank-movement-webhook]')!
-    created[3].handlers.get('completed')!({ id: 'b1' })
-    expect(bmwLog.info).toHaveBeenCalledWith('job b1 completed')
-    created[3].handlers.get('failed')!({ id: 'b1', attemptsMade: 4 }, new Error('be'))
-    expect(bmwLog.error).toHaveBeenCalledWith('job b1 failed (attempt 4)', { error: 'be' })
+    // Not exhausted yet (attemptsMade < attempts): no dead-letter.
+    await failed({ id: 'b1', data: { bankTransactionId: 'tx-1' }, attemptsMade: 3, opts: { attempts: 12 } }, new Error('boom'))
+    expect(webhookDeadLetters.record).not.toHaveBeenCalled()
+
+    // Final attempt: dead-letter with the looked-up subject and last status.
+    const err = Object.assign(new Error('Webhook failed: 500'), { status: 500 })
+    await failed({ id: 'b1', data: { bankTransactionId: 'tx-1' }, attemptsMade: 12, opts: { attempts: 12 } }, err)
+    expect(banking.bankTransactionRepository.findById).toHaveBeenCalledWith('tx-1')
+    expect(webhookDeadLetters.record).toHaveBeenCalledWith({
+      accountId: 'acc-1',
+      subjectType: 'bank_transaction',
+      subjectId: 'tx-1',
+      url: null,
+      lastStatus: 500,
+      lastError: 'Webhook failed: 500',
+      attempts: 12,
+    })
+  })
+
+  it('records null lastStatus on a transport failure (no HTTP status)', async () => {
+    const { container, webhookDeadLetters } = makeContainer()
+    createConciliationWorkers(container)
+    const failed = created[3].handlers.get('failed')!
+
+    await failed({ id: 'b1', data: { bankTransactionId: 'tx-1' }, attemptsMade: 12, opts: { attempts: 12 } }, new Error('connect ECONNREFUSED'))
+    expect(webhookDeadLetters.record).toHaveBeenCalledWith(expect.objectContaining({ lastStatus: null, lastError: 'connect ECONNREFUSED' }))
+  })
+
+  it('resolves the dead-letter when a bank-movement webhook completes', async () => {
+    const { container, webhookDeadLetters } = makeContainer()
+    createConciliationWorkers(container)
+
+    await created[3].handlers.get('completed')!({ id: 'b1', data: { bankTransactionId: 'tx-1' } })
+    expect(webhookDeadLetters.markResolved).toHaveBeenCalledWith('bank_transaction', 'tx-1')
+  })
+
+  it('dead-letters and resolves conciliation webhooks symmetrically', async () => {
+    const { container, conciliation, webhookDeadLetters } = makeContainer()
+    createConciliationWorkers(container)
+
+    await created[2].handlers.get('failed')!({ id: 'w1', data: { requestId: 'req-1' }, attemptsMade: 12, opts: { attempts: 12 } }, new Error('we'))
+    expect(conciliation.requestRepository.findById).toHaveBeenCalledWith('req-1')
+    expect(webhookDeadLetters.record).toHaveBeenCalledWith(expect.objectContaining({
+      accountId: 'acc-1', subjectType: 'conciliation_request', subjectId: 'req-1', attempts: 12,
+    }))
+
+    await created[2].handlers.get('completed')!({ id: 'w1', data: { requestId: 'req-1' } })
+    expect(webhookDeadLetters.markResolved).toHaveBeenCalledWith('conciliation_request', 'req-1')
   })
 })

--- a/src/shared/infrastructure/queues/workers/conciliation.worker.ts
+++ b/src/shared/infrastructure/queues/workers/conciliation.worker.ts
@@ -1,12 +1,26 @@
 import { Worker } from 'bullmq'
+import type { Job } from 'bullmq'
 import { redis } from '../QueueRegistry.js'
 import type { Container } from '../../../../composition/container.js'
+import type { WebhookError } from '../../webhooks/WebhookSender.js'
+import type { ILogger } from '../../../logger/ILogger.js'
 
 export interface ConciliationWorkers {
   conciliationWorker: Worker
   txConciliationWorker: Worker
   webhookWorker: Worker
   bankMovementWebhookWorker: Worker
+}
+
+/** True only on the attempt that exhausts the queue's retry budget. */
+function isFinalFailure(job: Job | undefined): boolean {
+  if (!job) return false
+  return job.attemptsMade >= (job.opts?.attempts ?? 1)
+}
+
+function lastStatusOf(err: Error): number | null {
+  const status = (err as Partial<WebhookError>).status
+  return typeof status === 'number' ? status : null
 }
 
 export function createConciliationWorkers(container: Container): ConciliationWorkers {
@@ -42,20 +56,83 @@ export function createConciliationWorkers(container: Container): ConciliationWor
     async (job) => { await conciliation.notifyWebhook.execute({ ...job.data, attempt: (job.attemptsMade ?? 0) + 1 }) },
     { connection: redis }
   )
-  webhookWorker.on('completed', (job) => webhookLog.info(`job ${job.id} completed`))
-  webhookWorker.on('failed', (job, err) =>
+  webhookWorker.on('completed', async (job) => {
+    webhookLog.info(`job ${job.id} completed`)
+    await resolveDeadLetter(
+      () => container.webhookDeadLetters.markResolved('conciliation_request', job.data.requestId),
+      webhookLog,
+    )
+  })
+  webhookWorker.on('failed', async (job, err) => {
     webhookLog.error(`job ${job?.id} failed (attempt ${job?.attemptsMade})`, { error: err.message })
-  )
+    if (!isFinalFailure(job)) return
+    await deadLetter(webhookLog, async () => {
+      const request = await container.conciliation.requestRepository.findById(job!.data.requestId)
+      if (!request) return null
+      return {
+        accountId: request.accountId,
+        subjectType: 'conciliation_request' as const,
+        subjectId: request.id,
+        url: null,
+        lastStatus: lastStatusOf(err),
+        lastError: err.message,
+        attempts: job!.attemptsMade,
+      }
+    })
+  })
 
   const bankMovementWebhookWorker = new Worker(
     'bank-movement-webhook',
     async (job) => { await container.banking.notifyBankMovement.execute({ ...job.data, attempt: (job.attemptsMade ?? 0) + 1 }) },
     { connection: redis }
   )
-  bankMovementWebhookWorker.on('completed', (job) => bankMovementWebhookLog.info(`job ${job.id} completed`))
-  bankMovementWebhookWorker.on('failed', (job, err) =>
+  bankMovementWebhookWorker.on('completed', async (job) => {
+    bankMovementWebhookLog.info(`job ${job.id} completed`)
+    await resolveDeadLetter(
+      () => container.webhookDeadLetters.markResolved('bank_transaction', job.data.bankTransactionId),
+      bankMovementWebhookLog,
+    )
+  })
+  bankMovementWebhookWorker.on('failed', async (job, err) => {
     bankMovementWebhookLog.error(`job ${job?.id} failed (attempt ${job?.attemptsMade})`, { error: err.message })
-  )
+    if (!isFinalFailure(job)) return
+    await deadLetter(bankMovementWebhookLog, async () => {
+      const tx = await container.banking.bankTransactionRepository.findById(job!.data.bankTransactionId)
+      if (!tx) return null
+      return {
+        accountId: tx.accountId,
+        subjectType: 'bank_transaction' as const,
+        subjectId: tx.id,
+        url: null,
+        lastStatus: lastStatusOf(err),
+        lastError: err.message,
+        attempts: job!.attemptsMade,
+      }
+    })
+  })
+
+  // Recording the dead-letter happens inside a fire-and-forget BullMQ event
+  // handler, so a transient DB error must not crash the worker. The partial
+  // unique index makes the upsert safe under at-least-once delivery.
+  async function deadLetter(
+    workerLog: ILogger,
+    build: () => Promise<Parameters<Container['webhookDeadLetters']['record']>[0] | null>,
+  ): Promise<void> {
+    try {
+      const entry = await build()
+      if (entry) await container.webhookDeadLetters.record(entry)
+    } catch (e) {
+      workerLog.error('dead-letter record failed', { error: (e as Error).message })
+    }
+  }
+
+  async function resolveDeadLetter(run: () => Promise<void>, workerLog: ILogger): Promise<void> {
+    try {
+      await run()
+    } catch (e) {
+      workerLog.error('dead-letter resolve failed', { error: (e as Error).message })
+    }
+  }
 
   return { conciliationWorker, txConciliationWorker, webhookWorker, bankMovementWebhookWorker }
 }

--- a/src/shared/infrastructure/queues/workers/conciliation.worker.ts
+++ b/src/shared/infrastructure/queues/workers/conciliation.worker.ts
@@ -39,7 +39,7 @@ export function createConciliationWorkers(container: Container): ConciliationWor
 
   const webhookWorker = new Worker(
     'webhook',
-    async (job) => { await conciliation.notifyWebhook.execute(job.data) },
+    async (job) => { await conciliation.notifyWebhook.execute({ ...job.data, attempt: (job.attemptsMade ?? 0) + 1 }) },
     { connection: redis }
   )
   webhookWorker.on('completed', (job) => webhookLog.info(`job ${job.id} completed`))
@@ -49,7 +49,7 @@ export function createConciliationWorkers(container: Container): ConciliationWor
 
   const bankMovementWebhookWorker = new Worker(
     'bank-movement-webhook',
-    async (job) => { await container.banking.notifyBankMovement.execute(job.data) },
+    async (job) => { await container.banking.notifyBankMovement.execute({ ...job.data, attempt: (job.attemptsMade ?? 0) + 1 }) },
     { connection: redis }
   )
   bankMovementWebhookWorker.on('completed', (job) => bankMovementWebhookLog.info(`job ${job.id} completed`))

--- a/src/shared/infrastructure/webhooks/IWebhookDeadLetterStore.ts
+++ b/src/shared/infrastructure/webhooks/IWebhookDeadLetterStore.ts
@@ -1,0 +1,32 @@
+import type { WebhookSubjectType } from './IWebhookNotificationLog.js'
+
+export interface WebhookDeadLetterEntry {
+  accountId: string
+  subjectType: WebhookSubjectType
+  subjectId: string
+  url: string | null
+  /** Last HTTP status seen; null when the final failure was a transport error. */
+  lastStatus: number | null
+  lastError: string | null
+  /** Total attempts made before the delivery was given up on. */
+  attempts: number
+}
+
+export interface WebhookDeadLetterRecord extends WebhookDeadLetterEntry {
+  id: string
+  failedAt: Date
+  resolvedAt: Date | null
+}
+
+export interface IWebhookDeadLetterStore {
+  /**
+   * Records a subject whose webhook delivery exhausted all retries. Idempotent
+   * per unresolved subject: a repeated final failure refreshes the existing row
+   * (status/error/attempts/failed_at) rather than creating a duplicate.
+   */
+  record(entry: WebhookDeadLetterEntry): Promise<void>
+  /** Unresolved dead-letters, newest first; scoped to an account when given. */
+  listUnresolved(accountId?: string): Promise<WebhookDeadLetterRecord[]>
+  /** Marks a subject's live dead-letter resolved. No-op when none is open. */
+  markResolved(subjectType: WebhookSubjectType, subjectId: string): Promise<void>
+}

--- a/src/shared/infrastructure/webhooks/IWebhookNotificationLog.ts
+++ b/src/shared/infrastructure/webhooks/IWebhookNotificationLog.ts
@@ -1,0 +1,19 @@
+export type WebhookSubjectType = 'bank_transaction' | 'conciliation_request'
+
+export interface WebhookNotificationLogEntry {
+  accountId: string
+  subjectType: WebhookSubjectType
+  subjectId: string
+  url: string
+  requestPayload: Record<string, unknown>
+  responseStatus: number | null
+  /** Raw response body string; the repository parses-or-wraps it into JSONB. */
+  responseBody: string | null
+  errorMessage: string | null
+  /** BullMQ attempt number (1-based). */
+  attempt: number
+}
+
+export interface IWebhookNotificationLog {
+  record(entry: WebhookNotificationLogEntry): Promise<void>
+}

--- a/src/shared/infrastructure/webhooks/LoggingWebhookSender.test.ts
+++ b/src/shared/infrastructure/webhooks/LoggingWebhookSender.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest'
+import { makeLoggingWebhookSender } from './LoggingWebhookSender.js'
+import type { WebhookError } from './WebhookSender.js'
+
+const ctx = {
+  accountId: 'acc-1',
+  subjectType: 'bank_transaction' as const,
+  subjectId: 'tx-1',
+  attempt: 1,
+}
+
+const opts = { url: 'https://hook', payload: { a: 1 }, authType: null, authToken: null }
+
+describe('makeLoggingWebhookSender', () => {
+  it('records a success entry and returns the inner result', async () => {
+    const log = { record: vi.fn().mockResolvedValue(undefined) }
+    const inner = vi.fn().mockResolvedValue({ status: 202, body: 'accepted' })
+    const send = makeLoggingWebhookSender(log, ctx, inner as any)
+
+    const result = await send(opts)
+
+    expect(result).toEqual({ status: 202, body: 'accepted' })
+    expect(log.record).toHaveBeenCalledTimes(1)
+    expect(log.record).toHaveBeenCalledWith({
+      ...ctx,
+      url: 'https://hook',
+      requestPayload: { a: 1 },
+      responseStatus: 202,
+      responseBody: 'accepted',
+      errorMessage: null,
+    })
+  })
+
+  it('records a failure entry with status/body and rethrows', async () => {
+    const log = { record: vi.fn().mockResolvedValue(undefined) }
+    const err = Object.assign(new Error('Webhook failed: 500'), { status: 500, body: 'boom' }) as WebhookError
+    const inner = vi.fn().mockRejectedValue(err)
+    const send = makeLoggingWebhookSender(log, ctx, inner as any)
+
+    await expect(send(opts)).rejects.toThrow('Webhook failed: 500')
+    expect(log.record).toHaveBeenCalledWith({
+      ...ctx,
+      url: 'https://hook',
+      requestPayload: { a: 1 },
+      responseStatus: 500,
+      responseBody: 'boom',
+      errorMessage: 'Webhook failed: 500',
+    })
+  })
+
+  it('records null status/body on a network error (no status on the error)', async () => {
+    const log = { record: vi.fn().mockResolvedValue(undefined) }
+    const inner = vi.fn().mockRejectedValue(new Error('ECONNRESET'))
+    const send = makeLoggingWebhookSender(log, ctx, inner as any)
+
+    await expect(send(opts)).rejects.toThrow('ECONNRESET')
+    expect(log.record).toHaveBeenCalledWith(expect.objectContaining({
+      responseStatus: null,
+      responseBody: null,
+      errorMessage: 'ECONNRESET',
+    }))
+  })
+})

--- a/src/shared/infrastructure/webhooks/LoggingWebhookSender.ts
+++ b/src/shared/infrastructure/webhooks/LoggingWebhookSender.ts
@@ -1,0 +1,52 @@
+import { sendWebhook } from './WebhookSender.js'
+import { IWebhookNotificationLog, WebhookSubjectType } from './IWebhookNotificationLog.js'
+
+export interface WebhookSubjectContext {
+  accountId: string
+  subjectType: WebhookSubjectType
+  subjectId: string
+  attempt: number
+}
+
+/**
+ * Wraps the pure `sendWebhook` so every delivery attempt — success or failure —
+ * is recorded to the shared notification log, without putting DB access into the
+ * sender itself. Returns a function matching `typeof sendWebhook` so it drops in
+ * as a use case's `sendWebhookFn`. Re-throws on failure to preserve retry semantics.
+ */
+export function makeLoggingWebhookSender(
+  log: IWebhookNotificationLog,
+  ctx: WebhookSubjectContext,
+  inner: typeof sendWebhook = sendWebhook,
+): typeof sendWebhook {
+  return async (opts) => {
+    try {
+      const result = await inner(opts)
+      await log.record({
+        ...ctx,
+        url: opts.url,
+        requestPayload: opts.payload,
+        responseStatus: result.status,
+        responseBody: result.body,
+        errorMessage: null,
+      })
+      return result
+    } catch (err) {
+      const status = typeof (err as { status?: unknown }).status === 'number'
+        ? (err as { status: number }).status
+        : null
+      const body = typeof (err as { body?: unknown }).body === 'string'
+        ? (err as { body: string }).body
+        : null
+      await log.record({
+        ...ctx,
+        url: opts.url,
+        requestPayload: opts.payload,
+        responseStatus: status,
+        responseBody: body,
+        errorMessage: (err as Error).message,
+      })
+      throw err
+    }
+  }
+}

--- a/src/shared/infrastructure/webhooks/WebhookDeadLetterRepository.test.ts
+++ b/src/shared/infrastructure/webhooks/WebhookDeadLetterRepository.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest'
+import { WebhookDeadLetterRepository } from './WebhookDeadLetterRepository.js'
+import type { WebhookDeadLetterEntry } from './IWebhookDeadLetterStore.js'
+
+function makeExecutor() {
+  return { query: vi.fn().mockResolvedValue({ rows: [], rowCount: 1 }) }
+}
+
+function entry(overrides: Partial<WebhookDeadLetterEntry> = {}): WebhookDeadLetterEntry {
+  return {
+    accountId: 'acc-1',
+    subjectType: 'bank_transaction',
+    subjectId: 'tx-1',
+    url: null,
+    lastStatus: 500,
+    lastError: 'Webhook failed: 500',
+    attempts: 12,
+    ...overrides,
+  }
+}
+
+describe('WebhookDeadLetterRepository', () => {
+  it('upserts on the unresolved-subject conflict with all fields in order', async () => {
+    const exec = makeExecutor()
+    const repo = new WebhookDeadLetterRepository(exec)
+    await repo.record(entry())
+    const [sql, params] = exec.query.mock.calls[0]
+    expect(sql).toMatch(/INSERT INTO webhook_dead_letters/)
+    expect(sql).toMatch(/ON CONFLICT \(subject_type, subject_id\) WHERE resolved_at IS NULL/)
+    expect(sql).toMatch(/DO UPDATE SET/)
+    expect(params).toEqual(['acc-1', 'bank_transaction', 'tx-1', null, 500, 'Webhook failed: 500', 12])
+  })
+
+  it('records a null lastStatus for transport failures', async () => {
+    const exec = makeExecutor()
+    const repo = new WebhookDeadLetterRepository(exec)
+    await repo.record(entry({ lastStatus: null, lastError: 'ECONNREFUSED' }))
+    const params = exec.query.mock.calls[0][1]
+    expect(params[4]).toBeNull()
+    expect(params[5]).toBe('ECONNREFUSED')
+  })
+
+  it('listUnresolved scopes by account when given and maps rows to records', async () => {
+    const exec = makeExecutor()
+    exec.query.mockResolvedValueOnce({
+      rows: [{
+        id: 'dl-1', account_id: 'acc-1', subject_type: 'bank_transaction', subject_id: 'tx-1',
+        url: null, last_status: 500, last_error: 'boom', attempts: 12,
+        failed_at: new Date('2026-06-01T00:00:00Z'), resolved_at: null,
+      }],
+      rowCount: 1,
+    })
+    const repo = new WebhookDeadLetterRepository(exec)
+    const out = await repo.listUnresolved('acc-1')
+    const [sql, params] = exec.query.mock.calls[0]
+    expect(sql).toMatch(/WHERE resolved_at IS NULL AND account_id = \$1/)
+    expect(params).toEqual(['acc-1'])
+    expect(out[0]).toEqual({
+      id: 'dl-1', accountId: 'acc-1', subjectType: 'bank_transaction', subjectId: 'tx-1',
+      url: null, lastStatus: 500, lastError: 'boom', attempts: 12,
+      failedAt: new Date('2026-06-01T00:00:00Z'), resolvedAt: null,
+    })
+  })
+
+  it('listUnresolved without account omits the account filter', async () => {
+    const exec = makeExecutor()
+    const repo = new WebhookDeadLetterRepository(exec)
+    await repo.listUnresolved()
+    const [sql, params] = exec.query.mock.calls[0]
+    expect(sql).not.toMatch(/account_id = \$1/)
+    expect(params).toBeUndefined()
+  })
+
+  it('markResolved closes only the open row for the subject', async () => {
+    const exec = makeExecutor()
+    const repo = new WebhookDeadLetterRepository(exec)
+    await repo.markResolved('conciliation_request', 'req-9')
+    const [sql, params] = exec.query.mock.calls[0]
+    expect(sql).toMatch(/UPDATE webhook_dead_letters/)
+    expect(sql).toMatch(/SET resolved_at = now\(\)/)
+    expect(sql).toMatch(/resolved_at IS NULL/)
+    expect(params).toEqual(['conciliation_request', 'req-9'])
+  })
+
+  it('withTx returns a new repository bound to the given executor', async () => {
+    const base = makeExecutor()
+    const txExec = makeExecutor()
+    const repo = new WebhookDeadLetterRepository(base)
+    const txRepo = repo.withTx(txExec)
+    expect(txRepo).not.toBe(repo)
+    await txRepo.record(entry())
+    expect(txExec.query).toHaveBeenCalled()
+    expect(base.query).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/infrastructure/webhooks/WebhookDeadLetterRepository.ts
+++ b/src/shared/infrastructure/webhooks/WebhookDeadLetterRepository.ts
@@ -1,0 +1,104 @@
+import type { QueryResult, QueryResultRow } from 'pg'
+import type { WebhookSubjectType } from './IWebhookNotificationLog.js'
+import {
+  IWebhookDeadLetterStore,
+  WebhookDeadLetterEntry,
+  WebhookDeadLetterRecord,
+} from './IWebhookDeadLetterStore.js'
+
+// Minimal executor shape, kept local so shared infra does not depend on any
+// bounded context. Structurally satisfied by every context's executorFromPool.
+export interface Executor {
+  query<R extends QueryResultRow = QueryResultRow>(
+    text: string,
+    params?: unknown[]
+  ): Promise<QueryResult<R>>
+}
+
+interface DeadLetterRow {
+  id: string
+  account_id: string
+  subject_type: WebhookSubjectType
+  subject_id: string
+  url: string | null
+  last_status: number | null
+  last_error: string | null
+  attempts: number
+  failed_at: Date
+  resolved_at: Date | null
+}
+
+function toRecord(row: DeadLetterRow): WebhookDeadLetterRecord {
+  return {
+    id: row.id,
+    accountId: row.account_id,
+    subjectType: row.subject_type,
+    subjectId: row.subject_id,
+    url: row.url,
+    lastStatus: row.last_status,
+    lastError: row.last_error,
+    attempts: row.attempts,
+    failedAt: row.failed_at,
+    resolvedAt: row.resolved_at,
+  }
+}
+
+export class WebhookDeadLetterRepository implements IWebhookDeadLetterStore {
+  constructor(private readonly executor: Executor) {}
+
+  withTx(tx: Executor): WebhookDeadLetterRepository {
+    return new WebhookDeadLetterRepository(tx)
+  }
+
+  async record(entry: WebhookDeadLetterEntry): Promise<void> {
+    // Upsert against the partial unique index on (subject_type, subject_id)
+    // WHERE resolved_at IS NULL, so a repeated final failure of the same open
+    // subject refreshes the row in place.
+    await this.executor.query(
+      `INSERT INTO webhook_dead_letters
+         (id, account_id, subject_type, subject_id, url, last_status, last_error, attempts)
+       VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (subject_type, subject_id) WHERE resolved_at IS NULL
+       DO UPDATE SET
+         url         = EXCLUDED.url,
+         last_status = EXCLUDED.last_status,
+         last_error  = EXCLUDED.last_error,
+         attempts    = EXCLUDED.attempts,
+         failed_at   = now()`,
+      [
+        entry.accountId,
+        entry.subjectType,
+        entry.subjectId,
+        entry.url,
+        entry.lastStatus,
+        entry.lastError,
+        entry.attempts,
+      ]
+    )
+  }
+
+  async listUnresolved(accountId?: string): Promise<WebhookDeadLetterRecord[]> {
+    const { rows } = accountId
+      ? await this.executor.query<DeadLetterRow>(
+          `SELECT * FROM webhook_dead_letters
+           WHERE resolved_at IS NULL AND account_id = $1
+           ORDER BY failed_at DESC`,
+          [accountId]
+        )
+      : await this.executor.query<DeadLetterRow>(
+          `SELECT * FROM webhook_dead_letters
+           WHERE resolved_at IS NULL
+           ORDER BY failed_at DESC`
+        )
+    return rows.map(toRecord)
+  }
+
+  async markResolved(subjectType: WebhookSubjectType, subjectId: string): Promise<void> {
+    await this.executor.query(
+      `UPDATE webhook_dead_letters
+       SET resolved_at = now()
+       WHERE subject_type = $1 AND subject_id = $2 AND resolved_at IS NULL`,
+      [subjectType, subjectId]
+    )
+  }
+}

--- a/src/shared/infrastructure/webhooks/WebhookNotificationLogRepository.test.ts
+++ b/src/shared/infrastructure/webhooks/WebhookNotificationLogRepository.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest'
+import { WebhookNotificationLogRepository } from './WebhookNotificationLogRepository.js'
+import type { WebhookNotificationLogEntry } from './IWebhookNotificationLog.js'
+
+function makeExecutor() {
+  return { query: vi.fn().mockResolvedValue({ rows: [], rowCount: 1 }) }
+}
+
+function entry(overrides: Partial<WebhookNotificationLogEntry> = {}): WebhookNotificationLogEntry {
+  return {
+    accountId: 'acc-1',
+    subjectType: 'bank_transaction',
+    subjectId: 'tx-1',
+    url: 'https://hook.example.com',
+    requestPayload: { id: 'tx-1', amount: 100 },
+    responseStatus: 200,
+    responseBody: '{"ok":true}',
+    errorMessage: null,
+    attempt: 1,
+    ...overrides,
+  }
+}
+
+describe('WebhookNotificationLogRepository', () => {
+  it('inserts a row with all fields in order', async () => {
+    const exec = makeExecutor()
+    const repo = new WebhookNotificationLogRepository(exec)
+    await repo.record(entry())
+    const [sql, params] = exec.query.mock.calls[0]
+    expect(sql).toMatch(/INSERT INTO webhook_notifications/)
+    expect(params).toEqual([
+      'acc-1',
+      'bank_transaction',
+      'tx-1',
+      'https://hook.example.com',
+      JSON.stringify({ id: 'tx-1', amount: 100 }),
+      200,
+      '{"ok":true}',          // already valid JSON → passed through for ::jsonb cast
+      null,
+      1,
+    ])
+  })
+
+  it('wraps a non-JSON response body as a JSON string node', async () => {
+    const exec = makeExecutor()
+    const repo = new WebhookNotificationLogRepository(exec)
+    await repo.record(entry({ responseBody: 'plain text not json' }))
+    const params = exec.query.mock.calls[0][1]
+    expect(params[6]).toBe(JSON.stringify('plain text not json'))
+  })
+
+  it('truncates an oversized response body to bound row size', async () => {
+    const exec = makeExecutor()
+    const repo = new WebhookNotificationLogRepository(exec)
+    const huge = 'x'.repeat(20_000)
+    await repo.record(entry({ responseBody: huge }))
+    const stored = JSON.parse(exec.query.mock.calls[0][1][6] as string)
+    expect(typeof stored).toBe('string')
+    expect(stored.length).toBeLessThanOrEqual(10_000)
+  })
+
+  it('maps null response body and null status (network error)', async () => {
+    const exec = makeExecutor()
+    const repo = new WebhookNotificationLogRepository(exec)
+    await repo.record(entry({ responseStatus: null, responseBody: null, errorMessage: 'ECONNRESET' }))
+    const params = exec.query.mock.calls[0][1]
+    expect(params[5]).toBeNull()       // response_status
+    expect(params[6]).toBeNull()       // response_body
+    expect(params[7]).toBe('ECONNRESET')
+  })
+
+  it('withTx returns a new repository bound to the given executor', async () => {
+    const base = makeExecutor()
+    const txExec = makeExecutor()
+    const repo = new WebhookNotificationLogRepository(base)
+    const txRepo = repo.withTx(txExec)
+    expect(txRepo).not.toBe(repo)
+    await txRepo.record(entry())
+    expect(txExec.query).toHaveBeenCalled()
+    expect(base.query).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/infrastructure/webhooks/WebhookNotificationLogRepository.ts
+++ b/src/shared/infrastructure/webhooks/WebhookNotificationLogRepository.ts
@@ -1,0 +1,62 @@
+import type { QueryResult, QueryResultRow } from 'pg'
+import { IWebhookNotificationLog, WebhookNotificationLogEntry } from './IWebhookNotificationLog.js'
+
+// Minimal executor shape, kept local so shared infra does not depend on any
+// bounded context. Structurally satisfied by every context's executorFromPool.
+export interface Executor {
+  query<R extends QueryResultRow = QueryResultRow>(
+    text: string,
+    params?: unknown[]
+  ): Promise<QueryResult<R>>
+}
+
+// Cap on the stored response body. Keeps a pathological multi-MB webhook
+// response from bloating the audit table (one row per attempt, x retries).
+const MAX_BODY_CHARS = 10_000
+
+/**
+ * Coerces a raw response body string into a value safe to cast to JSONB:
+ * if it is already valid JSON (and within the size cap) it is passed through;
+ * otherwise it is wrapped as a JSON string node so the column is always valid
+ * JSONB. Oversized bodies are truncated and stored as a string node.
+ */
+function toJsonbParam(body: string | null): string | null {
+  if (body === null) return null
+  if (body.length > MAX_BODY_CHARS) {
+    return JSON.stringify(body.slice(0, MAX_BODY_CHARS))
+  }
+  try {
+    JSON.parse(body)
+    return body
+  } catch {
+    return JSON.stringify(body)
+  }
+}
+
+export class WebhookNotificationLogRepository implements IWebhookNotificationLog {
+  constructor(private readonly executor: Executor) {}
+
+  withTx(tx: Executor): WebhookNotificationLogRepository {
+    return new WebhookNotificationLogRepository(tx)
+  }
+
+  async record(entry: WebhookNotificationLogEntry): Promise<void> {
+    await this.executor.query(
+      `INSERT INTO webhook_notifications
+         (id, account_id, subject_type, subject_id, url, request_payload,
+          response_status, response_body, error_message, attempt)
+       VALUES (gen_random_uuid(), $1, $2, $3, $4, $5::jsonb, $6, $7::jsonb, $8, $9)`,
+      [
+        entry.accountId,
+        entry.subjectType,
+        entry.subjectId,
+        entry.url,
+        JSON.stringify(entry.requestPayload),
+        entry.responseStatus,
+        toJsonbParam(entry.responseBody),
+        entry.errorMessage,
+        entry.attempt,
+      ]
+    )
+  }
+}

--- a/src/shared/infrastructure/webhooks/WebhookSender.test.ts
+++ b/src/shared/infrastructure/webhooks/WebhookSender.test.ts
@@ -91,6 +91,37 @@ describe('sendWebhook', () => {
     expect(headers['Authorization']).toBe('Bearer tok')
   })
 
+  it('returns the status and body on success', async () => {
+    fetchMock.mockResolvedValue(makeResponse(202, 'accepted', 'Accepted'))
+    const result = await sendWebhook({
+      url: 'https://example.com/x',
+      payload: {},
+      authType: null,
+      authToken: null,
+    })
+    expect(result).toEqual({ status: 202, body: 'accepted' })
+  })
+
+  it('attaches the status code to the thrown error on failure', async () => {
+    fetchMock.mockResolvedValue(makeResponse(503, 'down', 'Service Unavailable'))
+    await expect(sendWebhook({
+      url: 'https://example.com/x',
+      payload: {},
+      authType: null,
+      authToken: null,
+    })).rejects.toMatchObject({ status: 503 })
+  })
+
+  it('attaches the response body to the thrown error on failure', async () => {
+    fetchMock.mockResolvedValue(makeResponse(422, '{"code":"bad"}', 'Unprocessable Entity'))
+    await expect(sendWebhook({
+      url: 'https://example.com/x',
+      payload: {},
+      authType: null,
+      authToken: null,
+    })).rejects.toMatchObject({ status: 422, body: '{"code":"bad"}' })
+  })
+
   it('throws when response is not ok and includes body excerpt', async () => {
     fetchMock.mockResolvedValue(makeResponse(500, 'server exploded', 'Internal Server Error'))
     await expect(sendWebhook({
@@ -124,7 +155,7 @@ describe('sendWebhook', () => {
       payload: { a: 1 },
       authType: null,
       authToken: null,
-    })).resolves.toBeUndefined()
+    })).resolves.toEqual({ status: 200, body: '' })
     expect(childLog.info).toHaveBeenCalledWith('response', expect.objectContaining({ status: 200, body: '' }))
   })
 

--- a/src/shared/infrastructure/webhooks/WebhookSender.ts
+++ b/src/shared/infrastructure/webhooks/WebhookSender.ts
@@ -11,7 +11,17 @@ interface SendWebhookOptions {
   authToken: string | null
 }
 
-export async function sendWebhook({ url, payload, authType, authToken }: SendWebhookOptions): Promise<void> {
+export interface WebhookResult {
+  status: number
+  body: string
+}
+
+export interface WebhookError extends Error {
+  status: number
+  body: string
+}
+
+export async function sendWebhook({ url, payload, authType, authToken }: SendWebhookOptions): Promise<WebhookResult> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json', 'Accept': 'application/json' }
   if (authToken) {
     headers['Authorization'] = authType === 'api_key' ? `Api-Key ${authToken}` : `Bearer ${authToken}`
@@ -27,9 +37,14 @@ export async function sendWebhook({ url, payload, authType, authToken }: SendWeb
   log.info(`response`, { status: response.status, statusText: response.statusText, body: responseBody })
 
   if (!response.ok) {
-    throw new Error(
+    const error = new Error(
       `Webhook failed: ${response.status} ${response.statusText}` +
       (responseBody ? ` — ${responseBody.slice(0, 300)}` : '')
-    )
+    ) as WebhookError
+    error.status = response.status
+    error.body = responseBody
+    throw error
   }
+
+  return { status: response.status, body: responseBody }
 }

--- a/tests/integration/banking/NotifyBankMovementUseCase.integration.test.ts
+++ b/tests/integration/banking/NotifyBankMovementUseCase.integration.test.ts
@@ -13,6 +13,7 @@ import { AccountForBankingReaderAdapter } from '../../../src/contexts/banking/in
 import { NotificationConfigReaderAdapter } from '../../../src/contexts/banking/infrastructure/adapters/NotificationConfigReaderAdapter.js'
 import { UserOperationModeReaderAdapter } from '../../../src/contexts/banking/infrastructure/adapters/UserOperationModeReaderAdapter.js'
 import { NotifyBankMovementUseCase } from '../../../src/contexts/banking/application/NotifyBankMovementUseCase.js'
+import { WebhookNotificationLogRepository } from '../../../src/shared/infrastructure/webhooks/WebhookNotificationLogRepository.js'
 import { BankTransaction } from '../../../src/contexts/banking/domain/BankTransaction.js'
 
 let user: SeededUser
@@ -77,6 +78,7 @@ function buildUseCase(sendWebhookFn: any) {
     accountReader: new AccountForBankingReaderAdapter(new AccountRepository(accountExec(pool)), new AccountConfigRepository(accountExec(pool))),
     configReader: new NotificationConfigReaderAdapter(new AccountConfigRepository(accountExec(pool))),
     userModeReader: new UserOperationModeReaderAdapter(new UserRepository(userExec(pool))),
+    webhookLog: new WebhookNotificationLogRepository({ query: (text, params) => pool.query(text, params as any) }),
     sendWebhookFn,
   })
 }
@@ -97,7 +99,7 @@ describe('NotifyBankMovementUseCase (integration)', () => {
   it('happy path: claims notification and invokes send with correct payload', async () => {
     await seedAccountConfig()
     const tx = await seedBankTx()
-    const send = vi.fn().mockResolvedValue(undefined)
+    const send = vi.fn().mockResolvedValue({ status: 200, body: '' })
     const useCase = buildUseCase(send)
     await useCase.execute({ bankTransactionId: tx.id })
 
@@ -111,6 +113,40 @@ describe('NotifyBankMovementUseCase (integration)', () => {
     expect(call.payload.received_at).toBe(new Date('2024-05-01T10:00:00Z').toISOString())
     expect(call.payload.source).toBe('bank')
     expect(await txRepo.isNotified(tx.id)).toBe(true)
+
+    const { rows } = await getTestPool().query(
+      `SELECT subject_type, subject_id, account_id, response_status, error_message, attempt
+         FROM webhook_notifications WHERE subject_id = $1`,
+      [tx.id]
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].subject_type).toBe('bank_transaction')
+    expect(rows[0].account_id).toBe(account.id)
+    expect(rows[0].response_status).toBe(200)
+    expect(rows[0].error_message).toBeNull()
+    expect(rows[0].attempt).toBe(1)
+  })
+
+  it('logs a failure entry, releases the claim, and rethrows', async () => {
+    await seedAccountConfig()
+    const tx = await seedBankTx()
+    const err = Object.assign(new Error('Webhook failed: 500'), { status: 500, body: 'down' })
+    const send = vi.fn().mockRejectedValue(err)
+    const useCase = buildUseCase(send)
+
+    await expect(useCase.execute({ bankTransactionId: tx.id, attempt: 2 })).rejects.toThrow('Webhook failed: 500')
+    expect(await txRepo.isNotified(tx.id)).toBe(false)
+
+    const { rows } = await getTestPool().query(
+      `SELECT response_status, response_body, error_message, attempt
+         FROM webhook_notifications WHERE subject_id = $1`,
+      [tx.id]
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].response_status).toBe(500)
+    expect(rows[0].response_body).toBe('down')
+    expect(rows[0].error_message).toBe('Webhook failed: 500')
+    expect(rows[0].attempt).toBe(2)
   })
 
   it('silentIngestion=true claims but does not send', async () => {
@@ -162,7 +198,7 @@ describe('NotifyBankMovementUseCase (integration)', () => {
   it('second invocation with the same tx does not double-send (claim already taken)', async () => {
     await seedAccountConfig()
     const tx = await seedBankTx()
-    const send = vi.fn().mockResolvedValue(undefined)
+    const send = vi.fn().mockResolvedValue({ status: 200, body: '' })
     const useCase = buildUseCase(send)
     await useCase.execute({ bankTransactionId: tx.id })
     await useCase.execute({ bankTransactionId: tx.id })

--- a/tests/integration/banking/WebhookRetryDeadLetter.integration.test.ts
+++ b/tests/integration/banking/WebhookRetryDeadLetter.integration.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser, seedAccount, SeededAccount, SeededUser } from '../helpers/seed.js'
+import { BankTransactionRepository } from '../../../src/contexts/banking/infrastructure/BankTransactionRepository.js'
+import { executorFromPool as bankingExec } from '../../../src/contexts/banking/infrastructure/Executor.js'
+import { executorFromPool as accountExec } from '../../../src/contexts/account/infrastructure/Executor.js'
+import { executorFromPool as userExec } from '../../../src/contexts/user/infrastructure/Executor.js'
+import { AccountRepository } from '../../../src/contexts/account/infrastructure/AccountRepository.js'
+import { AccountConfigRepository } from '../../../src/contexts/account/infrastructure/AccountConfigRepository.js'
+import { UserRepository } from '../../../src/contexts/user/infrastructure/UserRepository.js'
+import { AccountForBankingReaderAdapter } from '../../../src/contexts/banking/infrastructure/adapters/AccountForBankingReaderAdapter.js'
+import { NotificationConfigReaderAdapter } from '../../../src/contexts/banking/infrastructure/adapters/NotificationConfigReaderAdapter.js'
+import { UserOperationModeReaderAdapter } from '../../../src/contexts/banking/infrastructure/adapters/UserOperationModeReaderAdapter.js'
+import { NotifyBankMovementUseCase } from '../../../src/contexts/banking/application/NotifyBankMovementUseCase.js'
+import { WebhookNotificationLogRepository } from '../../../src/shared/infrastructure/webhooks/WebhookNotificationLogRepository.js'
+import { WebhookDeadLetterRepository } from '../../../src/shared/infrastructure/webhooks/WebhookDeadLetterRepository.js'
+import { BankTransaction } from '../../../src/contexts/banking/domain/BankTransaction.js'
+
+let user: SeededUser
+let account: SeededAccount
+let scriptId: string
+let txRepo: BankTransactionRepository
+let deadLetters: WebhookDeadLetterRepository
+
+async function getActiveScriptId(): Promise<string> {
+  const { rows } = await getTestPool().query(
+    `SELECT id FROM bank_scripts WHERE bank='mi-dinero' AND flow_type='extract_transactions' AND status='active' LIMIT 1`
+  )
+  return rows[0].id
+}
+
+async function seedAccountConfig(): Promise<void> {
+  await getTestPool().query(
+    `INSERT INTO account_config
+      (id, account_id, pending_orders_endpoint, webhook_url, retry_limit,
+       polling_method, polling_body, auth_type, auth_token,
+       webhook_auth_type, webhook_auth_token, notify_on_expired,
+       webhook_extra_fields, silent_ingestion)
+     VALUES (gen_random_uuid(),$1,$2,$3,3,'GET',NULL,'bearer','tok',NULL,NULL,false,NULL,false)`,
+    [account.id, 'https://orders.example/pending', 'https://hook.example.com']
+  )
+}
+
+async function seedBankTx(): Promise<BankTransaction> {
+  const tx = BankTransaction.create(crypto.randomUUID(), {
+    accountId: account.id,
+    externalId: `ext-${crypto.randomBytes(3).toString('hex')}`,
+    referenceHash: 'ref',
+    amount: 250,
+    currency: 'USD',
+    senderName: 'Alice',
+    receivedAt: new Date('2024-05-01T10:00:00Z'),
+    scriptId,
+    rawPayload: { foo: 'bar' },
+  })
+  await txRepo.save(tx)
+  return tx
+}
+
+function buildUseCase(sendWebhookFn: any) {
+  const pool = getTestPool()
+  return new NotifyBankMovementUseCase({
+    bankTxRepo: txRepo,
+    accountReader: new AccountForBankingReaderAdapter(new AccountRepository(accountExec(pool)), new AccountConfigRepository(accountExec(pool))),
+    configReader: new NotificationConfigReaderAdapter(new AccountConfigRepository(accountExec(pool))),
+    userModeReader: new UserOperationModeReaderAdapter(new UserRepository(userExec(pool))),
+    webhookLog: new WebhookNotificationLogRepository({ query: (text, params) => pool.query(text, params as any) }),
+    sendWebhookFn,
+  })
+}
+
+/** Mirrors the worker's final-failure handler: dead-letter the exhausted subject. */
+async function deadLetterFinalFailure(tx: BankTransaction, err: Error, attempts: number): Promise<void> {
+  const status = (err as { status?: unknown }).status
+  await deadLetters.record({
+    accountId: tx.accountId,
+    subjectType: 'bank_transaction',
+    subjectId: tx.id,
+    url: null,
+    lastStatus: typeof status === 'number' ? status : null,
+    lastError: err.message,
+    attempts,
+  })
+}
+
+describe('Webhook retry + dead-letter (integration)', () => {
+  beforeEach(async () => {
+    await truncateAll()
+    const pool = getTestPool()
+    user = await seedUser({ email: `wrdl-${crypto.randomBytes(3).toString('hex')}@test.com`, operationMode: 'passthrough' })
+    account = await seedAccount(user.id)
+    scriptId = await getActiveScriptId()
+    txRepo = new BankTransactionRepository(bankingExec(pool))
+    deadLetters = new WebhookDeadLetterRepository({ query: (text, params) => pool.query(text, params as any) })
+    await seedAccountConfig()
+  })
+  afterAll(async () => { await closeTestPool() })
+
+  it('records every attempt, dead-letters on exhaustion, and resolves on re-drive', async () => {
+    const tx = await seedBankTx()
+
+    // Three failing attempts: 401, 500, then a transport error with no HTTP status.
+    const attemptErrors = [
+      Object.assign(new Error('Webhook failed: 401'), { status: 401, body: 'bad token' }),
+      Object.assign(new Error('Webhook failed: 500'), { status: 500, body: 'oops' }),
+      new Error('The operation was aborted due to timeout'),
+    ]
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      const send = vi.fn().mockRejectedValue(attemptErrors[attempt - 1])
+      await expect(buildUseCase(send).execute({ bankTransactionId: tx.id, attempt }))
+        .rejects.toThrow(attemptErrors[attempt - 1].message)
+    }
+
+    // (a) one audit row per attempt, 1-based, with the right status/body.
+    const audit = await getTestPool().query(
+      `SELECT attempt, response_status, response_body, error_message
+         FROM webhook_notifications WHERE subject_id = $1 ORDER BY attempt`,
+      [tx.id]
+    )
+    expect(audit.rows.map(r => r.attempt)).toEqual([1, 2, 3])
+    expect(audit.rows.map(r => r.response_status)).toEqual([401, 500, null])
+    expect(audit.rows[0].response_body).toBe('bad token')
+    expect(audit.rows[2].response_body).toBeNull()
+
+    // (b) after the final failure the worker dead-letters the subject.
+    await deadLetterFinalFailure(tx, attemptErrors[2], 3)
+    const dl = await deadLetters.listUnresolved(account.id)
+    expect(dl).toHaveLength(1)
+    expect(dl[0]).toMatchObject({ subjectId: tx.id, lastStatus: null, attempts: 3, resolvedAt: null })
+    expect(dl[0].lastError).toBe('The operation was aborted due to timeout')
+    // The movement is released — without the dead-letter it would be
+    // indistinguishable from one never attempted.
+    expect(await txRepo.isNotified(tx.id)).toBe(false)
+
+    // (c) re-drive: the endpoint is back, delivery succeeds, dead-letter resolves.
+    const okSend = vi.fn().mockResolvedValue({ status: 200, body: '{"ok":true}' })
+    await buildUseCase(okSend).execute({ bankTransactionId: tx.id, attempt: 4 })
+    await deadLetters.markResolved('bank_transaction', tx.id) // worker's `completed` handler
+
+    expect(await txRepo.isNotified(tx.id)).toBe(true)
+    expect(await deadLetters.listUnresolved(account.id)).toHaveLength(0)
+    const success = await getTestPool().query(
+      `SELECT response_status FROM webhook_notifications WHERE subject_id = $1 AND attempt = 4`,
+      [tx.id]
+    )
+    expect(success.rows[0].response_status).toBe(200)
+  })
+})

--- a/tests/integration/conciliation/NotifyWebhookUseCase.integration.test.ts
+++ b/tests/integration/conciliation/NotifyWebhookUseCase.integration.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser, seedAccount, SeededAccount } from '../helpers/seed.js'
+import { insertConciliationRequest, insertBankTransaction, insertAccountConfig } from './helpers.js'
+import { executorFromPool } from '../../../src/contexts/conciliation/infrastructure/Executor.js'
+import { ConciliationRequestRepository } from '../../../src/contexts/conciliation/infrastructure/ConciliationRequestRepository.js'
+import { ConciliatedTransactionRepository } from '../../../src/contexts/conciliation/infrastructure/ConciliatedTransactionRepository.js'
+import { AccountConfigReaderAdapter } from '../../../src/contexts/conciliation/infrastructure/adapters/AccountConfigReaderAdapter.js'
+import { NotifyWebhookUseCase } from '../../../src/contexts/conciliation/application/NotifyWebhookUseCase.js'
+import { WebhookNotificationLogRepository } from '../../../src/shared/infrastructure/webhooks/WebhookNotificationLogRepository.js'
+
+let account: SeededAccount
+
+function buildUseCase(sendWebhookFn: any) {
+  const pool = getTestPool()
+  return new NotifyWebhookUseCase({
+    requestRepo: new ConciliationRequestRepository(executorFromPool(pool)),
+    matchRepo: new ConciliatedTransactionRepository(executorFromPool(pool)),
+    configReader: new AccountConfigReaderAdapter(pool),
+    webhookLog: new WebhookNotificationLogRepository({ query: (text, params) => pool.query(text, params as any) }),
+    sendWebhookFn,
+  })
+}
+
+async function isNotified(matchId: string): Promise<boolean> {
+  const { rows } = await getTestPool().query(
+    'SELECT is_notified FROM conciliated_transactions WHERE id = $1', [matchId]
+  )
+  return !!rows[0]?.is_notified
+}
+
+describe('NotifyWebhookUseCase (integration)', () => {
+  beforeEach(async () => {
+    await truncateAll()
+    const user = await seedUser({ email: `nw-${crypto.randomBytes(3).toString('hex')}@test.com` })
+    account = await seedAccount(user.id)
+    await insertAccountConfig(account.id)
+  })
+  afterAll(async () => { await closeTestPool() })
+
+  it('matched: sends, marks notified, and logs a webhook_notifications row', async () => {
+    const request = await insertConciliationRequest({ accountId: account.id, status: 'matched' })
+    const bankTx = await insertBankTransaction({ accountId: account.id })
+    const matchId = crypto.randomUUID()
+    await new ConciliatedTransactionRepository(executorFromPool(getTestPool())).save({
+      id: matchId, accountId: account.id, requestId: request.id, bankTransactionId: bankTx.id,
+    })
+
+    const send = vi.fn().mockResolvedValue({ status: 200, body: '{"received":true}' })
+    await buildUseCase(send).execute({ requestId: request.id })
+
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(await isNotified(matchId)).toBe(true)
+
+    const { rows } = await getTestPool().query(
+      `SELECT subject_type, subject_id, account_id, response_status, error_message, attempt
+         FROM webhook_notifications WHERE subject_id = $1`,
+      [request.id]
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].subject_type).toBe('conciliation_request')
+    expect(rows[0].account_id).toBe(account.id)
+    expect(rows[0].response_status).toBe(200)
+    expect(rows[0].error_message).toBeNull()
+    expect(rows[0].attempt).toBe(1)
+  })
+
+  it('logs a failure row, does not mark notified, and rethrows', async () => {
+    const request = await insertConciliationRequest({ accountId: account.id, status: 'matched' })
+    const bankTx = await insertBankTransaction({ accountId: account.id })
+    const matchId = crypto.randomUUID()
+    await new ConciliatedTransactionRepository(executorFromPool(getTestPool())).save({
+      id: matchId, accountId: account.id, requestId: request.id, bankTransactionId: bankTx.id,
+    })
+
+    const err = Object.assign(new Error('Webhook failed: 503'), { status: 503, body: 'down' })
+    const send = vi.fn().mockRejectedValue(err)
+
+    await expect(buildUseCase(send).execute({ requestId: request.id, attempt: 2 }))
+      .rejects.toThrow('Webhook failed: 503')
+    expect(await isNotified(matchId)).toBe(false)
+
+    const { rows } = await getTestPool().query(
+      `SELECT response_status, response_body, error_message, attempt
+         FROM webhook_notifications WHERE subject_id = $1`,
+      [request.id]
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].response_status).toBe(503)
+    expect(rows[0].response_body).toBe('down')
+    expect(rows[0].error_message).toBe('Webhook failed: 503')
+    expect(rows[0].attempt).toBe(2)
+  })
+})

--- a/tests/integration/helpers/testDb.ts
+++ b/tests/integration/helpers/testDb.ts
@@ -13,6 +13,7 @@ export function getTestPool(): pg.Pool {
 }
 
 const ALL_DOMAIN_TABLES = [
+  'webhook_dead_letters',
   'webhook_notifications',
   'conciliated_transactions',
   'conciliation_attempts',

--- a/tests/integration/helpers/testDb.ts
+++ b/tests/integration/helpers/testDb.ts
@@ -13,6 +13,7 @@ export function getTestPool(): pg.Pool {
 }
 
 const ALL_DOMAIN_TABLES = [
+  'webhook_notifications',
   'conciliated_transactions',
   'conciliation_attempts',
   'conciliation_requests',

--- a/tests/integration/shared/WebhookDeadLetterRepository.integration.test.ts
+++ b/tests/integration/shared/WebhookDeadLetterRepository.integration.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser, seedAccount, SeededAccount, SeededUser } from '../helpers/seed.js'
+import { WebhookDeadLetterRepository } from '../../../src/shared/infrastructure/webhooks/WebhookDeadLetterRepository.js'
+import type { WebhookDeadLetterEntry } from '../../../src/shared/infrastructure/webhooks/IWebhookDeadLetterStore.js'
+
+let user: SeededUser
+let account: SeededAccount
+let repo: WebhookDeadLetterRepository
+
+function entry(overrides: Partial<WebhookDeadLetterEntry> = {}): WebhookDeadLetterEntry {
+  return {
+    accountId: account.id,
+    subjectType: 'bank_transaction',
+    subjectId: crypto.randomUUID(),
+    url: null,
+    lastStatus: 500,
+    lastError: 'Webhook failed: 500',
+    attempts: 12,
+    ...overrides,
+  }
+}
+
+describe('WebhookDeadLetterRepository (integration)', () => {
+  beforeEach(async () => {
+    await truncateAll()
+    user = await seedUser({ email: `wdl-${crypto.randomBytes(3).toString('hex')}@test.com` })
+    account = await seedAccount(user.id)
+    repo = new WebhookDeadLetterRepository({
+      query: (text, params) => getTestPool().query(text, params as any),
+    })
+  })
+  afterAll(async () => { await closeTestPool() })
+
+  it('records and lists an unresolved dead-letter', async () => {
+    const e = entry()
+    await repo.record(e)
+    const out = await repo.listUnresolved(account.id)
+    expect(out).toHaveLength(1)
+    expect(out[0]).toMatchObject({
+      accountId: account.id,
+      subjectType: 'bank_transaction',
+      subjectId: e.subjectId,
+      lastStatus: 500,
+      lastError: 'Webhook failed: 500',
+      attempts: 12,
+      resolvedAt: null,
+    })
+  })
+
+  it('upserts in place for a repeated final failure of the same open subject', async () => {
+    const subjectId = crypto.randomUUID()
+    await repo.record(entry({ subjectId, lastStatus: 500, attempts: 6 }))
+    await repo.record(entry({ subjectId, lastStatus: 503, lastError: 'still down', attempts: 12 }))
+
+    const { rows } = await getTestPool().query(
+      'SELECT last_status, last_error, attempts FROM webhook_dead_letters WHERE subject_id = $1',
+      [subjectId]
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].last_status).toBe(503)
+    expect(rows[0].last_error).toBe('still down')
+    expect(rows[0].attempts).toBe(12)
+  })
+
+  it('markResolved frees the subject so a new failure records again', async () => {
+    const subjectId = crypto.randomUUID()
+    await repo.record(entry({ subjectId }))
+    await repo.markResolved('bank_transaction', subjectId)
+
+    expect(await repo.listUnresolved(account.id)).toHaveLength(0)
+
+    // A fresh failure after resolution opens a new live row.
+    await repo.record(entry({ subjectId }))
+    expect(await repo.listUnresolved(account.id)).toHaveLength(1)
+
+    const { rows } = await getTestPool().query(
+      'SELECT resolved_at FROM webhook_dead_letters WHERE subject_id = $1 ORDER BY failed_at',
+      [subjectId]
+    )
+    expect(rows).toHaveLength(2)
+    expect(rows.filter(r => r.resolved_at === null)).toHaveLength(1)
+  })
+
+  it('listUnresolved scopes by account', async () => {
+    const otherUser = await seedUser({ email: `wdl2-${crypto.randomBytes(3).toString('hex')}@test.com` })
+    const otherAccount = await seedAccount(otherUser.id)
+    await repo.record(entry())
+    await repo.record(entry({ accountId: otherAccount.id }))
+
+    expect(await repo.listUnresolved(account.id)).toHaveLength(1)
+    expect(await repo.listUnresolved(otherAccount.id)).toHaveLength(1)
+    expect(await repo.listUnresolved()).toHaveLength(2)
+  })
+
+  it('cascades on account deletion (FK ON DELETE CASCADE)', async () => {
+    const e = entry()
+    await repo.record(e)
+    await getTestPool().query('DELETE FROM accounts WHERE id = $1', [account.id])
+    const { rows } = await getTestPool().query(
+      'SELECT 1 FROM webhook_dead_letters WHERE subject_id = $1',
+      [e.subjectId]
+    )
+    expect(rows).toHaveLength(0)
+  })
+})

--- a/tests/integration/shared/WebhookNotificationLogRepository.integration.test.ts
+++ b/tests/integration/shared/WebhookNotificationLogRepository.integration.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser, seedAccount, SeededAccount, SeededUser } from '../helpers/seed.js'
+import { WebhookNotificationLogRepository } from '../../../src/shared/infrastructure/webhooks/WebhookNotificationLogRepository.js'
+import type { WebhookNotificationLogEntry } from '../../../src/shared/infrastructure/webhooks/IWebhookNotificationLog.js'
+
+let user: SeededUser
+let account: SeededAccount
+let repo: WebhookNotificationLogRepository
+
+function entry(overrides: Partial<WebhookNotificationLogEntry> = {}): WebhookNotificationLogEntry {
+  return {
+    accountId: account.id,
+    subjectType: 'bank_transaction',
+    subjectId: crypto.randomUUID(),
+    url: 'https://hook.example.com',
+    requestPayload: { id: 'tx-1', amount: 100 },
+    responseStatus: 200,
+    responseBody: '{"ok":true}',
+    errorMessage: null,
+    attempt: 1,
+    ...overrides,
+  }
+}
+
+describe('WebhookNotificationLogRepository (integration)', () => {
+  beforeEach(async () => {
+    await truncateAll()
+    user = await seedUser({ email: `whn-${crypto.randomBytes(3).toString('hex')}@test.com` })
+    account = await seedAccount(user.id)
+    repo = new WebhookNotificationLogRepository({
+      query: (text, params) => getTestPool().query(text, params as any),
+    })
+  })
+  afterAll(async () => { await closeTestPool() })
+
+  it('persists an entry and round-trips JSONB payload and response body', async () => {
+    const e = entry()
+    await repo.record(e)
+    const { rows } = await getTestPool().query(
+      'SELECT * FROM webhook_notifications WHERE subject_id = $1',
+      [e.subjectId]
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].account_id).toBe(account.id)
+    expect(rows[0].subject_type).toBe('bank_transaction')
+    expect(rows[0].response_status).toBe(200)
+    expect(rows[0].attempt).toBe(1)
+    expect(rows[0].error_message).toBeNull()
+    expect(rows[0].request_payload).toEqual({ id: 'tx-1', amount: 100 })
+    expect(rows[0].response_body).toEqual({ ok: true })
+  })
+
+  it('wraps a non-JSON response body as a JSON string node', async () => {
+    const e = entry({ responseBody: 'plain text' })
+    await repo.record(e)
+    const { rows } = await getTestPool().query(
+      'SELECT response_body FROM webhook_notifications WHERE subject_id = $1',
+      [e.subjectId]
+    )
+    expect(rows[0].response_body).toBe('plain text')
+  })
+
+  it('stores null response on a network failure', async () => {
+    const e = entry({ responseStatus: null, responseBody: null, errorMessage: 'ECONNRESET' })
+    await repo.record(e)
+    const { rows } = await getTestPool().query(
+      'SELECT response_status, response_body, error_message FROM webhook_notifications WHERE subject_id = $1',
+      [e.subjectId]
+    )
+    expect(rows[0].response_status).toBeNull()
+    expect(rows[0].response_body).toBeNull()
+    expect(rows[0].error_message).toBe('ECONNRESET')
+  })
+
+  it('is append-only: multiple attempts produce multiple rows', async () => {
+    const subjectId = crypto.randomUUID()
+    await repo.record(entry({ subjectId, responseStatus: 500, errorMessage: 'first', attempt: 1 }))
+    await repo.record(entry({ subjectId, responseStatus: 200, errorMessage: null, attempt: 2 }))
+    const { rows } = await getTestPool().query(
+      'SELECT attempt, response_status FROM webhook_notifications WHERE subject_id = $1 ORDER BY attempt',
+      [subjectId]
+    )
+    expect(rows.map(r => r.attempt)).toEqual([1, 2])
+  })
+
+  it('cascades on account deletion (FK ON DELETE CASCADE)', async () => {
+    const e = entry()
+    await repo.record(e)
+    await getTestPool().query('DELETE FROM accounts WHERE id = $1', [account.id])
+    const { rows } = await getTestPool().query(
+      'SELECT 1 FROM webhook_notifications WHERE subject_id = $1',
+      [e.subjectId]
+    )
+    expect(rows).toHaveLength(0)
+  })
+})

--- a/tests/integration/user/ChangeOperationModeUseCase.integration.test.ts
+++ b/tests/integration/user/ChangeOperationModeUseCase.integration.test.ts
@@ -51,11 +51,17 @@ async function seedAccountData(userId: string, accountId: string): Promise<Seede
      VALUES (gen_random_uuid(), $1, 'bank_transaction', $2, 'https://hook', '{}'::jsonb, 200, 1)`,
     [accountId, txId]
   )
+  await pool.query(
+    `INSERT INTO webhook_dead_letters
+       (id, account_id, subject_type, subject_id, last_status, last_error, attempts)
+     VALUES (gen_random_uuid(), $1, 'bank_transaction', $2, 500, 'boom', 12)`,
+    [accountId, txId]
+  )
 
   return { userId, accountId, txId, requestId, conciliatedId }
 }
 
-async function countDataFor(accountId: string): Promise<{ bt: number; cr: number; ct: number; wn: number }> {
+async function countDataFor(accountId: string): Promise<{ bt: number; cr: number; ct: number; wn: number; wdl: number }> {
   const pool = getTestPool()
   const bt = await pool.query<{ n: number }>(
     'SELECT COUNT(*)::int AS n FROM bank_transactions WHERE account_id = $1', [accountId]
@@ -69,7 +75,10 @@ async function countDataFor(accountId: string): Promise<{ bt: number; cr: number
   const wn = await pool.query<{ n: number }>(
     'SELECT COUNT(*)::int AS n FROM webhook_notifications WHERE account_id = $1', [accountId]
   )
-  return { bt: bt.rows[0].n, cr: cr.rows[0].n, ct: ct.rows[0].n, wn: wn.rows[0].n }
+  const wdl = await pool.query<{ n: number }>(
+    'SELECT COUNT(*)::int AS n FROM webhook_dead_letters WHERE account_id = $1', [accountId]
+  )
+  return { bt: bt.rows[0].n, cr: cr.rows[0].n, ct: ct.rows[0].n, wn: wn.rows[0].n, wdl: wdl.rows[0].n }
 }
 
 describe('ChangeOperationModeUseCase (integration)', () => {
@@ -84,7 +93,7 @@ describe('ChangeOperationModeUseCase (integration)', () => {
 
     // Sanity: data is there before the use case runs
     const before = await countDataFor(account.id)
-    expect(before).toEqual({ bt: 1, cr: 1, ct: 1, wn: 1 })
+    expect(before).toEqual({ bt: 1, cr: 1, ct: 1, wn: 1, wdl: 1 })
     void data
 
     const pool = getTestPool()
@@ -109,7 +118,7 @@ describe('ChangeOperationModeUseCase (integration)', () => {
 
     // Account-scoped data was wiped
     const after = await countDataFor(account.id)
-    expect(after).toEqual({ bt: 0, cr: 0, ct: 0, wn: 0 })
+    expect(after).toEqual({ bt: 0, cr: 0, ct: 0, wn: 0, wdl: 0 })
 
     // Event was published
     expect(received).toHaveLength(1)

--- a/tests/integration/user/ChangeOperationModeUseCase.integration.test.ts
+++ b/tests/integration/user/ChangeOperationModeUseCase.integration.test.ts
@@ -45,11 +45,17 @@ async function seedAccountData(userId: string, accountId: string): Promise<Seede
      VALUES ($1, $2, $3, $4, 'amount')`,
     [conciliatedId, accountId, requestId, txId]
   )
+  await pool.query(
+    `INSERT INTO webhook_notifications
+       (id, account_id, subject_type, subject_id, url, request_payload, response_status, attempt)
+     VALUES (gen_random_uuid(), $1, 'bank_transaction', $2, 'https://hook', '{}'::jsonb, 200, 1)`,
+    [accountId, txId]
+  )
 
   return { userId, accountId, txId, requestId, conciliatedId }
 }
 
-async function countDataFor(accountId: string): Promise<{ bt: number; cr: number; ct: number }> {
+async function countDataFor(accountId: string): Promise<{ bt: number; cr: number; ct: number; wn: number }> {
   const pool = getTestPool()
   const bt = await pool.query<{ n: number }>(
     'SELECT COUNT(*)::int AS n FROM bank_transactions WHERE account_id = $1', [accountId]
@@ -60,7 +66,10 @@ async function countDataFor(accountId: string): Promise<{ bt: number; cr: number
   const ct = await pool.query<{ n: number }>(
     'SELECT COUNT(*)::int AS n FROM conciliated_transactions WHERE account_id = $1', [accountId]
   )
-  return { bt: bt.rows[0].n, cr: cr.rows[0].n, ct: ct.rows[0].n }
+  const wn = await pool.query<{ n: number }>(
+    'SELECT COUNT(*)::int AS n FROM webhook_notifications WHERE account_id = $1', [accountId]
+  )
+  return { bt: bt.rows[0].n, cr: cr.rows[0].n, ct: ct.rows[0].n, wn: wn.rows[0].n }
 }
 
 describe('ChangeOperationModeUseCase (integration)', () => {
@@ -75,7 +84,7 @@ describe('ChangeOperationModeUseCase (integration)', () => {
 
     // Sanity: data is there before the use case runs
     const before = await countDataFor(account.id)
-    expect(before).toEqual({ bt: 1, cr: 1, ct: 1 })
+    expect(before).toEqual({ bt: 1, cr: 1, ct: 1, wn: 1 })
     void data
 
     const pool = getTestPool()
@@ -100,7 +109,7 @@ describe('ChangeOperationModeUseCase (integration)', () => {
 
     // Account-scoped data was wiped
     const after = await countDataFor(account.id)
-    expect(after).toEqual({ bt: 0, cr: 0, ct: 0 })
+    expect(after).toEqual({ bt: 0, cr: 0, ct: 0, wn: 0 })
 
     // Event was published
     expect(received).toHaveLength(1)


### PR DESCRIPTION
This pull request introduces support for tracking and managing webhook delivery failures ("dead letters") for bank movement notifications. It adds the ability to list exhausted webhook deliveries for operators, ensures reliable re-enqueueing of failed jobs, and wires up the necessary infrastructure for dead letter and webhook notification logs throughout the composition modules. Several tests are updated and extended to cover the new behavior.

**Dead letter management and operator features:**
* Added a new `ListWebhookDeadLettersUseCase` and API endpoint (`GET /dead-letters`) to list bank movement webhook deliveries that have exhausted all retries and require manual intervention. [[1]](diffhunk://#diff-2d9dbee1808b28af9441367494458fd03cf2260a851c18d900d363c9e171212aR1-R22) [[2]](diffhunk://#diff-7b4c4b699b1f042f7ae9c7559ea791fb402da9efaca636559dd56d54adcd9238R46-R53)
* Updated the `.env.example` file to document new environment variables for webhook delivery retry attempts and backoff configuration.

**Reliable job re-enqueueing:**
* Modified the `enqueueNotify` logic to always remove a stale BullMQ job before re-adding, ensuring that re-driving a failed webhook delivery is never a silent no-op. [[1]](diffhunk://#diff-c336d18a9dc427759b01ea8093ee7e38a127a559447db4917739776ea1b55ca4R109-R117) [[2]](diffhunk://#diff-b374c17c8d7bbb39abaeb8b80ab1e5ebeff5b07f42a3b58ae3deb2349dc04888R99-R110)

**Infrastructure and dependency wiring:**
* Introduced `IWebhookNotificationLog` and `IWebhookDeadLetterStore` types and repositories, and connected them through the dependency injection container and all relevant modules (`bankingModule`, `conciliationModule`). [[1]](diffhunk://#diff-c336d18a9dc427759b01ea8093ee7e38a127a559447db4917739776ea1b55ca4R5-R6) [[2]](diffhunk://#diff-c336d18a9dc427759b01ea8093ee7e38a127a559447db4917739776ea1b55ca4R28-R36) [[3]](diffhunk://#diff-c336d18a9dc427759b01ea8093ee7e38a127a559447db4917739776ea1b55ca4R129-R137) [[4]](diffhunk://#diff-b469eca5d70522f8765e6db3dbabf958a2949178beb8a7a7277fa48861e7b9eeR5) [[5]](diffhunk://#diff-b469eca5d70522f8765e6db3dbabf958a2949178beb8a7a7277fa48861e7b9eeR16) [[6]](diffhunk://#diff-b469eca5d70522f8765e6db3dbabf958a2949178beb8a7a7277fa48861e7b9eeR119) [[7]](diffhunk://#diff-dee0f7c27557fd0982b93011ac1053506caa62c231750ba2eaba0f7b03bb9b68R10-R13) [[8]](diffhunk://#diff-dee0f7c27557fd0982b93011ac1053506caa62c231750ba2eaba0f7b03bb9b68R26-R27) [[9]](diffhunk://#diff-dee0f7c27557fd0982b93011ac1053506caa62c231750ba2eaba0f7b03bb9b68R47-R55)

**Testing improvements:**
* Updated and extended tests to verify new behaviors, including proper job removal before re-adding in `reNotifyBankMovement`, and the correct instantiation and wiring of the new use case and repositories. [[1]](diffhunk://#diff-b374c17c8d7bbb39abaeb8b80ab1e5ebeff5b07f42a3b58ae3deb2349dc04888L4-R4) [[2]](diffhunk://#diff-b374c17c8d7bbb39abaeb8b80ab1e5ebeff5b07f42a3b58ae3deb2349dc04888R40) [[3]](diffhunk://#diff-b374c17c8d7bbb39abaeb8b80ab1e5ebeff5b07f42a3b58ae3deb2349dc04888R59-R60) [[4]](diffhunk://#diff-b374c17c8d7bbb39abaeb8b80ab1e5ebeff5b07f42a3b58ae3deb2349dc04888R84) [[5]](diffhunk://#diff-b1a8c6cc259ea6f1661e73b9a1bd13761122cb35cb57165432b166e56a1c3306R12-R15) [[6]](diffhunk://#diff-b1a8c6cc259ea6f1661e73b9a1bd13761122cb35cb57165432b166e56a1c3306L28-R33) [[7]](diffhunk://#diff-b1a8c6cc259ea6f1661e73b9a1bd13761122cb35cb57165432b166e56a1c3306R48-R51)

These changes ensure failed webhook deliveries are visible and actionable, and that manual re-drives are reliable and effective.