### PR TITLE
Harden CI and add security scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  # Backend / root workspace
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      backend-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # Frontend workspace
+  - package-ecosystem: npm
+    directory: /client
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      client-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions used by the workflows
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,40 @@ on:
   pull_request:
 
 jobs:
+  quality:
+    name: quality
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck (backend)
+        run: pnpm typecheck
+
+      - name: Typecheck (client tests)
+        run: pnpm --filter ./client typecheck:test
+
+      - name: Lint (client)
+        run: pnpm --filter ./client lint
+
+      - name: Build (backend)
+        run: pnpm build
+
+      - name: Build (client)
+        run: pnpm --filter ./client build
+
   test:
+    name: test
     runs-on: ubuntu-latest
 
     services:
@@ -52,14 +85,28 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Typecheck
-        run: pnpm typecheck
+      - name: Backend tests (unit + integration, with coverage)
+        run: pnpm test:coverage
 
-      - name: Unit tests
-        run: pnpm test
+      - name: Client tests (with coverage)
+        run: pnpm --filter ./client test:coverage
 
-      - name: Integration tests
-        run: pnpm test:integration
+  audit:
+    name: audit
+    runs-on: ubuntu-latest
 
-      - name: Client tests
-        run: pnpm --filter ./client test
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Audit dependencies (fail on high/critical)
+        run: pnpm audit --audit-level=high

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # Weekly scan (Mondays 06:00 UTC) to catch newly disclosed query updates.
+    - cron: '0 6 * * 1'
+
+jobs:
+  analyze:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          # 'security-and-quality' is broader than the default 'security' suite.
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:javascript-typescript'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,14 @@ export default defineConfig({
         'src/shared/infrastructure/db/migrations/**',
       ],
       reporter: ['text', 'html'],
+      // Ratchet gate: floored just below the current measured coverage so CI
+      // fails on regressions without flaking. Raise these as coverage climbs.
+      thresholds: {
+        statements: 97,
+        branches: 95,
+        functions: 97,
+        lines: 98,
+      },
     },
   },
 })


### PR DESCRIPTION
## What it does

This pull request implements a hardened CI pipeline and adds security scanning. The previous CI only ran tests + typecheck; it now also runs lint, build, a coverage gate, CodeQL, Dependabot and `pnpm audit`.

### Changes

- **`.github/workflows/ci.yml`** — restructured into 3 jobs:
  - `quality`: typecheck (backend + client tests), client lint, backend + client build.
  - `test`: backend coverage (with gate) + client coverage, running against Postgres 16 / Redis 7.
  - `audit`: `pnpm audit --audit-level=high`.
- **`.github/workflows/codeql.yml`** (new) — CodeQL static analysis for JS/TS on push to `main`, on PRs and weekly.
- **`.github/dependabot.yml`** (new) — weekly npm updates (root + `client`) and GitHub Actions, grouped by minor/patch.
- **`vitest.config.ts`** — backend coverage thresholds (97/95/97/98), a ratchet pattern over the current coverage (~98%) to fail on regressions.

### Repo configuration applied (outside these files)

- Branch protection on `main`: required checks `quality`/`test`/`CodeQL` (strict), linear history, PR required (0 approvals), conversation resolution, force-push/deletion blocked, not enforced on admins.
- Merge: squash + rebase enabled, merge commit disabled, delete branch on merge.
- Secret scanning + push protection, vulnerability alerts and Dependabot security updates enabled.

### Notes

- The `audit` job will be **red** due to 4 pre-existing `high` vulnerabilities (`react-router` ≤7.14.1 and `fast-uri`, transitive via `shadcn`). It is not a required check, so it does not block merging. Dependabot will open the fix PRs.
- Local verification all green: typecheck, lint, builds, backend coverage (gate enforced) and client coverage (100%).
