### PR TITLE
Fix logger logs directory path

### DIFF
--- a/src/shared/infrastructure/logger/transports.ts
+++ b/src/shared/infrastructure/logger/transports.ts
@@ -7,7 +7,7 @@ import { mkdirSync } from 'fs'
 const { combine, timestamp, json, printf, colorize, errors } = winston.format
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const logsDir = path.resolve(__dirname, '../../../../..', 'logs')
+const logsDir = path.resolve(__dirname, '../../../..', 'logs')
 
 mkdirSync(logsDir, { recursive: true })
 


### PR DESCRIPTION
This pull request makes a minor update to the log directory path in the logger transport module, ensuring that logs are stored in the correct location relative to the project structure.

- Logging configuration:
  * Updated the `logsDir` path in `src/shared/infrastructure/logger/transports.ts` to be one directory closer to the source file, correcting the log output location.