### PR TITLE
Add bank script debug logging

### DIFF
--- a/src/composition/bankingModule.test.ts
+++ b/src/composition/bankingModule.test.ts
@@ -48,7 +48,9 @@ const scriptLoaderMock = ScriptLoader as unknown as { loadActive: ReturnType<typ
 const runnerStartMock = (PersistentPlaywrightRunner as unknown as { __start: ReturnType<typeof vi.fn> }).__start
 
 function makeContainer() {
-  const logger: any = { debug() {}, info() {}, warn() {}, error() {}, child() { return logger } }
+  const childLogger: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+  childLogger.child = vi.fn(() => childLogger)
+  const logger: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn(() => childLogger) }
   const accountRepository: any = { findById: vi.fn() }
   const accountConfigRepository: any = { findByAccountId: vi.fn() }
   return {
@@ -198,6 +200,35 @@ describe('buildBankingModule', () => {
 
       if (prev === undefined) delete process.env.PERSISTENT_POLL_INTERVAL_MS
       else process.env.PERSISTENT_POLL_INTERVAL_MS = prev
+    })
+
+    it('wires a [bank-monitor] debugLog that routes script events to the logger with accountId+bank', async () => {
+      const c = makeContainer()
+      c.account.accountRepository.findById.mockResolvedValue({ id: 'acc-1', userId: 'u', bank: 'TEST' })
+      c.account.accountConfigRepository.findByAccountId.mockResolvedValue({
+        sessionType: 'persistent', loginMode: 'simple',
+      })
+      dbMock.query.mockResolvedValueOnce({ rows: [{ username: 'user', encrypted_password: 'pw' }] })
+      scriptLoaderMock.loadActive.mockResolvedValue({ id: 'script-1', codeSnapshot: 'code()' })
+      ;(c.pool as any).query.mockResolvedValue({ rows: [] })
+      runnerStartMock.mockResolvedValue({ stop: vi.fn(), done: new Promise(() => {}) })
+
+      const mod = buildBankingModule(c)
+      await mod.sessionManager.ensureRunning('acc-1')
+
+      expect((c.logger as any).child).toHaveBeenCalledWith('[bank-monitor]')
+      expect((c.logger as any).child).toHaveBeenCalledWith('[session-manager]')
+
+      const arg = runnerStartMock.mock.calls[0][0]
+      expect(typeof arg.context.debugLog).toBe('function')
+
+      // The child logger is a shared spy; the sink writes to it. Emitting a script
+      // event must route through with the system accountId/bank and redaction.
+      const child = (c.logger as any).child.mock.results[0].value
+      arg.context.debugLog(JSON.stringify({ event: 'poll_summary', incoming: 2, password: 'x' }))
+      expect(child.info).toHaveBeenCalledWith('poll_summary', expect.objectContaining({
+        accountId: 'acc-1', bank: 'TEST', incoming: 2, password: '[REDACTED]',
+      }))
     })
 
     it('uses the default poll interval when PERSISTENT_POLL_INTERVAL_MS is unset', async () => {

--- a/src/composition/bankingModule.ts
+++ b/src/composition/bankingModule.ts
@@ -20,6 +20,7 @@ import { BankSessionRepository } from '../contexts/banking/infrastructure/BankSe
 import { SessionManager } from '../contexts/banking/infrastructure/SessionManager.js'
 import { PersistentPlaywrightRunner } from '../contexts/script-engine/infrastructure/PersistentPlaywrightRunner.js'
 import { ScriptLoader } from '../contexts/script-engine/infrastructure/ScriptLoader.js'
+import { makeDebugLogSink } from '../contexts/script-engine/infrastructure/debugLogSink.js'
 import { db } from '../shared/infrastructure/db/client.js'
 import { NotifyBankMovementUseCase } from '../contexts/banking/application/NotifyBankMovementUseCase.js'
 import { ListBankMovementsUseCase } from '../contexts/banking/application/ListBankMovementsUseCase.js'
@@ -61,12 +62,14 @@ export function buildBankingModule(container: ContainerBase): BankingModule {
   const accountReader = new AccountForBankingReaderAdapter(accountRepo, configRepo)
   const configReader = new NotificationConfigReaderAdapter(configRepo)
   const userModeReader = new UserOperationModeReaderAdapter(userRepo)
-  const scriptEngine = new ScriptEngineAdapter()
+  const scriptEngine = new ScriptEngineAdapter(container.logger)
 
   const ingest = new IngestTransactionsUseCase({ txRepo: bankTxRepo, eventBus: container.eventBus })
 
   const bankSessionRepo = new BankSessionRepository(exec)
   const persistentRunner = new PersistentPlaywrightRunner()
+
+  const monitorLog = container.logger.child('[bank-monitor]')
 
   const startFn = async (accountId: string) => {
     const account = await accountReader.findById(accountId)
@@ -88,7 +91,13 @@ export function buildBankingModule(container: ContainerBase): BankingModule {
       scriptCode: script.codeSnapshot,
       loginMode: account.loginMode,
       pollIntervalMs: Number(process.env.PERSISTENT_POLL_INTERVAL_MS ?? 60_000),
-      context: { accountId, username: creds.username, password: credentialsCipher().decrypt(creds.encrypted_password), lastExternalId },
+      context: {
+        accountId,
+        username: creds.username,
+        password: credentialsCipher().decrypt(creds.encrypted_password),
+        lastExternalId,
+        debugLog: makeDebugLogSink(monitorLog, { accountId, bank: account.bank }),
+      },
       onTransactions: async (batch) => { await ingest.execute(accountId, script.id, batch) },
       shouldStop: () => false,
       // Bank-local day key; a change clears runMonitor's dedup set so it stays bounded
@@ -101,7 +110,7 @@ export function buildBankingModule(container: ContainerBase): BankingModule {
     })
   }
 
-  const sessionManager = new SessionManager(startFn, bankSessionRepo)
+  const sessionManager = new SessionManager(startFn, bankSessionRepo, container.logger.child('[session-manager]'))
 
   const enqueueNotify = async (bankTransactionId: string) => {
     const jobId = `bank-movement-webhook_${bankTransactionId}`

--- a/src/contexts/banking/infrastructure/ScriptEngineAdapter.test.ts
+++ b/src/contexts/banking/infrastructure/ScriptEngineAdapter.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const loadActiveMock = vi.fn()
 const executeMock = vi.fn()
+const ctorArgs: unknown[][] = []
 
 vi.mock('../../script-engine/infrastructure/ScriptLoader.js', () => ({
   ScriptLoader: { loadActive: (...args: unknown[]) => loadActiveMock(...args) },
@@ -9,6 +10,7 @@ vi.mock('../../script-engine/infrastructure/ScriptLoader.js', () => ({
 
 vi.mock('../../script-engine/infrastructure/PlaywrightRunner.js', () => ({
   PlaywrightRunner: class {
+    constructor(...args: unknown[]) { ctorArgs.push(args) }
     execute(...args: unknown[]) { return executeMock(...args) }
   },
 }))
@@ -19,6 +21,7 @@ describe('ScriptEngineAdapter', () => {
   beforeEach(() => {
     loadActiveMock.mockReset()
     executeMock.mockReset()
+    ctorArgs.length = 0
   })
 
   describe('loadActiveScript', () => {
@@ -66,6 +69,22 @@ describe('ScriptEngineAdapter', () => {
         { id: 'script-1', codeSnapshot: 'return []' },
         { accountId: 'acc-1', lastExternalId: null },
       )
+    })
+
+    it('forwards its logger to the PlaywrightRunner constructor', async () => {
+      executeMock.mockResolvedValue([])
+      const logger = { debug() {}, info() {}, warn() {}, error() {}, child() { return logger } } as any
+      const adapter = new ScriptEngineAdapter(logger)
+      await adapter.runScript({ id: 's', codeSnapshot: 'return []' }, { accountId: 'a', lastExternalId: null })
+      expect(ctorArgs).toHaveLength(1)
+      expect(ctorArgs[0][0]).toBe(logger)
+    })
+
+    it('constructs the runner with undefined when no logger is provided', async () => {
+      executeMock.mockResolvedValue([])
+      const adapter = new ScriptEngineAdapter()
+      await adapter.runScript({ id: 's', codeSnapshot: 'return []' }, { accountId: 'a', lastExternalId: null })
+      expect(ctorArgs[0][0]).toBeUndefined()
     })
 
     it('propagates errors thrown by the underlying runner', async () => {

--- a/src/contexts/banking/infrastructure/ScriptEngineAdapter.ts
+++ b/src/contexts/banking/infrastructure/ScriptEngineAdapter.ts
@@ -1,8 +1,11 @@
 import { ScriptLoader } from '../../script-engine/infrastructure/ScriptLoader.js'
 import { PlaywrightRunner } from '../../script-engine/infrastructure/PlaywrightRunner.js'
 import { ActiveScript, IScriptEnginePort, ScrapedTransaction } from '../domain/IScriptEnginePort.js'
+import type { ILogger } from '../../../shared/logger/ILogger.js'
 
 export class ScriptEngineAdapter implements IScriptEnginePort {
+  constructor(private readonly logger?: ILogger) {}
+
   async loadActiveScript(bank: string, flowType: string): Promise<ActiveScript | null> {
     const script = await ScriptLoader.loadActive(bank, flowType as any)
     if (!script || !script.codeSnapshot) return null
@@ -14,7 +17,7 @@ export class ScriptEngineAdapter implements IScriptEnginePort {
     context: { accountId: string; lastExternalId: string | null }
   ): Promise<ScrapedTransaction[]> {
     // PlaywrightRunner expects a BankScript-like object with codeSnapshot and id
-    const runner = new PlaywrightRunner()
+    const runner = new PlaywrightRunner(this.logger)
     return runner.execute({ id: script.id, codeSnapshot: script.codeSnapshot } as any, context)
   }
 }

--- a/src/contexts/banking/infrastructure/SessionManager.test.ts
+++ b/src/contexts/banking/infrastructure/SessionManager.test.ts
@@ -8,6 +8,7 @@ function deferred<T>() {
 }
 
 const sessionRepo = () => ({ markRunning: vi.fn().mockResolvedValue(undefined), markStopped: vi.fn().mockResolvedValue(undefined) })
+const fakeLogger = () => { const l: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: () => l }; return l }
 
 describe('SessionManager', () => {
   it('starts a session, marks it running, and is idempotent while alive', async () => {
@@ -113,6 +114,64 @@ describe('SessionManager', () => {
     await new Promise((r) => setTimeout(r, 0))
 
     expect(repo.markStopped).toHaveBeenCalledWith('acc-1', 'plain string failure')
+  })
+
+  it('logs session lifecycle at the right level (started=info, unclean stop=warn, crash/start-fail=error)', async () => {
+    const repo = sessionRepo()
+    const log = fakeLogger()
+
+    // started -> info
+    const d = deferred<string>()
+    const started = new SessionManager(vi.fn().mockResolvedValue({ stop: vi.fn(), done: d.promise } as SessionHandle), repo, log)
+    await started.ensureRunning('acc-1')
+    expect(log.info).toHaveBeenCalledWith('session started', { accountId: 'acc-1' })
+
+    // unclean stop -> warn
+    d.resolve('logged_out')
+    await new Promise((r) => setTimeout(r, 0))
+    expect(log.warn).toHaveBeenCalledWith('session stopped', { accountId: 'acc-1', reason: 'logged_out' })
+
+    // clean stop -> info
+    const d2 = deferred<string>()
+    const clean = new SessionManager(vi.fn().mockResolvedValue({ stop: vi.fn(), done: d2.promise } as SessionHandle), repo, log)
+    await clean.ensureRunning('acc-2')
+    d2.resolve('stop_requested')
+    await new Promise((r) => setTimeout(r, 0))
+    expect(log.info).toHaveBeenCalledWith('session stopped', { accountId: 'acc-2', reason: 'stop_requested' })
+
+    // crash (done rejects) -> error
+    const crashed = new SessionManager(vi.fn().mockResolvedValue({ stop: vi.fn(), done: Promise.reject(new Error('boom')) } as SessionHandle), repo, log)
+    await crashed.ensureRunning('acc-3')
+    await new Promise((r) => setTimeout(r, 0))
+    expect(log.error).toHaveBeenCalledWith('session crashed', { accountId: 'acc-3', error: 'boom' })
+
+    // start failure -> error
+    const failed = new SessionManager(vi.fn().mockRejectedValue(new Error('no creds')), repo, log)
+    await expect(failed.ensureRunning('acc-4')).rejects.toThrow('no creds')
+    expect(log.error).toHaveBeenCalledWith('session start failed', { accountId: 'acc-4', error: 'no creds' })
+  })
+
+  it('logs max_runtime as a clean stop (info)', async () => {
+    const repo = sessionRepo()
+    const log = fakeLogger()
+    const d = deferred<string>()
+    const mgr = new SessionManager(vi.fn().mockResolvedValue({ stop: vi.fn(), done: d.promise } as SessionHandle), repo, log)
+    await mgr.ensureRunning('acc-1')
+    d.resolve('max_runtime')
+    await new Promise((r) => setTimeout(r, 0))
+    expect(log.info).toHaveBeenCalledWith('session stopped', { accountId: 'acc-1', reason: 'max_runtime' })
+    expect(log.warn).not.toHaveBeenCalled()
+  })
+
+  it('logs auth_timeout as an unclean stop (warn)', async () => {
+    const repo = sessionRepo()
+    const log = fakeLogger()
+    const d = deferred<string>()
+    const mgr = new SessionManager(vi.fn().mockResolvedValue({ stop: vi.fn(), done: d.promise } as SessionHandle), repo, log)
+    await mgr.ensureRunning('acc-1')
+    d.resolve('auth_timeout')
+    await new Promise((r) => setTimeout(r, 0))
+    expect(log.warn).toHaveBeenCalledWith('session stopped', { accountId: 'acc-1', reason: 'auth_timeout' })
   })
 
   it('coerces non-Error rejections from startFn to a string for markStopped', async () => {

--- a/src/contexts/banking/infrastructure/SessionManager.ts
+++ b/src/contexts/banking/infrastructure/SessionManager.ts
@@ -1,4 +1,8 @@
 import type { IBankSessionRepository } from '../domain/IBankSessionRepository.js'
+import type { ILogger } from '../../../shared/logger/ILogger.js'
+
+// Stop reasons that represent a clean exit vs an unexpected loss of session.
+const CLEAN_STOP_REASONS = new Set(['stop_requested', 'max_runtime'])
 
 export interface SessionHandle {
   stop(): void
@@ -25,6 +29,7 @@ export class SessionManager {
   constructor(
     private readonly startFn: StartSessionFn,
     private readonly sessionRepo: IBankSessionRepository,
+    private readonly logger?: ILogger,
   ) {}
 
   // Records a stopped session (with its stop reason) for operator visibility.
@@ -57,18 +62,29 @@ export class SessionManager {
     } catch (err) {
       // Record the failed start so operators can see why it isn't monitoring,
       // then rethrow so the job is marked failed.
-      await this.recordStop(accountId, err instanceof Error ? err.message : String(err))
+      const error = err instanceof Error ? err.message : String(err)
+      this.logger?.error('session start failed', { accountId, error })
+      await this.recordStop(accountId, error)
       throw err
     }
 
     this.live.set(accountId, handle)
     await this.sessionRepo.markRunning(accountId)
+    this.logger?.info('session started', { accountId })
 
     handle.done
       // Resolve carries a MonitorStopReason (stop_requested|max_runtime|logged_out|
       // auth_timeout); reject carries a thrown error. Either way we just record the stop.
-      .then((reason) => this.recordStop(accountId, reason))
-      .catch((err) => this.recordStop(accountId, err instanceof Error ? err.message : String(err)))
+      .then((reason) => {
+        const level = CLEAN_STOP_REASONS.has(reason) ? 'info' : 'warn'
+        this.logger?.[level]('session stopped', { accountId, reason })
+        return this.recordStop(accountId, reason)
+      })
+      .catch((err) => {
+        const error = err instanceof Error ? err.message : String(err)
+        this.logger?.error('session crashed', { accountId, error })
+        return this.recordStop(accountId, error)
+      })
       .finally(() => { this.live.delete(accountId) })
   }
 

--- a/src/contexts/script-engine/infrastructure/PersistentPlaywrightRunner.test.ts
+++ b/src/contexts/script-engine/infrastructure/PersistentPlaywrightRunner.test.ts
@@ -142,6 +142,19 @@ describe('PersistentPlaywrightRunner', () => {
     expect(runMonitorMock).toHaveBeenCalledWith(expect.objectContaining({ getBankDay }))
   })
 
+  it('forwards context.debugLog through to runMonitor unchanged', async () => {
+    buildContext()
+    runMonitorMock.mockResolvedValue('stop_requested')
+    const runner = new PersistentPlaywrightRunner()
+    const debugLog = vi.fn()
+    const input = baseInput()
+
+    await (await runner.start({ ...input, context: { ...input.context, debugLog } })).done
+    expect(runMonitorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ context: expect.objectContaining({ debugLog }) }),
+    )
+  })
+
   it('still closes the context when the monitor rejects', async () => {
     const { close } = buildContext()
     runMonitorMock.mockRejectedValue(new Error('monitor blew up'))

--- a/src/contexts/script-engine/infrastructure/PlaywrightRunner.test.ts
+++ b/src/contexts/script-engine/infrastructure/PlaywrightRunner.test.ts
@@ -136,6 +136,48 @@ describe('PlaywrightRunner', () => {
     }
   })
 
+  it('does not wire debugLog into the script context when no logger is given', async () => {
+    dbQueryMock.mockResolvedValueOnce({ rows: [{ username: 'u', encrypted_password: 'p' }] })
+    buildBrowserChain('')
+    const runner = new PlaywrightRunner()
+    const txs = await runner.execute(
+      { id: 's', codeSnapshot: 'return [{ externalId: "1", referenceHash: "h", amount: 1, currency: "USD", receivedAt: new Date(0), raw: { kind: typeof context.debugLog } }]' } as any,
+      { accountId: 'acc-1', lastExternalId: null },
+    )
+    expect(txs[0].raw.kind).toBe('undefined')
+  })
+
+  it('wires a [bank-scrape-script] debugLog into the script context when a logger is given', async () => {
+    dbQueryMock.mockResolvedValueOnce({ rows: [{ username: 'u', encrypted_password: 'p' }] })
+    buildBrowserChain('')
+    const child: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() }
+    const logger: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn(() => child) }
+
+    const runner = new PlaywrightRunner(logger)
+    const txs = await runner.execute(
+      { id: 's', codeSnapshot: 'return [{ externalId: "1", referenceHash: "h", amount: 1, currency: "USD", receivedAt: new Date(0), raw: { kind: typeof context.debugLog } }]' } as any,
+      { accountId: 'acc-42', lastExternalId: null },
+    )
+    expect(txs[0].raw.kind).toBe('function')
+    expect(logger.child).toHaveBeenCalledWith('[bank-scrape-script]')
+  })
+
+  it('routes a script debugLog event through the real sink to the logger (redacted, with accountId)', async () => {
+    dbQueryMock.mockResolvedValueOnce({ rows: [{ username: 'u', encrypted_password: 'p' }] })
+    buildBrowserChain('')
+    const child: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() }
+    const logger: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn(() => child) }
+
+    const runner = new PlaywrightRunner(logger)
+    await runner.execute(
+      { id: 's', codeSnapshot: 'context.debugLog(JSON.stringify({ event: "poll_summary", incoming: 3, password: "x" })); return []' } as any,
+      { accountId: 'acc-42', lastExternalId: null },
+    )
+    expect(child.info).toHaveBeenCalledWith('poll_summary', expect.objectContaining({
+      accountId: 'acc-42', incoming: 3, password: '[REDACTED]',
+    }))
+  })
+
   it('rejects when the script takes longer than the configured timeout', async () => {
     vi.useFakeTimers()
     dbQueryMock.mockResolvedValueOnce({ rows: [{ username: 'u', encrypted_password: 'p' }] })

--- a/src/contexts/script-engine/infrastructure/PlaywrightRunner.ts
+++ b/src/contexts/script-engine/infrastructure/PlaywrightRunner.ts
@@ -2,6 +2,8 @@ import { BankScript } from '../domain/BankScript.js'
 import { db } from '../../../shared/infrastructure/db/client.js'
 import { credentialsCipher } from '../../../shared/infrastructure/crypto/CredentialsCipher.js'
 import { CHROMIUM_ARGS, USER_AGENT, VIEWPORT, isHeadless, applyAntiWebdriver } from './playwrightLaunch.js'
+import { makeDebugLogSink } from './debugLogSink.js'
+import type { ILogger } from '../../../shared/logger/ILogger.js'
 
 interface ScrapedTransaction {
   externalId: string
@@ -19,6 +21,8 @@ interface RunContext {
 }
 
 export class PlaywrightRunner {
+  constructor(private readonly logger?: ILogger) {}
+
   async execute(script: BankScript, context: RunContext): Promise<ScrapedTransaction[]> {
     if (!script.codeSnapshot) throw new Error(`Script ${script.id} has no code snapshot`)
 
@@ -50,6 +54,9 @@ export class PlaywrightRunner {
       username: creds.username,
       password: credentialsCipher().decrypt(creds.encrypted_password),
       lastExternalId: context.lastExternalId,
+      debugLog: this.logger
+        ? makeDebugLogSink(this.logger.child('[bank-scrape-script]'), { accountId: context.accountId })
+        : undefined,
     }
 
     const TIMEOUT_MS = 10 * 60 * 1000 // 10 minutes

--- a/src/contexts/script-engine/infrastructure/debugLogSink.test.ts
+++ b/src/contexts/script-engine/infrastructure/debugLogSink.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi } from 'vitest'
+import { makeDebugLogSink } from './debugLogSink.js'
+
+const fakeLogger = () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn(),
+})
+
+const emit = (event: string, data: Record<string, unknown> = {}) =>
+  JSON.stringify({ at: '2026-06-09T00:00:00.000Z', event, ...data })
+
+describe('makeDebugLogSink', () => {
+  describe('level classification', () => {
+    it('maps known lifecycle events to their level', () => {
+      const log = fakeLogger()
+      const sink = makeDebugLogSink(log)
+      sink(emit('logged_out'))
+      sink(emit('authenticated'))
+      sink(emit('poll_summary'))
+      expect(log.warn).toHaveBeenCalledWith('logged_out', expect.any(Object))
+      expect(log.info).toHaveBeenCalledWith('authenticated', expect.any(Object))
+      expect(log.info).toHaveBeenCalledWith('poll_summary', expect.any(Object))
+    })
+
+    it('classifies auth_timeout as warn (pattern), consistent with SessionManager', () => {
+      const log = fakeLogger()
+      makeDebugLogSink(log)(emit('auth_timeout'))
+      expect(log.warn).toHaveBeenCalledWith('auth_timeout', expect.any(Object))
+      expect(log.error).not.toHaveBeenCalled()
+    })
+
+    it('maps navigation_failed to error (override beats the *_failed pattern)', () => {
+      const log = fakeLogger()
+      makeDebugLogSink(log)(emit('navigation_failed'))
+      expect(log.error).toHaveBeenCalledWith('navigation_failed', expect.any(Object))
+      expect(log.warn).not.toHaveBeenCalled()
+    })
+
+    it('maps failure-shaped events to warn via pattern', () => {
+      const log = fakeLogger()
+      const sink = makeDebugLogSink(log)
+      for (const e of [
+        'foo_failed', 'detail_uuid_timeout', 'detail_fetch_error', 'detail_row_missing',
+        'transactions_not_captured', 'see_movements_link_not_visible', 'pagination_cap_reached',
+        'movements_empty_or_invalid', 'detail_mismatch', 'dom_rows_missing',
+      ]) sink(emit(e))
+      expect(log.warn).toHaveBeenCalledTimes(10)
+      expect(log.debug).not.toHaveBeenCalled()
+    })
+
+    it('defaults unknown / step events to debug', () => {
+      const log = fakeLogger()
+      const sink = makeDebugLogSink(log)
+      sink(emit('pagination_done'))
+      sink(emit('login_submit_start'))
+      sink(emit('something_brand_new'))
+      expect(log.debug).toHaveBeenCalledTimes(3)
+    })
+
+    it('honors a valid explicit level field, ignores an invalid one', () => {
+      const log = fakeLogger()
+      const sink = makeDebugLogSink(log)
+      sink(emit('pagination_done', { level: 'warn' }))   // valid -> warn
+      sink(emit('pagination_done', { level: 'trace' }))  // invalid -> classify -> debug
+      expect(log.warn).toHaveBeenCalledTimes(1)
+      expect(log.debug).toHaveBeenCalledTimes(1)
+    })
+
+    it('covers the remaining override events (poll_failed/stop_requested/max_runtime)', () => {
+      const log = fakeLogger()
+      const sink = makeDebugLogSink(log)
+      sink(emit('poll_failed'))
+      sink(emit('stop_requested'))
+      sink(emit('max_runtime'))
+      expect(log.warn).toHaveBeenCalledWith('poll_failed', expect.any(Object))
+      expect(log.info).toHaveBeenCalledWith('stop_requested', expect.any(Object))
+      expect(log.info).toHaveBeenCalledWith('max_runtime', expect.any(Object))
+    })
+
+    it('classifies an empty-string event as debug, but still honors an explicit level', () => {
+      const log = fakeLogger()
+      const sink = makeDebugLogSink(log)
+      sink(emit(''))                       // empty event -> debug, name monitor_event
+      sink(emit('', { level: 'info' }))    // explicit level wins
+      expect(log.debug).toHaveBeenCalledWith('monitor_event', expect.any(Object))
+      expect(log.info).toHaveBeenCalledWith('monitor_event', expect.any(Object))
+    })
+  })
+
+  describe('meta handling', () => {
+    it('merges baseMeta and forwards payload fields, keeping at', () => {
+      const log = fakeLogger()
+      makeDebugLogSink(log, { accountId: 'acc-1', bank: 'pichincha' })(
+        emit('poll_summary', { incoming: 3, merged: 20 })
+      )
+      expect(log.info).toHaveBeenCalledWith('poll_summary', {
+        accountId: 'acc-1',
+        bank: 'pichincha',
+        at: '2026-06-09T00:00:00.000Z',
+        incoming: 3,
+        merged: 20,
+      })
+    })
+
+    it('strips reserved/colliding keys from the payload', () => {
+      const log = fakeLogger()
+      makeDebugLogSink(log)(
+        emit('poll_summary', { message: 'x', level: 'error', timestamp: 'y', context: 'z', keep: 1 })
+      )
+      // explicit level 'error' is consumed as a level hint -> routes to error
+      expect(log.error).toHaveBeenCalled()
+      const meta = log.error.mock.calls[0][1] as Record<string, unknown>
+      expect(meta).not.toHaveProperty('message')
+      expect(meta).not.toHaveProperty('timestamp')
+      expect(meta).not.toHaveProperty('context')
+      expect(meta).not.toHaveProperty('level')
+      expect(meta.keep).toBe(1)
+    })
+
+    it('redacts credential-like keys', () => {
+      const log = fakeLogger()
+      makeDebugLogSink(log)(
+        emit('poll_summary', { password: 'hunter2', token: 'abc', Authorization: 'Bearer x', safe: 'ok' })
+      )
+      const meta = log.info.mock.calls[0][1] as Record<string, unknown>
+      expect(meta.password).toBe('[REDACTED]')
+      expect(meta.token).toBe('[REDACTED]')
+      expect(meta.Authorization).toBe('[REDACTED]')
+      expect(meta.safe).toBe('ok')
+    })
+
+    it('redacts credential keys regardless of casing', () => {
+      const log = fakeLogger()
+      makeDebugLogSink(log)(
+        emit('poll_summary', {
+          PASSWORD: 'a', Token: 'b', SECRET: 'c', Pin: 'd', Credential: 'e', AUTHORIZATION: 'f',
+        })
+      )
+      const meta = log.info.mock.calls[0][1] as Record<string, unknown>
+      for (const k of ['PASSWORD', 'Token', 'SECRET', 'Pin', 'Credential', 'AUTHORIZATION']) {
+        expect(meta[k]).toBe('[REDACTED]')
+      }
+    })
+
+    it('redacts compound credential key names (substring match)', () => {
+      const log = fakeLogger()
+      makeDebugLogSink(log)(
+        emit('poll_summary', {
+          accessToken: 'a', apiKey: 'b', api_key: 'c', refreshToken: 'd',
+          passwordHash: 'e', sessionCookie: 'f',
+        })
+      )
+      const meta = log.info.mock.calls[0][1] as Record<string, unknown>
+      for (const k of ['accessToken', 'apiKey', 'api_key', 'refreshToken', 'passwordHash', 'sessionCookie']) {
+        expect(meta[k]).toBe('[REDACTED]')
+      }
+    })
+
+    it('does not over-redact benign keys that merely contain short stems', () => {
+      const log = fakeLogger()
+      makeDebugLogSink(log)(
+        emit('poll_summary', { shipping: 'addr', authenticated: true, monkey: 'm', incoming: 3 })
+      )
+      const meta = log.info.mock.calls[0][1] as Record<string, unknown>
+      expect(meta.shipping).toBe('addr')        // contains "pin" — exact-match only
+      expect(meta.authenticated).toBe(true)     // contains "auth" — exact-match only
+      expect(meta.monkey).toBe('m')             // contains "key" — exact-match only
+      expect(meta.incoming).toBe(3)
+    })
+
+    it('lets system baseMeta win over a script-spoofed accountId/bank', () => {
+      const log = fakeLogger()
+      makeDebugLogSink(log, { accountId: 'real', bank: 'pichincha' })(
+        emit('poll_summary', { accountId: 'spoof', bank: 'evil', incoming: 1 })
+      )
+      const meta = log.info.mock.calls[0][1] as Record<string, unknown>
+      expect(meta.accountId).toBe('real')
+      expect(meta.bank).toBe('pichincha')
+      expect(meta.incoming).toBe(1)
+    })
+
+    it('omits at when the payload has none', () => {
+      const log = fakeLogger()
+      makeDebugLogSink(log)(JSON.stringify({ event: 'poll_summary', incoming: 2 }))
+      const meta = log.info.mock.calls[0][1] as Record<string, unknown>
+      expect(meta).not.toHaveProperty('at')
+      expect(meta.incoming).toBe(2)
+    })
+  })
+
+  describe('guards', () => {
+    it('falls back to debug for non-JSON lines', () => {
+      const log = fakeLogger()
+      makeDebugLogSink(log, { accountId: 'a' })('not json at all')
+      expect(log.debug).toHaveBeenCalledWith('not json at all', { accountId: 'a' })
+    })
+
+    it('does not throw on non-object JSON (number/null/string)', () => {
+      const log = fakeLogger()
+      const sink = makeDebugLogSink(log)
+      expect(() => { sink('123'); sink('null'); sink('"hello"') }).not.toThrow()
+      expect(log.debug).toHaveBeenCalledTimes(3)
+    })
+
+    it('treats a JSON array as a non-record and falls back to debug', () => {
+      const log = fakeLogger()
+      makeDebugLogSink(log, { accountId: 'a' })('[1,2,3]')
+      expect(log.debug).toHaveBeenCalledWith('[1,2,3]', { accountId: 'a' })
+      expect(log.info).not.toHaveBeenCalled()
+      expect(log.warn).not.toHaveBeenCalled()
+    })
+
+    it('ignores non-string input without calling the logger', () => {
+      const log = fakeLogger()
+      const sink = makeDebugLogSink(log)
+      for (const bad of [null, undefined, 123, {}, []] as unknown[]) {
+        sink(bad as string)
+      }
+      expect(log.debug).not.toHaveBeenCalled()
+      expect(log.info).not.toHaveBeenCalled()
+      expect(log.warn).not.toHaveBeenCalled()
+      expect(log.error).not.toHaveBeenCalled()
+    })
+
+    it('processes a line exactly at the 1MB cap, rejects one byte over', () => {
+      const log = fakeLogger()
+      const sink = makeDebugLogSink(log)
+
+      // Pad an otherwise-valid event so the serialized line is exactly 1_000_000 bytes.
+      const base = JSON.stringify({ event: 'poll_summary', pad: '' })
+      const atCap = JSON.stringify({ event: 'poll_summary', pad: 'x'.repeat(1_000_000 - base.length) })
+      expect(atCap.length).toBe(1_000_000)
+      sink(atCap)
+      expect(log.info).toHaveBeenCalledWith('poll_summary', expect.any(Object))
+      expect(log.warn).not.toHaveBeenCalled()
+
+      sink('x'.repeat(1_000_001))
+      expect(log.warn).toHaveBeenCalledWith('oversized_log_entry', expect.objectContaining({ size: 1_000_001 }))
+    })
+
+    it('drops oversized lines at warn without parsing', () => {
+      const log = fakeLogger()
+      const huge = JSON.stringify({ event: 'x', blob: 'a'.repeat(1_000_001) })
+      makeDebugLogSink(log, { accountId: 'a' })(huge)
+      expect(log.warn).toHaveBeenCalledWith('oversized_log_entry', expect.objectContaining({ accountId: 'a' }))
+      expect(log.info).not.toHaveBeenCalled()
+    })
+
+    it('coerces a missing/non-string event to monitor_event', () => {
+      const log = fakeLogger()
+      const sink = makeDebugLogSink(log)
+      sink(JSON.stringify({ at: 't' }))                 // no event -> debug + monitor_event
+      sink(JSON.stringify({ event: 42, level: 'info' })) // non-string event
+      expect(log.debug).toHaveBeenCalledWith('monitor_event', expect.any(Object))
+      expect(log.info).toHaveBeenCalledWith('monitor_event', expect.any(Object))
+    })
+
+    it('never calls a non-existent logger method', () => {
+      const log = fakeLogger()
+      // @ts-expect-error - intentionally not present
+      log.trace = undefined
+      expect(() => makeDebugLogSink(log)(emit('whatever', { level: 'trace' }))).not.toThrow()
+    })
+  })
+})

--- a/src/contexts/script-engine/infrastructure/debugLogSink.ts
+++ b/src/contexts/script-engine/infrastructure/debugLogSink.ts
@@ -1,0 +1,106 @@
+import type { ILogger } from '../../../shared/logger/ILogger.js'
+
+type Level = 'debug' | 'info' | 'warn' | 'error'
+
+const LEVELS = new Set<Level>(['debug', 'info', 'warn', 'error'])
+
+// Largest debugLog line we'll parse. A persistent monitor can accumulate large
+// in-memory state; refuse to JSON.parse a multi-MB line (OOM risk) and surface it.
+const MAX_LINE_SIZE = 1_000_000
+
+// Winston/printf reserve these; `context` would override the child-logger context.
+const RESERVED_KEYS = ['message', 'level', 'timestamp', 'context', 'at']
+
+// Defensive masking in case a script ever logs a credential-bearing field
+// (e.g. the full `raw` movement or the context). Scripts don't today, but the
+// sink is the only choke point that sees everything. Matched as a substring so
+// compound names (accessToken, apiKey, passwordHash, refreshToken) are caught.
+// NOTE: this is a SHALLOW pass — a credential nested inside an object value is
+// NOT masked. Acceptable while scripts only ever log flat primitives; revisit if
+// a script starts logging `raw`/nested objects.
+const REDACT_SUBSTRINGS = [
+  'password', 'passphrase', 'secret', 'token', 'credential', 'cookie', 'apikey', 'api_key', 'authorization',
+]
+// Short stems matched EXACTLY — as substrings they collide with benign words
+// (e.g. "pin" in "shipping", "auth" in "authenticated", "key" in "monkey").
+const REDACT_EXACT = new Set(['pin', 'auth', 'key'])
+
+const isSecretKey = (key: string): boolean => {
+  const k = key.toLowerCase()
+  return REDACT_EXACT.has(k) || REDACT_SUBSTRINGS.some((s) => k.includes(s))
+}
+
+// Explicit overrides win over the pattern below (e.g. navigation_failed is fatal,
+// not a recoverable warn). Everything else is classified structurally so new
+// banks/events get a sensible level without touching this file. auth_timeout is
+// intentionally NOT here: the `_timeout` pattern classifies it as warn, matching
+// how SessionManager treats the auth_timeout stop reason (an operational, often
+// expected outcome — e.g. a human not completing assisted 2FA in time).
+const OVERRIDES: Record<string, Level> = {
+  navigation_failed: 'error',
+  logged_out: 'warn',
+  poll_failed: 'warn',
+  authenticated: 'info',
+  poll_summary: 'info',
+  stop_requested: 'info',
+  max_runtime: 'info',
+}
+
+const WARN_PATTERN =
+  /(_failed|_error|_timeout|_mismatch|_missing|not_captured|not_visible|cap_reached|empty_or_invalid)/
+
+function classify(event: string, explicit?: unknown): Level {
+  if (typeof explicit === 'string' && LEVELS.has(explicit as Level)) return explicit as Level
+  if (OVERRIDES[event]) return OVERRIDES[event]
+  if (WARN_PATTERN.test(event)) return 'warn'
+  return 'debug'
+}
+
+/**
+ * Builds a `debugLog(line)` callback for a bank script's MonitorScriptContext.
+ * Scripts emit one JSON object per event (`{ at, event, ...data }`); this parses
+ * it, assigns a Winston level by event name, strips colliding/secret fields, and
+ * forwards it to `logger` with `baseMeta` (e.g. accountId, bank) on every line.
+ */
+export function makeDebugLogSink(
+  logger: ILogger,
+  baseMeta: Record<string, unknown> = {}
+): (line: string) => void {
+  return (line: string) => {
+    if (typeof line !== 'string') return
+
+    if (line.length > MAX_LINE_SIZE) {
+      logger.warn('oversized_log_entry', { ...baseMeta, size: line.length })
+      return
+    }
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(line)
+    } catch {
+      logger.debug(line, baseMeta)
+      return
+    }
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      logger.debug(line, baseMeta)
+      return
+    }
+
+    const { event, level, ...rest } = parsed as Record<string, unknown>
+    const at = rest.at
+
+    const cleaned: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(rest)) {
+      if (RESERVED_KEYS.includes(k)) continue
+      cleaned[k] = isSecretKey(k) ? '[REDACTED]' : v
+    }
+
+    const lvl = classify(typeof event === 'string' ? event : '', level)
+    const name = typeof event === 'string' && event ? event : 'monitor_event'
+    // `at` is the event-emit time from the script; Winston adds its own log-write
+    // `timestamp` in transports.ts. Both are kept on purpose — they're distinct.
+    // baseMeta (system-supplied accountId/bank) wins: a script must not be able to
+    // spoof trace identity by emitting its own accountId/bank in the payload.
+    logger[lvl](name, { ...cleaned, ...(at !== undefined ? { at } : {}), ...baseMeta })
+  }
+}

--- a/src/contexts/script-engine/infrastructure/runMonitor.test.ts
+++ b/src/contexts/script-engine/infrastructure/runMonitor.test.ts
@@ -194,4 +194,127 @@ describe('runMonitor', () => {
     })
     expect(reason).toBe('auth_timeout')
   })
+
+  describe('debugLog payloads', () => {
+    // Collects the structured events runMonitor emits via context.debugLog.
+    function recorder() {
+      const events: Array<Record<string, unknown>> = []
+      const debugLog = vi.fn((line: string) => { events.push(JSON.parse(line)) })
+      return { debugLog, events, names: () => events.map((e) => e.event) }
+    }
+
+    it('forwards the poll error message on poll_failed', async () => {
+      const { debugLog, events } = recorder()
+      let pollCount = 0
+      const h = hooks({
+        poll: vi.fn().mockImplementation(async () => {
+          pollCount += 1
+          if (pollCount === 1) throw new Error('selector not found')
+          return []
+        }),
+        keepAlive: vi.fn().mockResolvedValue(undefined),
+      })
+      let calls = 0
+      await runMonitor({
+        hooks: h, page: {}, context: { ...baseContext, debugLog }, sleep: noSleep,
+        onTransactions: async () => {},
+        shouldStop: () => { calls += 1; return calls > 2 },
+      })
+      const failed = events.find((e) => e.event === 'poll_failed')
+      expect(failed).toMatchObject({ event: 'poll_failed', error: 'selector not found' })
+      expect(failed?.at).toEqual(expect.any(String))
+    })
+
+    it('stringifies a non-Error poll rejection', async () => {
+      const { debugLog, events } = recorder()
+      let pollCount = 0
+      const h = hooks({
+        poll: vi.fn().mockImplementation(async () => {
+          pollCount += 1
+          if (pollCount === 1) throw 'net down' // eslint-disable-line no-throw-literal
+          return []
+        }),
+      })
+      let calls = 0
+      await runMonitor({
+        hooks: h, page: {}, context: { ...baseContext, debugLog }, sleep: noSleep,
+        onTransactions: async () => {},
+        shouldStop: () => { calls += 1; return calls > 2 },
+      })
+      expect(events.find((e) => e.event === 'poll_failed')).toMatchObject({ error: 'net down' })
+    })
+
+    it('emits authenticated then stop_requested on a clean run', async () => {
+      const { debugLog, names } = recorder()
+      const h = hooks({ poll: vi.fn().mockResolvedValue([]) })
+      let calls = 0
+      await runMonitor({
+        hooks: h, page: {}, context: { ...baseContext, debugLog }, sleep: noSleep,
+        onTransactions: async () => {},
+        shouldStop: () => { calls += 1; return calls > 0 },
+      })
+      expect(names()).toContain('authenticated')
+      expect(names()).toContain('stop_requested')
+    })
+
+    it('emits auth_timeout when auth never succeeds', async () => {
+      const { debugLog, names } = recorder()
+      const h = hooks({ isAuthenticated: vi.fn().mockResolvedValue(false) })
+      await runMonitor({
+        hooks: h, page: {}, context: { ...baseContext, debugLog }, sleep: noSleep, authTimeoutMs: 5,
+        onTransactions: async () => {},
+      })
+      expect(names()).toEqual(['auth_timeout'])
+    })
+
+    it('emits logged_out when the session is lost mid-loop', async () => {
+      const { debugLog, names } = recorder()
+      let auth = 0
+      const h = hooks({
+        isAuthenticated: vi.fn().mockImplementation(async () => { auth += 1; return auth <= 1 }),
+      })
+      await runMonitor({
+        hooks: h, page: {}, context: { ...baseContext, debugLog }, sleep: noSleep,
+        onTransactions: async () => {},
+      })
+      expect(names()).toContain('logged_out')
+    })
+
+    it('emits max_runtime when the deadline elapses', async () => {
+      const { debugLog, names } = recorder()
+      const h = hooks({ poll: vi.fn().mockResolvedValue([]) })
+      await runMonitor({
+        hooks: h, page: {}, context: { ...baseContext, debugLog }, sleep: noSleep,
+        onTransactions: async () => {}, maxRuntimeMs: 1, shouldStop: () => false,
+      })
+      expect(names()).toContain('max_runtime')
+    })
+  })
+
+  it('supports an async shouldStop predicate', async () => {
+    const h = hooks({ poll: vi.fn().mockResolvedValue([]) })
+    let calls = 0
+    const reason = await runMonitor({
+      hooks: h, page: {}, context: baseContext, sleep: noSleep,
+      onTransactions: async () => {},
+      shouldStop: async () => { calls += 1; return calls > 1 },
+    })
+    expect(reason).toBe('stop_requested')
+    expect(calls).toBeGreaterThan(1)
+  })
+
+  it('loops without keepAlive when a poll yields only duplicates', async () => {
+    // lastExternalId seeds the dedup set, so the returned tx is never fresh and,
+    // with no keepAlive hook, the loop just sleeps and continues until stop.
+    const h = hooks({ poll: vi.fn().mockResolvedValue([tx('dup')]) })
+    const onTransactions = vi.fn().mockResolvedValue(undefined)
+    let calls = 0
+    const reason = await runMonitor({
+      hooks: h, page: {}, context: { ...baseContext, lastExternalId: 'dup' }, sleep: noSleep,
+      onTransactions,
+      shouldStop: () => { calls += 1; return calls > 1 },
+    })
+    expect(reason).toBe('stop_requested')
+    expect(onTransactions).not.toHaveBeenCalled()
+  })
 })

--- a/src/contexts/script-engine/infrastructure/runMonitor.ts
+++ b/src/contexts/script-engine/infrastructure/runMonitor.ts
@@ -68,7 +68,8 @@ export async function runMonitor(opts: RunMonitorOptions): Promise<MonitorStopRe
     sleep = (ms: number) => new Promise((r) => setTimeout(r, ms)),
   } = opts
 
-  const log = (event: string) => context.debugLog?.(JSON.stringify({ at: new Date().toISOString(), event }))
+  const log = (event: string, data?: Record<string, unknown>) =>
+    context.debugLog?.(JSON.stringify({ at: new Date().toISOString(), event, ...data }))
 
   // 1) Login + wait for authentication (assisted: long timeout for human 2FA).
   await hooks.login(page, context)
@@ -102,7 +103,7 @@ export async function runMonitor(opts: RunMonitorOptions): Promise<MonitorStopRe
     try {
       batch = await hooks.poll(page, context)
     } catch (err) {
-      log('poll_failed')
+      log('poll_failed', { error: err instanceof Error ? err.message : String(err) })
       if (hooks.keepAlive) await hooks.keepAlive(page).catch(() => {})
       await sleep(pollIntervalMs)
       continue


### PR DESCRIPTION
 This pull request implements structured debug logging for the bank-scraping
  monitor, wiring the previously-dead `context.debugLog` callback so that script
  and monitor events actually reach the Winston logger.

  ## Problem

  Bank scripts and `runMonitor` already emit structured JSON events through an
  optional `context.debugLog(line)` callback, but it was never wired in either
  execution path. Every event — poll summaries, auth timeouts, pagination,
  session lifecycle — was silently dropped. `SessionManager` only recorded
  start/stop in the `bank_sessions` table, with nothing in the logs.

  ## What this does

  - **Central sink** (`debugLogSink.ts`): `makeDebugLogSink(logger, baseMeta)`
    parses each JSON event line, classifies it to a Winston level by event name
    (pattern + override map), and forwards it with system metadata (accountId,
    bank) on every line. Guards: 1MB size cap, non-JSON / non-object / array
    fallback, invalid-level fallback, reserved-key stripping
    (`message`/`level`/`timestamp`/`context`/`at`), and credential redaction.
  - **Both execution paths wired**: persistent (`bankingModule` →
    `PersistentPlaywrightRunner` → `runMonitor`) and one-shot
    (`ScriptEngineAdapter` → `PlaywrightRunner`).
  - **Session lifecycle logs** in `SessionManager`: started (info), clean stop
    (info), unclean stop (warn), crash and start-failure (error).
  - **`runMonitor`** now includes the error message on `poll_failed`.

  ## Volume control

  Only the heartbeat (`poll_summary`) and lifecycle events log at `info`; all
  per-step/DOM noise stays at `debug` (suppressed under the default
  `LOG_LEVEL=info`). This keeps the rotating log files well within the 20MB/day
  rotation threshold.

  ## Security

  Trace identity is non-spoofable: system-supplied `baseMeta` (accountId/bank)
  wins over any field a script emits. Credential-like keys are redacted
  (substring match, so `accessToken`/`apiKey`/`passwordHash` are caught), with
  short ambiguous stems matched exactly to avoid over-redaction.

  ## Testing

  Full unit coverage of the sink's branches and guards, payload assertions in
  `runMonitor`, the complete `SessionManager` level matrix, and end-to-end checks
  proving `context.debugLog(...)` → sink → logger with the right level, metadata,
  and redaction through both runners. `npm test` and `npm run typecheck` pass.