### PR TITLE
Improve error messages across the app

### DIFF
--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -1,6 +1,9 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
-import App from './App'
+import { toast } from 'sonner'
+import type { Mutation } from '@tanstack/react-query'
+import App, { queryClient } from './App'
+import i18n from '@/shared/i18n'
 
 describe('App', () => {
   beforeEach(() => {
@@ -12,6 +15,46 @@ describe('App', () => {
     render(<App />)
     await waitFor(() => {
       expect(screen.getAllByRole('button').length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('mutation cache error fallback', () => {
+    const onError = queryClient.getMutationCache().config.onError!
+    const fakeMutation = (overrides: { onError?: () => void; meta?: Record<string, unknown> }) =>
+      ({ options: { onError: overrides.onError }, meta: overrides.meta }) as unknown as Mutation<
+        unknown,
+        unknown,
+        unknown
+      >
+    let errorSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      errorSpy = vi.spyOn(toast, 'error').mockImplementation(() => '')
+    })
+
+    afterEach(() => {
+      errorSpy.mockRestore()
+    })
+
+    it('does not toast when the mutation declares its own onError', () => {
+      onError(new Error('x'), undefined, undefined, fakeMutation({ onError: () => {} }))
+      expect(errorSpy).not.toHaveBeenCalled()
+    })
+
+    it('does not toast when the mutation marks the error as handled via meta', () => {
+      onError(new Error('x'), undefined, undefined, fakeMutation({ meta: { errorHandled: true } }))
+      expect(errorSpy).not.toHaveBeenCalled()
+    })
+
+    it('toasts the server message for unhandled failures', () => {
+      const err = { response: { data: { error: 'server says no' } } }
+      onError(err, undefined, undefined, fakeMutation({ meta: {} }))
+      expect(errorSpy).toHaveBeenCalledWith('server says no')
+    })
+
+    it('falls back to the generic message when the error has no usable payload', () => {
+      onError(new Error('x'), undefined, undefined, fakeMutation({}))
+      expect(errorSpy).toHaveBeenCalledWith(i18n.t('errors.generic'))
     })
   })
 })

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,11 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MutationCache, QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { toast } from 'sonner'
 import { TooltipProvider } from '@/shared/ui/tooltip'
 import { Toaster } from '@/shared/ui/sonner'
+import { ErrorBoundary } from '@/shared/ui/ErrorBoundary'
+import { localizedApiError } from '@/shared/http/client'
+import i18n from '@/shared/i18n'
 import { AuthProvider } from '@/features/user/providers/AuthProvider'
 import { PublicShell } from '@/shared/layout/PublicShell'
 import { ProtectedShell } from '@/shared/layout/ProtectedShell'
@@ -11,9 +15,16 @@ import { accountRoutes } from '@/features/account/routes'
 import { bankingRoutes } from '@/features/banking/routes'
 import { conciliationRoutes } from '@/features/conciliation/routes'
 import { scriptEngineRoutes } from '@/features/script-engine/routes'
-import '@/shared/i18n'
-
-const queryClient = new QueryClient()
+// Fallback toast for mutations that declare no local onError so failures are never silent
+const queryClient = new QueryClient({
+  mutationCache: new MutationCache({
+    onError: (error, _vars, _ctx, mutation) => {
+      // meta.errorHandled marks hooks whose callers pass onError to mutate() which the cache cannot see
+      if (mutation.options.onError || mutation.meta?.errorHandled) return
+      toast.error(localizedApiError(error) ?? i18n.t('errors.generic'))
+    },
+  }),
+})
 
 export default function App() {
   return (
@@ -21,6 +32,7 @@ export default function App() {
       <AuthProvider>
         <TooltipProvider>
           <BrowserRouter>
+            <ErrorBoundary>
             <Routes>
               <Route element={<PublicShell />}>{userPublicRoutes}</Route>
               <Route element={<ProtectedShell />}>
@@ -32,6 +44,7 @@ export default function App() {
               </Route>
               <Route path="*" element={<Navigate to="/" replace />} />
             </Routes>
+            </ErrorBoundary>
           </BrowserRouter>
           <Toaster />
         </TooltipProvider>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,8 +15,10 @@ import { accountRoutes } from '@/features/account/routes'
 import { bankingRoutes } from '@/features/banking/routes'
 import { conciliationRoutes } from '@/features/conciliation/routes'
 import { scriptEngineRoutes } from '@/features/script-engine/routes'
-// Fallback toast for mutations that declare no local onError so failures are never silent
-const queryClient = new QueryClient({
+// Fallback toast for mutations that declare no local onError so failures are never silent.
+// Exported so tests can exercise the cache-level fallback directly.
+// eslint-disable-next-line react-refresh/only-export-components
+export const queryClient = new QueryClient({
   mutationCache: new MutationCache({
     onError: (error, _vars, _ctx, mutation) => {
       // meta.errorHandled marks hooks whose callers pass onError to mutate() which the cache cannot see

--- a/client/src/features/account/hooks/useAccountConfig.ts
+++ b/client/src/features/account/hooks/useAccountConfig.ts
@@ -16,6 +16,7 @@ export function useUpsertAccountConfig(accountId: string) {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (input: UpsertAccountConfigInput) => upsertAccountConfig(accountId, input),
+    meta: { errorHandled: true },
     onSuccess: () => qc.invalidateQueries({ queryKey: accountConfigQueryKey(accountId) }),
   })
 }

--- a/client/src/features/account/hooks/useAccounts.ts
+++ b/client/src/features/account/hooks/useAccounts.ts
@@ -28,6 +28,7 @@ export function useDeleteAccount() {
   return useMutation({
     mutationFn: ({ accountId, confirmationName }: { accountId: string; confirmationName: string }) =>
       deleteAccount(accountId, confirmationName),
+    meta: { errorHandled: true },
     onSuccess: () => qc.invalidateQueries({ queryKey: accountsQueryKey }),
   })
 }

--- a/client/src/features/account/pages/AccountConfig.test.tsx
+++ b/client/src/features/account/pages/AccountConfig.test.tsx
@@ -266,6 +266,21 @@ describe('AccountConfig page', () => {
     })
   })
 
+  it('shows the query error state with a retry button when loading the config fails', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('/api/accounts/:accountId/config', () => HttpResponse.json({}, { status: 500 }))
+    )
+    renderAccountConfig()
+    expect(await screen.findByText(/No se pudieron cargar los datos/i)).toBeInTheDocument()
+    // Fix the endpoint and retry.
+    server.use(...accountHandlers)
+    await user.click(screen.getByRole('button', { name: /Reintentar/i }))
+    await waitFor(() => {
+      expect(screen.getByText('Configuración de cuenta')).toBeInTheDocument()
+    })
+  })
+
   it('shows the credentials tab by default', async () => {
     renderAccountConfig()
     await waitFor(() => {

--- a/client/src/features/account/pages/AccountConfig.tsx
+++ b/client/src/features/account/pages/AccountConfig.tsx
@@ -1,8 +1,10 @@
+import { QueryError } from '@/shared/ui/QueryError'
 import { useState, useEffect, useMemo } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 import { Button } from '@/shared/ui/button'
 import { Input } from '@/shared/ui/input'
+import { FormField } from '@/shared/ui/FormField'
 import { Label } from '@/shared/ui/label'
 import { Card, CardAction, CardContent, CardHeader, CardTitle } from '@/shared/ui/card'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/ui/select'
@@ -10,6 +12,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/shared/ui/tabs'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/tooltip'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shared/ui/dialog'
 import { cn } from '@/shared/lib/utils'
+import { localizedApiError } from '@/shared/http/client'
 import { Radio } from '@base-ui/react/radio'
 import { RadioGroup } from '@base-ui/react/radio-group'
 import { ArrowLeft, Save, Info, Trash2, AlertTriangle, ShieldAlert, Check, Bell, BellOff, TrendingDown, Lock, FileCheck, Settings as SettingsIcon, Terminal, KeyRound, Webhook, ListChecks, AlertCircle } from 'lucide-react'
@@ -57,7 +60,7 @@ export function AccountConfig() {
   const [activeTab, setActiveTab] = useState<string>('credentials-session')
 
   const { data: account } = useAccount(accountId)
-  const { data, isLoading } = useAccountConfig(accountId)
+  const { data, isLoading, isError, refetch } = useAccountConfig(accountId)
 
   const hasSavedCredential = !!(data?.bankUsername && data.bankUsername.trim() !== '')
 
@@ -74,7 +77,7 @@ export function AccountConfig() {
         return ['pendingOrdersEndpoint', 'authToken']
       case 'webhook':
         return ['webhookUrl']
-      /* v8 ignore start -- exhaustive switch over fixed tab IDs; default is unreachable. */
+      /* v8 ignore start -- exhaustive switch over fixed tab IDs makes default unreachable */
       default:
         return []
       /* v8 ignore stop */
@@ -85,7 +88,7 @@ export function AccountConfig() {
     const required = requiredFieldsFor(tab)
     const done = required.filter(k => {
       const value = form[k]
-      /* v8 ignore next -- all required fields are strings; the String(value) coercion is defensive. */
+      /* v8 ignore next -- all required fields are strings so the `String(value)` coercion is defensive */
       const stringValue = typeof value === 'string' ? value : String(value)
       return stringValue.trim() !== '' && !liveErrors[k]
     }).length
@@ -117,7 +120,7 @@ export function AccountConfig() {
 
   useEffect(() => {
     if (!data) return
-    // Hydrate the editable form from the loaded config snapshot.
+    // Hydrate the editable form from the loaded config snapshot
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setForm(f => ({
       ...f,
@@ -157,13 +160,13 @@ export function AccountConfig() {
     if (!trimmed) return null
     try {
       const parsed = JSON.parse(trimmed)
-      /* v8 ignore else -- validation rejects arrays for extra-fields and non-object pollingBody never round-trips through here in practice. */
+      /* v8 ignore else -- validation rejects arrays and non-object payloads before this point */
       if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
         return parsed as Record<string, unknown>
       }
-    /* v8 ignore start -- validation already gates malformed JSON and non-object payloads before reaching the catch + fallback return. */
+    /* v8 ignore start -- validation already gates malformed JSON before the catch and fallback return */
     } catch {
-      // Ignored — validation already gates this path.
+      // Ignored because validation already gates this path
     }
     return null
     /* v8 ignore stop */
@@ -185,7 +188,7 @@ export function AccountConfig() {
     if (Object.keys(next).length > 0) {
       setErrors(next)
       const firstField = FIELD_ORDER.find(k => next[k] !== undefined)
-      /* v8 ignore else -- validation always sets errors keyed by FIELD_ORDER, so `find` always matches. */
+      /* v8 ignore else -- validation always sets errors keyed by `FIELD_ORDER` so `find` always matches */
       if (firstField) {
         const targetTab = resolveTabForField(firstField, mode)
         if (targetTab && targetTab !== activeTab) setActiveTab(targetTab)
@@ -213,7 +216,7 @@ export function AccountConfig() {
         silentIngestion: form.silentIngestion,
         sessionType: form.sessionType,
         loginMode: form.loginMode,
-        /* v8 ignore start -- validation requires bankUsername; the empty branch is unreachable from a valid save. */
+        /* v8 ignore start -- validation requires bankUsername so the empty branch is unreachable */
         bankUsername: trimmedBankUsername === '' ? null : trimmedBankUsername,
         /* v8 ignore stop */
         bankPassword: form.bankPassword === '' ? null : form.bankPassword,
@@ -225,9 +228,9 @@ export function AccountConfig() {
         },
         onError: (err: unknown) => {
           const message =
-            (err as { response?: { data?: { error?: string } } })?.response?.data?.error ??
+            localizedApiError(err) ??
             (err as { message?: string })?.message ??
-            /* v8 ignore start -- axios always populates err.message, so the generic fallback is unreachable. */
+            /* v8 ignore start -- axios always populates err.message so the generic fallback is unreachable */
             t('accountConfig.errors.generic')
             /* v8 ignore stop */
           const field = mapServerErrorToField(message)
@@ -244,15 +247,14 @@ export function AccountConfig() {
   }
 
   function handleDelete() {
-    /* v8 ignore next -- delete button is disabled when accountId is missing; guard is defensive. */
+    /* v8 ignore next -- delete button is disabled when accountId is missing so the guard is defensive */
     if (!accountId) return
     remove.mutate(
       { accountId, confirmationName: deleteConfirmName.trim() },
       {
         onSuccess: () => navigate('/accounts'),
         onError: (err: unknown) => {
-          const message = (err as { response?: { data?: { error?: string } } })?.response?.data?.error
-          setDeleteError(message ?? t('accountConfig.danger.genericError'))
+          setDeleteError(localizedApiError(err) ?? t('accountConfig.danger.genericError'))
         },
       }
     )
@@ -270,6 +272,7 @@ export function AccountConfig() {
   }
 
   if (isLoading) return <div className="p-8 text-muted-foreground text-sm">{t('accountConfig.loading')}</div>
+  if (isError) return <QueryError onRetry={() => refetch()} />
 
   return (
     <div className="flex min-h-full flex-col">
@@ -510,6 +513,7 @@ export function AccountConfig() {
             </CardContent>
           </Card>
         </TabsContent>
+
 
         {/* Orders (reconcile mode only) */}
         {mode === 'reconcile' && (
@@ -837,45 +841,6 @@ interface AuthCardProps {
   }
   setForm: React.Dispatch<React.SetStateAction<AccountConfigForm>>
   hintKey: string
-}
-
-interface FormFieldProps {
-  label: React.ReactNode
-  required?: boolean
-  hint?: string
-  error?: string
-  children: React.ReactNode
-}
-
-function FormField({ label, required, hint, error, children }: FormFieldProps) {
-  const hasError = Boolean(error)
-  return (
-    <div className="grid gap-1.5">
-      <Label className={cn('text-[13px] transition-colors flex items-center gap-1', hasError && 'text-destructive')}>
-        <span>{label}</span>
-        {required && (
-          <span className="text-destructive" aria-hidden>*</span>
-        )}
-      </Label>
-      {children}
-      {(hasError || hint) && (
-        <p
-          aria-live="polite"
-          className={cn(
-            'flex items-center gap-1 text-[11px] leading-4 min-h-4 transition-colors',
-            hasError ? 'text-destructive' : 'text-muted-foreground',
-          )}
-        >
-          {hasError ? (
-            <AlertCircle className="size-3 shrink-0" aria-hidden />
-          ) : (
-            <Info className="size-3 shrink-0 opacity-60" aria-hidden />
-          )}
-          <span>{hasError ? error : hint}</span>
-        </p>
-      )}
-    </div>
-  )
 }
 
 function AuthCard({ form, errors, t, field, setForm, hintKey }: AuthCardProps) {

--- a/client/src/features/account/pages/Accounts.test.tsx
+++ b/client/src/features/account/pages/Accounts.test.tsx
@@ -208,4 +208,53 @@ describe('Accounts page', () => {
     // Avoid unused-vi-import warning when running in isolation.
     expect(vi).toBeDefined()
   })
+
+  it('shows the query error state with a retry button when the list fails', async () => {
+    const user = userEvent.setup()
+    server.use(http.get('/api/accounts', () => HttpResponse.json({}, { status: 500 })))
+    renderWithProviders(<Accounts />)
+    expect(await screen.findByText(/No se pudieron cargar los datos/i)).toBeInTheDocument()
+    // Fix the endpoint and retry.
+    server.use(...accountHandlers)
+    await user.click(screen.getByRole('button', { name: /Reintentar/i }))
+    await waitFor(() => {
+      expect(screen.getByText('Cuenta 1')).toBeInTheDocument()
+    })
+  })
+
+  it('toasts the server message when creating an account fails', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.post('/api/accounts', () =>
+        HttpResponse.json({ error: 'banco rechazado' }, { status: 500 })
+      )
+    )
+    renderWithProviders(<Accounts />)
+    await waitFor(() => expect(screen.getByText('Cuenta 1')).toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: /Nueva cuenta/i }))
+    await screen.findByRole('dialog')
+    await user.type(screen.getByPlaceholderText(/ej: Cuenta principal/i), 'Fallida')
+    await user.click(screen.getByRole('combobox'))
+    await user.click(await screen.findByRole('option', { name: /Mi Dinero/i }))
+    await user.click(screen.getByRole('button', { name: /Crear cuenta/i }))
+
+    expect(await screen.findByText('banco rechazado')).toBeInTheDocument()
+  })
+
+  it('toasts the generic error when creating an account fails without a message', async () => {
+    const user = userEvent.setup()
+    server.use(http.post('/api/accounts', () => HttpResponse.json({}, { status: 500 })))
+    renderWithProviders(<Accounts />)
+    await waitFor(() => expect(screen.getByText('Cuenta 1')).toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: /Nueva cuenta/i }))
+    await screen.findByRole('dialog')
+    await user.type(screen.getByPlaceholderText(/ej: Cuenta principal/i), 'Fallida')
+    await user.click(screen.getByRole('combobox'))
+    await user.click(await screen.findByRole('option', { name: /Mi Dinero/i }))
+    await user.click(screen.getByRole('button', { name: /Crear cuenta/i }))
+
+    expect(await screen.findByText(/Algo salió mal/i)).toBeInTheDocument()
+  })
 })

--- a/client/src/features/account/pages/Accounts.tsx
+++ b/client/src/features/account/pages/Accounts.tsx
@@ -1,14 +1,16 @@
-import { useId, useState, type ReactNode } from 'react'
+import { QueryError } from '@/shared/ui/QueryError'
+import { useId, useState } from 'react'
+import { toast } from 'sonner'
+import { localizedApiError } from '@/shared/http/client'
+import { FormField } from '@/shared/ui/FormField'
 import { Button, buttonVariants } from '@/shared/ui/button'
 import { Input } from '@/shared/ui/input'
-import { Label } from '@/shared/ui/label'
 import { Badge } from '@/shared/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card'
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/shared/ui/dialog'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/ui/select'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/shared/ui/table'
-import { cn } from '@/shared/lib/utils'
-import { Plus, Settings, Info, AlertCircle } from 'lucide-react'
+import { Plus, Settings } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useAccounts, useCreateAccount } from '../hooks/useAccounts'
@@ -29,7 +31,7 @@ export function Accounts() {
   const bankHelpId = useId()
   const nameHelpId = useId()
 
-  const { data: accounts = [], isLoading } = useAccounts()
+  const { data: accounts = [], isLoading, isError, refetch } = useAccounts()
   const { data: banks = [] } = useBanks()
 
   const bankNameByCode = Object.fromEntries(banks.map(b => [b.code, b.name]))
@@ -55,6 +57,7 @@ export function Accounts() {
         setErrors({})
         setSubmitted(false)
       },
+      onError: err => toast.error(localizedApiError(err) ?? t('common:errors.generic')),
     })
   }
 
@@ -66,7 +69,7 @@ export function Accounts() {
     })
   }
 
-  /* v8 ignore next -- base-ui Select always passes a string; `?? ''` is a defensive fallback for null. */
+  /* v8 ignore next -- base-ui Select always passes a string so `?? ''` is defensive */
   const onBankChange = (v: string | null) => updateForm('bankId', v ?? '')
 
   function handleOpenChange(next: boolean) {
@@ -97,7 +100,7 @@ export function Accounts() {
               </DialogDescription>
             </DialogHeader>
             <div className="flex flex-col gap-3.5">
-              <Field
+              <FormField
                 label={t('accounts.dialog.name')}
                 htmlFor={nameId}
                 helpId={nameHelpId}
@@ -112,8 +115,8 @@ export function Accounts() {
                   aria-invalid={errors.name ? true : undefined}
                   aria-describedby={nameHelpId}
                 />
-              </Field>
-              <Field
+              </FormField>
+              <FormField
                 label={t('accounts.dialog.bank')}
                 htmlFor={bankId}
                 helpId={bankHelpId}
@@ -137,7 +140,7 @@ export function Accounts() {
                     ))}
                   </SelectContent>
                 </Select>
-              </Field>
+              </FormField>
             </div>
             <div className="flex items-center justify-end gap-2 pt-1">
               <DialogClose render={<Button variant="ghost" size="sm" />}>
@@ -159,6 +162,8 @@ export function Accounts() {
         <CardContent>
           {isLoading ? (
             <p className="text-muted-foreground text-sm">{t('accounts.loading')}</p>
+          ) : isError ? (
+            <QueryError onRetry={() => refetch()} />
           ) : (
             <Table>
               <TableHeader>
@@ -201,53 +206,6 @@ export function Accounts() {
           )}
         </CardContent>
       </Card>
-    </div>
-  )
-}
-
-interface FieldProps {
-  label: string
-  htmlFor: string
-  helpId: string
-  hint: string
-  error?: string
-  children: ReactNode
-}
-
-/**
- * Field wrapper with field-state emphasis: the input itself carries the
- * red border/ring (via aria-invalid), the label tints destructive on error,
- * and the helper line below stays muted unless it's communicating an error.
- */
-function Field({ label, htmlFor, helpId, hint, error, children }: FieldProps) {
-  const hasError = Boolean(error)
-  return (
-    <div className="grid gap-1.5">
-      <Label
-        htmlFor={htmlFor}
-        className={cn(
-          'text-[13px] transition-colors',
-          hasError && 'text-destructive'
-        )}
-      >
-        {label}
-      </Label>
-      {children}
-      <p
-        id={helpId}
-        aria-live="polite"
-        className={cn(
-          'flex items-center gap-1 text-[11px] leading-4 min-h-4 transition-colors',
-          hasError ? 'text-destructive' : 'text-muted-foreground'
-        )}
-      >
-        {hasError ? (
-          <AlertCircle className="size-3 shrink-0" aria-hidden />
-        ) : (
-          <Info className="size-3 shrink-0 opacity-60" aria-hidden />
-        )}
-        <span>{hasError ? error : hint}</span>
-      </p>
     </div>
   )
 }

--- a/client/src/features/banking/hooks/useBankMovements.ts
+++ b/client/src/features/banking/hooks/useBankMovements.ts
@@ -1,3 +1,6 @@
+import { toast } from 'sonner'
+import { localizedApiError } from '@/shared/http/client'
+import i18n from '@/shared/i18n'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import { listBankMovements, reNotifyMovement } from '../api/movements'
 
@@ -15,5 +18,6 @@ export function useBankMovements(accountId: string | undefined, limit = 100, off
 export function useReNotifyMovement(accountId: string) {
   return useMutation({
     mutationFn: (movementId: string) => reNotifyMovement(accountId, movementId),
+    onError: (err) => toast.error(localizedApiError(err) ?? i18n.t('banking:movements.renotifyError')),
   })
 }

--- a/client/src/features/banking/i18n/en.json
+++ b/client/src/features/banking/i18n/en.json
@@ -18,6 +18,7 @@
     "renotifyTitle": "Are you sure you want to re-notify?",
     "renotifyDesc": "This will re-send the webhook for this movement to the external system.",
     "renotifyConfirm": "Notify",
-    "renotifyCancel": "Cancel"
+    "renotifyCancel": "Cancel",
+    "renotifyError": "Could not resend the notification"
   }
 }

--- a/client/src/features/banking/i18n/es.json
+++ b/client/src/features/banking/i18n/es.json
@@ -18,6 +18,7 @@
     "renotifyTitle": "¿Seguro que querés volver a notificar?",
     "renotifyDesc": "Esto reenvía el webhook de este movimiento al sistema externo.",
     "renotifyConfirm": "Notificar",
-    "renotifyCancel": "Cancelar"
+    "renotifyCancel": "Cancelar",
+    "renotifyError": "No se pudo reenviar la notificación"
   }
 }

--- a/client/src/features/banking/pages/BankMovements.test.tsx
+++ b/client/src/features/banking/pages/BankMovements.test.tsx
@@ -109,4 +109,66 @@ describe('BankMovements page', () => {
 
     await waitFor(() => expect(notifyCalls).toBe(1))
   })
+
+  it('shows the query error state with a retry button when the accounts query fails', async () => {
+    const user = userEvent.setup()
+    server.use(http.get('/api/accounts', () => HttpResponse.json({}, { status: 500 })))
+    renderWithProviders(<BankMovements />)
+    expect(await screen.findByText(/No se pudieron cargar los datos/i)).toBeInTheDocument()
+    // Fix the endpoint and retry.
+    server.use(...accountHandlers)
+    await user.click(screen.getByRole('button', { name: /Reintentar/i }))
+    await waitFor(() => expect(screen.getByText('ext-1')).toBeInTheDocument())
+  })
+
+  it('shows the query error state when loading the movements of an account fails', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('/api/accounts/:accountId/movements', () => HttpResponse.json({}, { status: 500 }))
+    )
+    renderWithProviders(<BankMovements />)
+    expect(await screen.findByText(/No se pudieron cargar los datos/i)).toBeInTheDocument()
+    // Fix the endpoint and retry.
+    server.use(...bankingHandlers)
+    await user.click(screen.getByRole('button', { name: /Reintentar/i }))
+    await waitFor(() => expect(screen.getByText('ext-1')).toBeInTheDocument())
+  })
+
+  it('toasts the server message when renotifying fails', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.post('/api/accounts/:accountId/movements/:movementId/notify', () =>
+        HttpResponse.json({ error: 'webhook caído' }, { status: 500 })
+      )
+    )
+    renderWithProviders(<BankMovements />)
+    await waitFor(() => expect(screen.getByText('ext-1')).toBeInTheDocument())
+
+    const bellTriggers = screen.getAllByRole('button').filter(b => b.querySelector('.lucide-bell'))
+    await user.click(bellTriggers[0])
+    const dialog = await screen.findByRole('dialog')
+    await user.click(within(dialog).getByRole('button', { name: 'Notificar' }))
+
+    expect(await screen.findAllByText('webhook caído')).not.toHaveLength(0)
+  })
+
+  it('toasts the fallback messages when renotifying fails without a message', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.post('/api/accounts/:accountId/movements/:movementId/notify', () =>
+        HttpResponse.json({}, { status: 500 })
+      )
+    )
+    renderWithProviders(<BankMovements />)
+    await waitFor(() => expect(screen.getByText('ext-1')).toBeInTheDocument())
+
+    const bellTriggers = screen.getAllByRole('button').filter(b => b.querySelector('.lucide-bell'))
+    await user.click(bellTriggers[0])
+    const dialog = await screen.findByRole('dialog')
+    await user.click(within(dialog).getByRole('button', { name: 'Notificar' }))
+
+    // Hook-level and page-level handlers each toast their own fallback copy.
+    expect(await screen.findByText(/No se pudo reenviar la notificación/i)).toBeInTheDocument()
+    expect(await screen.findByText(/Algo salió mal/i)).toBeInTheDocument()
+  })
 })

--- a/client/src/features/banking/pages/BankMovements.tsx
+++ b/client/src/features/banking/pages/BankMovements.tsx
@@ -1,3 +1,4 @@
+import { QueryError } from '@/shared/ui/QueryError'
 import { useQueryClient } from '@tanstack/react-query'
 import { useAccounts } from '@/features/account/hooks/useAccounts'
 import { useBankMovements, useReNotifyMovement, bankMovementsQueryKey } from '../hooks/useBankMovements'
@@ -8,13 +9,15 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, Di
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/shared/ui/table'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/shared/ui/tabs'
 import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { localizedApiError } from '@/shared/http/client'
 import { Bell, CheckCircle2, Clock, Inbox } from 'lucide-react'
 
 function MovementsTable({ accountId }: { accountId: string }) {
-  const { t } = useTranslation('banking')
+  const { t } = useTranslation(['banking', 'common'])
   const qc = useQueryClient()
 
-  const { data: movements = [], isLoading } = useBankMovements(accountId)
+  const { data: movements = [], isLoading, isError, refetch } = useBankMovements(accountId)
 
   const renotify = useReNotifyMovement(accountId)
 
@@ -23,11 +26,16 @@ function MovementsTable({ accountId }: { accountId: string }) {
       onSuccess: () => {
         qc.invalidateQueries({ queryKey: bankMovementsQueryKey(accountId) })
       },
+      onError: err => toast.error(localizedApiError(err) ?? t('common:errors.generic')),
     })
   }
 
   if (isLoading) {
     return <p className="text-muted-foreground text-sm">{t('movements.loading')}</p>
+  }
+
+  if (isError) {
+    return <QueryError onRetry={() => refetch()} />
   }
 
   return (
@@ -113,7 +121,7 @@ function MovementsTable({ accountId }: { accountId: string }) {
 
 export function BankMovements() {
   const { t } = useTranslation('banking')
-  const { data: accounts = [], isLoading } = useAccounts()
+  const { data: accounts = [], isLoading, isError, refetch } = useAccounts()
 
   return (
     <div className="p-8 space-y-6">
@@ -124,6 +132,8 @@ export function BankMovements() {
 
       {isLoading ? (
         <p className="text-muted-foreground text-sm">{t('movements.loading')}</p>
+      ) : isError ? (
+        <QueryError onRetry={() => refetch()} />
       ) : accounts.length === 0 ? (
         <Card>
           <CardContent className="py-12 text-center text-muted-foreground">

--- a/client/src/features/conciliation/hooks/useConciliations.ts
+++ b/client/src/features/conciliation/hooks/useConciliations.ts
@@ -1,3 +1,6 @@
+import { toast } from 'sonner'
+import { localizedApiError } from '@/shared/http/client'
+import i18n from '@/shared/i18n'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import { listConciliations, getConciliation, enqueueRun, enqueueNotify, enqueuePoll } from '../api/conciliations'
 import type { ListFilter } from '../types'
@@ -24,7 +27,10 @@ export function useRunConciliation() {
 }
 
 export function useNotifyConciliation() {
-  return useMutation({ mutationFn: enqueueNotify })
+  return useMutation({
+    mutationFn: enqueueNotify,
+    onError: (err) => toast.error(localizedApiError(err) ?? i18n.t('conciliation:conciliations.renotifyError')),
+  })
 }
 
 export function usePollConciliation() {

--- a/client/src/features/conciliation/i18n/en.json
+++ b/client/src/features/conciliation/i18n/en.json
@@ -26,6 +26,7 @@
     "renotifyTitle": "Are you sure you want to re-notify?",
     "renotifyDesc": "This will send the webhook again and trigger actions on the target system.",
     "renotifyConfirm": "Notify",
-    "renotifyCancel": "Cancel"
+    "renotifyCancel": "Cancel",
+    "renotifyError": "Could not resend the notification"
   }
 }

--- a/client/src/features/conciliation/i18n/es.json
+++ b/client/src/features/conciliation/i18n/es.json
@@ -26,6 +26,7 @@
     "renotifyTitle": "¿Seguro que querés volver a notificar?",
     "renotifyDesc": "Esto enviará el webhook nuevamente y provocará que se ejecuten acciones en el sistema al que apunta.",
     "renotifyConfirm": "Notificar",
-    "renotifyCancel": "Cancelar"
+    "renotifyCancel": "Cancelar",
+    "renotifyError": "No se pudo reenviar la notificación"
   }
 }

--- a/client/src/features/conciliation/pages/Conciliations.test.tsx
+++ b/client/src/features/conciliation/pages/Conciliations.test.tsx
@@ -348,4 +348,82 @@ describe('Conciliations page', () => {
       expect(screen.getAllByText('Aún no hay órdenes').length).toBeGreaterThan(0)
     })
   })
+
+  it('shows the query error state and retries all failing queries', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('/api/conciliation', () => HttpResponse.json({}, { status: 500 })),
+      http.get('/api/accounts', () => HttpResponse.json({}, { status: 500 })),
+      http.get('/api/me', () => HttpResponse.json({}, { status: 500 }))
+    )
+    renderWithProviders(<Conciliations />)
+    expect(await screen.findByText(/No se pudieron cargar los datos/i)).toBeInTheDocument()
+    // Fix the endpoints and retry.
+    setReconcileMode()
+    server.use(...accountHandlers, ...conciliationHandlers)
+    await user.click(screen.getByRole('button', { name: /Reintentar/i }))
+    await waitFor(() => expect(screen.getByText('ord-1')).toBeInTheDocument())
+  })
+
+  it('retries only the conciliation query when it is the only failing one', async () => {
+    const user = userEvent.setup()
+    server.use(http.get('/api/conciliation', () => HttpResponse.json({}, { status: 500 })))
+    renderWithProviders(<Conciliations />)
+    expect(await screen.findByText(/No se pudieron cargar los datos/i)).toBeInTheDocument()
+    server.use(...conciliationHandlers)
+    await user.click(screen.getByRole('button', { name: /Reintentar/i }))
+    await waitFor(() => expect(screen.getByText('ord-1')).toBeInTheDocument())
+  })
+
+  it('retries only the accounts query when it is the only failing one', async () => {
+    const user = userEvent.setup()
+    server.use(http.get('/api/accounts', () => HttpResponse.json({}, { status: 500 })))
+    renderWithProviders(<Conciliations />)
+    expect(await screen.findByText(/No se pudieron cargar los datos/i)).toBeInTheDocument()
+    server.use(...accountHandlers)
+    await user.click(screen.getByRole('button', { name: /Reintentar/i }))
+    await waitFor(() => expect(screen.getByText('ord-1')).toBeInTheDocument())
+  })
+
+  it('toasts the server message when renotifying fails', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('/api/conciliation', () =>
+        HttpResponse.json([{ ...baseRow, id: 'c-1', externalId: 'ord-1', status: 'matched' }])
+      ),
+      http.post('/api/conciliation/:requestId/notify', () =>
+        HttpResponse.json({ error: 'webhook caído' }, { status: 500 })
+      )
+    )
+    renderWithProviders(<Conciliations />)
+    await waitFor(() => expect(screen.getByText('ord-1')).toBeInTheDocument())
+
+    const bell = screen.getAllByRole('button').find(b => b.querySelector('.lucide-bell') && !(b as HTMLButtonElement).disabled)!
+    await user.click(bell)
+    const dialog = await screen.findByRole('dialog')
+    await user.click(within(dialog).getByRole('button', { name: /^Notificar$/i }))
+
+    expect(await screen.findAllByText('webhook caído')).not.toHaveLength(0)
+  })
+
+  it('toasts the fallback messages when renotifying fails without a message', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('/api/conciliation', () =>
+        HttpResponse.json([{ ...baseRow, id: 'c-1', externalId: 'ord-1', status: 'matched' }])
+      ),
+      http.post('/api/conciliation/:requestId/notify', () => HttpResponse.json({}, { status: 500 }))
+    )
+    renderWithProviders(<Conciliations />)
+    await waitFor(() => expect(screen.getByText('ord-1')).toBeInTheDocument())
+
+    const bell = screen.getAllByRole('button').find(b => b.querySelector('.lucide-bell') && !(b as HTMLButtonElement).disabled)!
+    await user.click(bell)
+    const dialog = await screen.findByRole('dialog')
+    await user.click(within(dialog).getByRole('button', { name: /^Notificar$/i }))
+
+    // Hook-level and dialog-level handlers each toast their own fallback copy.
+    expect(await screen.findByText(/No se pudo reenviar la notificación/i)).toBeInTheDocument()
+    expect(await screen.findByText(/Algo salió mal/i)).toBeInTheDocument()
+  })
 })

--- a/client/src/features/conciliation/pages/Conciliations.tsx
+++ b/client/src/features/conciliation/pages/Conciliations.tsx
@@ -1,3 +1,4 @@
+import { QueryError } from '@/shared/ui/QueryError'
 import { useState, useMemo } from 'react'
 import { useUser } from '@/features/user/hooks/useUser'
 import { useAccounts } from '@/features/account/hooks/useAccounts'
@@ -14,6 +15,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/shared/ui/table'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/shared/ui/tabs'
 import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { localizedApiError } from '@/shared/http/client'
 import { X, SlidersHorizontal, Bell, CheckCircle2, Clock, Loader2, SearchX, HelpCircle, XCircle, History, Ban, Inbox, type LucideIcon } from 'lucide-react'
 
 const STATUS_KEYS = ['matched', 'pending', 'processing', 'not_found', 'ambiguous', 'failed', 'expired', 'cancelled'] as const
@@ -106,7 +109,9 @@ function OrdersTable({ requests, accounts, showAccount }: { requests: Conciliati
                         </Button>
                       } />
                       <DialogClose render={
-                        <Button onClick={() => renotify.mutate(r.id)}>
+                        <Button onClick={() => renotify.mutate(r.id, {
+                          onError: err => toast.error(localizedApiError(err) ?? t('common:errors.generic')),
+                        })}>
                           {t('conciliations.renotifyConfirm')}
                         </Button>
                       } />
@@ -143,13 +148,19 @@ export function Conciliations() {
   const [filters, setFilters] = useState<Filters>(emptyFilters)
   const [draft, setDraft] = useState<Filters>(emptyFilters)
 
-  const { data: requests = [], isLoading: loadingReqs } = useConciliations()
-  const { data: allAccounts = [], isLoading: loadingAccounts } = useAccounts()
-  const { data: me, isLoading: loadingMe } = useUser()
+  const { data: requests = [], isLoading: loadingReqs, isError: errorReqs, refetch: refetchReqs } = useConciliations()
+  const { data: allAccounts = [], isLoading: loadingAccounts, isError: errorAccounts, refetch: refetchAccounts } = useAccounts()
+  const { data: me, isLoading: loadingMe, isError: errorMe, refetch: refetchMe } = useUser()
 
   const accounts = allAccounts
 
   const isLoading = loadingReqs || loadingAccounts || loadingMe
+  const isError = errorReqs || errorAccounts || errorMe
+  const retryFailed = () => {
+    if (errorReqs) void refetchReqs()
+    if (errorAccounts) void refetchAccounts()
+    if (errorMe) void refetchMe()
+  }
   const wrongMode = !isLoading && me?.operationMode !== 'reconcile'
 
   /* v8 ignore next -- base-ui Select always passes a string; `?? ''` is a defensive fallback for null. */
@@ -195,6 +206,8 @@ export function Conciliations() {
 
       {isLoading ? (
         <p className="text-muted-foreground text-sm">{t('conciliations.loading')}</p>
+      ) : isError ? (
+        <QueryError onRetry={retryFailed} />
       ) : wrongMode ? (
         <Card>
           <CardContent className="py-12 text-center text-muted-foreground">

--- a/client/src/features/dashboard/pages/Dashboard.test.tsx
+++ b/client/src/features/dashboard/pages/Dashboard.test.tsx
@@ -42,6 +42,7 @@ vi.mock('recharts', async () => {
 })
 import { http, HttpResponse } from 'msw'
 import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { server } from '../../../../tests/msw/server'
 import { accountHandlers } from '../../../../tests/msw/handlers/account'
 import { conciliationHandlers } from '../../../../tests/msw/handlers/conciliation'
@@ -274,5 +275,45 @@ describe('Dashboard (passthrough mode)', () => {
     expect(monthFmt.tick!('2026-05')).toBe('05/26')
     // Month-grouped label: 2026-05 → 05/2026
     expect(monthFmt.label!('2026-05')).toBe('05/2026')
+  })
+
+  it('shows the query error state and retries all failing queries', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('/api/accounts', () => HttpResponse.json({}, { status: 500 })),
+      http.get('/api/conciliation', () => HttpResponse.json({}, { status: 500 }))
+    )
+    renderWithProviders(<Dashboard />)
+    expect(await screen.findByText(/No se pudieron cargar los datos/i)).toBeInTheDocument()
+    // Fix the endpoints and retry.
+    server.use(...accountHandlers, ...conciliationHandlers)
+    await user.click(screen.getByRole('button', { name: /Reintentar/i }))
+    await waitFor(() => {
+      expect(screen.queryByText(/No se pudieron cargar los datos/i)).not.toBeInTheDocument()
+    })
+  })
+
+  it('retries only the accounts query when it is the only failing one', async () => {
+    const user = userEvent.setup()
+    server.use(http.get('/api/accounts', () => HttpResponse.json({}, { status: 500 })))
+    renderWithProviders(<Dashboard />)
+    expect(await screen.findByText(/No se pudieron cargar los datos/i)).toBeInTheDocument()
+    server.use(...accountHandlers)
+    await user.click(screen.getByRole('button', { name: /Reintentar/i }))
+    await waitFor(() => {
+      expect(screen.queryByText(/No se pudieron cargar los datos/i)).not.toBeInTheDocument()
+    })
+  })
+
+  it('retries only the conciliations query when it is the only failing one', async () => {
+    const user = userEvent.setup()
+    server.use(http.get('/api/conciliation', () => HttpResponse.json({}, { status: 500 })))
+    renderWithProviders(<Dashboard />)
+    expect(await screen.findByText(/No se pudieron cargar los datos/i)).toBeInTheDocument()
+    server.use(...conciliationHandlers)
+    await user.click(screen.getByRole('button', { name: /Reintentar/i }))
+    await waitFor(() => {
+      expect(screen.queryByText(/No se pudieron cargar los datos/i)).not.toBeInTheDocument()
+    })
   })
 })

--- a/client/src/features/dashboard/pages/Dashboard.tsx
+++ b/client/src/features/dashboard/pages/Dashboard.tsx
@@ -1,3 +1,4 @@
+import { QueryError } from '@/shared/ui/QueryError'
 import { useQueries } from '@tanstack/react-query'
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card'
 import { Building2, GitMerge, CheckCircle, AlertCircle, Bell, LineChart as LineChartIcon } from 'lucide-react'
@@ -131,6 +132,12 @@ export function Dashboard() {
 
   const allMovements = movementResults.flatMap(r => r.data ?? [])
 
+  const isError = accountsQuery.isError || conciliationsQuery.isError
+  const retryFailed = () => {
+    if (accountsQuery.isError) void accountsQuery.refetch()
+    if (conciliationsQuery.isError) void conciliationsQuery.refetch()
+  }
+
   // Reconcile stats
   const reconciledToday = conciliations.filter(
     r => r.status === 'matched' && new Date(r.createdAt).toLocaleDateString('sv') === today
@@ -146,6 +153,18 @@ export function Dashboard() {
   const { data: movementChart, groupedByMonth: movementGrouped } = buildTimeSeriesData(
     allMovements.map(m => m.receivedAt)
   )
+
+  if (isError) {
+    return (
+      <div className="p-8 space-y-8">
+        <div>
+          <h2 className="text-2xl font-semibold">{t('dashboard.title')}</h2>
+          <p className="text-muted-foreground">{t('dashboard.subtitle')}</p>
+        </div>
+        <QueryError onRetry={retryFailed} />
+      </div>
+    )
+  }
 
   return (
     <div className="p-8 space-y-8">

--- a/client/src/features/script-engine/hooks/useScripts.ts
+++ b/client/src/features/script-engine/hooks/useScripts.ts
@@ -1,3 +1,6 @@
+import { toast } from 'sonner'
+import { localizedApiError } from '@/shared/http/client'
+import i18n from '@/shared/i18n'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { listScripts, promoteScript } from '../api/scripts'
 
@@ -12,5 +15,6 @@ export function usePromoteScript() {
   return useMutation({
     mutationFn: promoteScript,
     onSuccess: () => qc.invalidateQueries({ queryKey: scriptsQueryKey }),
+    onError: (err) => toast.error(localizedApiError(err) ?? i18n.t('script-engine:scripts.promoteError')),
   })
 }

--- a/client/src/features/script-engine/i18n/en.json
+++ b/client/src/features/script-engine/i18n/en.json
@@ -14,6 +14,7 @@
     "colOrigin": "Origin",
     "colStatus": "Status",
     "colActions": "Actions",
-    "promote": "Promote"
+    "promote": "Promote",
+    "promoteError": "Could not promote the script"
   }
 }

--- a/client/src/features/script-engine/i18n/es.json
+++ b/client/src/features/script-engine/i18n/es.json
@@ -14,6 +14,7 @@
     "colOrigin": "Origen",
     "colStatus": "Estado",
     "colActions": "Acciones",
-    "promote": "Promover"
+    "promote": "Promover",
+    "promoteError": "No se pudo promover el script"
   }
 }

--- a/client/src/features/script-engine/pages/Scripts.test.tsx
+++ b/client/src/features/script-engine/pages/Scripts.test.tsx
@@ -155,4 +155,73 @@ describe('Scripts page', () => {
       expect(screen.getByText('unknown-code')).toBeInTheDocument()
     })
   })
+
+  it('shows the query error state with a retry button when the list fails', async () => {
+    const user = userEvent.setup()
+    server.use(http.get('/api/scripts', () => HttpResponse.json({}, { status: 500 })))
+    renderWithProviders(<Scripts />)
+    expect(await screen.findByText(/No se pudieron cargar los datos/i)).toBeInTheDocument()
+    // Fix the endpoint and retry.
+    server.use(...scriptEngineHandlers)
+    await user.click(screen.getByRole('button', { name: /Reintentar/i }))
+    await waitFor(() => expect(screen.getByText('2.0.1')).toBeInTheDocument())
+  })
+
+  it('toasts the server message when promoting fails', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('/api/scripts', () =>
+        HttpResponse.json([
+          {
+            id: 's-9',
+            bank: 'mi-dinero',
+            flowType: 'extract_transactions',
+            version: '3.0.0',
+            status: 'review',
+            origin: 'system',
+            createdAt: '2026-05-17T10:00:00Z',
+          },
+        ])
+      ),
+      http.post('/api/scripts/s-9/promote', () =>
+        HttpResponse.json({ error: 'sandbox caído' }, { status: 500 })
+      )
+    )
+    renderWithProviders(<Scripts />)
+    await waitFor(() => expect(screen.getByRole('tab', { name: 'Todos' })).toBeInTheDocument())
+    await user.click(screen.getByRole('tab', { name: 'Todos' }))
+    await waitFor(() => expect(screen.getByText('3.0.0')).toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: /Promover/i }))
+    expect(await screen.findAllByText('sandbox caído')).not.toHaveLength(0)
+  })
+
+  it('toasts the fallback messages when promoting fails without a message', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('/api/scripts', () =>
+        HttpResponse.json([
+          {
+            id: 's-9',
+            bank: 'mi-dinero',
+            flowType: 'extract_transactions',
+            version: '3.0.0',
+            status: 'review',
+            origin: 'system',
+            createdAt: '2026-05-17T10:00:00Z',
+          },
+        ])
+      ),
+      http.post('/api/scripts/s-9/promote', () => HttpResponse.json({}, { status: 500 }))
+    )
+    renderWithProviders(<Scripts />)
+    await waitFor(() => expect(screen.getByRole('tab', { name: 'Todos' })).toBeInTheDocument())
+    await user.click(screen.getByRole('tab', { name: 'Todos' }))
+    await waitFor(() => expect(screen.getByText('3.0.0')).toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: /Promover/i }))
+    // Hook-level and button-level handlers each toast their own fallback copy.
+    expect(await screen.findByText(/No se pudo promover el script/i)).toBeInTheDocument()
+    expect(await screen.findByText(/Algo salió mal/i)).toBeInTheDocument()
+  })
 })

--- a/client/src/features/script-engine/pages/Scripts.tsx
+++ b/client/src/features/script-engine/pages/Scripts.tsx
@@ -1,3 +1,4 @@
+import { QueryError } from '@/shared/ui/QueryError'
 import { Badge } from '@/shared/ui/badge'
 import { Button } from '@/shared/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card'
@@ -6,6 +7,8 @@ import { Tabs, TabsList, TabsTrigger } from '@/shared/ui/tabs'
 import { CheckCircle } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { localizedApiError } from '@/shared/http/client'
 import { useScripts, usePromoteScript } from '../hooks/useScripts'
 import { useBanks } from '@/features/account/hooks/useBanks'
 import type { ScriptStatus } from '../types'
@@ -23,7 +26,7 @@ type ScriptTab = 'active' | 'all'
 
 export function Scripts() {
   const { t } = useTranslation(['script-engine', 'common'])
-  const { data: scripts = [], isLoading } = useScripts()
+  const { data: scripts = [], isLoading, isError, refetch } = useScripts()
   const { data: banks = [] } = useBanks()
   const promote = usePromoteScript()
   const [tab, setTab] = useState<ScriptTab>('active')
@@ -58,6 +61,8 @@ export function Scripts() {
           <CardContent>
             {isLoading ? (
               <p className="text-muted-foreground text-sm">{t('scripts.loading')}</p>
+            ) : isError ? (
+              <QueryError onRetry={() => refetch()} />
             ) : (
               <Table>
                 <TableHeader>
@@ -82,7 +87,9 @@ export function Scripts() {
                       </TableCell>
                       <TableCell>
                         {s.status === 'review' && (
-                          <Button size="sm" variant="outline" onClick={() => promote.mutate(s.id)}>
+                          <Button size="sm" variant="outline" onClick={() => promote.mutate(s.id, {
+                            onError: err => toast.error(localizedApiError(err) ?? t('common:errors.generic')),
+                          })}>
                             <CheckCircle className="size-3 mr-1" />
                             {t('scripts.promote')}
                           </Button>

--- a/client/src/features/user/components/SettingsDialog.test.tsx
+++ b/client/src/features/user/components/SettingsDialog.test.tsx
@@ -235,9 +235,7 @@ describe('SettingsDialog', () => {
       await screen.findByRole('button', { name: /Sí, cambiar y borrar datos/i })
     )
     await waitFor(() => {
-      expect(
-        screen.getByText(/No se pudo actualizar el modo de operación/i)
-      ).toBeInTheDocument()
+      expect(screen.getByText(/boom/i)).toBeInTheDocument()
     })
   })
 

--- a/client/src/features/user/components/SettingsDialog.test.tsx
+++ b/client/src/features/user/components/SettingsDialog.test.tsx
@@ -239,6 +239,30 @@ describe('SettingsDialog', () => {
     })
   })
 
+  it('falls back to the localized save error when the failure has no message', async () => {
+    server.use(meHandler({ operationMode: 'passthrough' }))
+    server.use(
+      http.put('/api/me/operation-mode', () => HttpResponse.json({}, { status: 500 }))
+    )
+    const user = userEvent.setup()
+    renderWithProviders(<Host />)
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('user@x')).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('tab', { name: /Operación/i }))
+    await user.click(screen.getByRole('button', { name: /Cambiar modo/i }))
+    await user.click(
+      await screen.findByRole('button', { name: /Conciliación/i })
+    )
+    await user.click(screen.getByRole('button', { name: /^Guardar$/i }))
+    await user.click(
+      await screen.findByRole('button', { name: /Sí, cambiar y borrar datos/i })
+    )
+    await waitFor(() => {
+      expect(screen.getByText(/No se pudo actualizar el modo de operación/i)).toBeInTheDocument()
+    })
+  })
+
   it('clicking outside closes the dialog and resets internal state', async () => {
     server.use(meHandler({ operationMode: 'passthrough' }))
     const onOpenChange = vi.fn()

--- a/client/src/features/user/components/SettingsDialog.tsx
+++ b/client/src/features/user/components/SettingsDialog.tsx
@@ -1,3 +1,4 @@
+import { localizedApiError } from '@/shared/http/client'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -35,7 +36,7 @@ export function SettingsDialog({ open, onOpenChange }: { open: boolean; onOpenCh
   const [confirmOpen, setConfirmOpen] = useState(false)
 
   function handleOpenChange(o: boolean) {
-    /* v8 ignore next 4 -- dialog has no internal trigger so it only emits onOpenChange(false); the truthy branch is defensive. */
+    /* v8 ignore next 4 -- dialog has no internal trigger so the truthy branch is defensive */
     if (!o) {
       setExpanded(false)
       setSelected(null)
@@ -58,7 +59,7 @@ export function SettingsDialog({ open, onOpenChange }: { open: boolean; onOpenCh
   }
 
   function confirmChange() {
-    /* v8 ignore next 1 -- confirmChange only fires from the Save button which requires canSave (selected != null). */
+    /* v8 ignore next 1 -- only fires from the Save button which requires `selected != null` */
     if (!selected) return
     setMode.mutate(selected, {
       onSuccess: () => {
@@ -67,8 +68,8 @@ export function SettingsDialog({ open, onOpenChange }: { open: boolean; onOpenCh
         setSelected(null)
         toast.success(t('settings.mode.saved'))
       },
-      onError: () => {
-        toast.error(t('settings.mode.saveError'))
+      onError: (err) => {
+        toast.error(localizedApiError(err) ?? t('settings.mode.saveError'))
       },
     })
   }
@@ -92,7 +93,7 @@ export function SettingsDialog({ open, onOpenChange }: { open: boolean; onOpenCh
     MODE_OPTIONS.find(o => o.mode === currentMode) ?? MODE_OPTIONS[0]
   const backOption = MODE_OPTIONS.find(o => o.mode !== activeOption.mode)!
 
-  /* v8 ignore next -- isPending guard blocks dismiss during the in-flight save; the truthy branch is defensive. */
+  /* v8 ignore next -- isPending guard blocks dismiss during the in-flight save */
   const onConfirmOpenChange = (o: boolean) => { if (!setMode.isPending) setConfirmOpen(o) }
 
   return (
@@ -274,7 +275,7 @@ export function SettingsDialog({ open, onOpenChange }: { open: boolean; onOpenCh
                         </Button>
                       </div>
 
-                      {/* Stacked cards: SWAP — active (front) slides DOWN while back rises to take its exact spot */}
+                      {/* Stacked card swap where the active card slides down while the back card takes its exact spot */}
                       <div
                         className="relative transition-[height] duration-[500ms] ease-[cubic-bezier(0.22,1,0.36,1)]"
                         style={{
@@ -283,7 +284,7 @@ export function SettingsDialog({ open, onOpenChange }: { open: boolean; onOpenCh
                             : `${cardHeight + 8}px`,
                         }}
                       >
-                        {/* Back card: peek (top:0, scaled) → slides DOWN to active's old slot (top:8) */}
+                        {/* Back card peeks scaled at the top then slides down into the active card's old slot */}
                         <div
                           className="absolute inset-x-0 z-10 origin-top transition-[top,transform,opacity] duration-[500ms] ease-[cubic-bezier(0.22,1,0.36,1)]"
                           style={{
@@ -305,7 +306,7 @@ export function SettingsDialog({ open, onOpenChange }: { open: boolean; onOpenCh
                           />
                         </div>
 
-                        {/* Active card: visible slot (top:8) → slides DOWN below the back */}
+                        {/* Active card slides down below the back card */}
                         <div
                           ref={activeCardRef}
                           className="absolute inset-x-0 z-20 transition-[top] duration-[500ms] ease-[cubic-bezier(0.22,1,0.36,1)]"
@@ -327,7 +328,7 @@ export function SettingsDialog({ open, onOpenChange }: { open: boolean; onOpenCh
                         </div>
                       </div>
 
-                      {/* Inline destructive warning + Save — fade in together when an alternate mode is selected */}
+                      {/* Destructive warning and Save fade in together when an alternate mode is selected */}
                       <div
                         className={cn(
                           'space-y-3 pt-1 transition-opacity duration-300 ease-out',

--- a/client/src/features/user/components/TwoFactorSection.tsx
+++ b/client/src/features/user/components/TwoFactorSection.tsx
@@ -1,3 +1,4 @@
+import { localizedApiError } from '@/shared/http/client'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
@@ -36,7 +37,7 @@ export function TwoFactorSection({ enabled }: { enabled: boolean }) {
       setOtpauthUri(otpauthUri)
       setStage('enrolling')
     },
-    onError: () => toast.error(t('settings.security.enrollError')),
+    onError: (err) => toast.error(localizedApiError(err) ?? t('settings.security.enrollError')),
   })
 
   const confirm = useMutation({
@@ -47,7 +48,7 @@ export function TwoFactorSection({ enabled }: { enabled: boolean }) {
       setStage('backup')
       qc.invalidateQueries({ queryKey: meQueryKey })
     },
-    onError: () => toast.error(t('settings.security.codeError')),
+    onError: (err) => toast.error(localizedApiError(err) ?? t('settings.security.codeError')),
   })
 
   const disable = useMutation({
@@ -57,7 +58,7 @@ export function TwoFactorSection({ enabled }: { enabled: boolean }) {
       reset()
       qc.invalidateQueries({ queryKey: meQueryKey })
     },
-    onError: () => toast.error(t('settings.security.codeError')),
+    onError: (err) => toast.error(localizedApiError(err) ?? t('settings.security.codeError')),
   })
 
   // Already enabled: show status + disable flow.

--- a/client/src/features/user/hooks/useSetOperationMode.ts
+++ b/client/src/features/user/hooks/useSetOperationMode.ts
@@ -8,6 +8,7 @@ export function useSetOperationMode() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: setOperationMode,
+    meta: { errorHandled: true },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: meQueryKey })
       qc.invalidateQueries({ queryKey: accountsQueryKey })

--- a/client/src/features/user/i18n/en.json
+++ b/client/src/features/user/i18n/en.json
@@ -29,6 +29,16 @@
     "hasAccount": "Already have an account?",
     "login": "Sign in"
   },
+  "passwordRules": {
+    "minLength": "Password must be at least 12 characters",
+    "maxLength": "Password must be at most 32 characters",
+    "lowercase": "Password must contain a lowercase letter",
+    "uppercase": "Password must contain an uppercase letter",
+    "number": "Password must contain a number"
+  },
+  "errors": {
+    "emailInvalid": "Enter a valid email address"
+  },
   "settings": {
     "title": "Settings",
     "subtitle": "Manage your profile and operation mode",

--- a/client/src/features/user/i18n/es.json
+++ b/client/src/features/user/i18n/es.json
@@ -29,6 +29,16 @@
     "hasAccount": "¿Ya tenés cuenta?",
     "login": "Ingresar"
   },
+  "passwordRules": {
+    "minLength": "La contraseña debe tener al menos 12 caracteres",
+    "maxLength": "La contraseña debe tener como máximo 32 caracteres",
+    "lowercase": "La contraseña debe incluir una letra minúscula",
+    "uppercase": "La contraseña debe incluir una letra mayúscula",
+    "number": "La contraseña debe incluir un número"
+  },
+  "errors": {
+    "emailInvalid": "Ingresá un email válido"
+  },
   "settings": {
     "title": "Configuración",
     "subtitle": "Gestioná tu perfil y el modo de operación",

--- a/client/src/features/user/pages/Login.test.tsx
+++ b/client/src/features/user/pages/Login.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Routes, Route } from 'react-router-dom'
 import { server } from '../../../../tests/msw/server'
@@ -30,7 +30,7 @@ describe('Login page', () => {
   it('navigates to "/" on successful login', async () => {
     const user = userEvent.setup()
     renderLogin()
-    await user.type(screen.getByLabelText(/Email/i), 'ok@x')
+    await user.type(screen.getByLabelText(/Email/i), 'ok@x.com')
     await user.type(screen.getByLabelText(/Contraseña/i), 'good')
     await user.click(screen.getByRole('button', { name: /Ingresar/i }))
     await waitFor(() => {
@@ -41,7 +41,7 @@ describe('Login page', () => {
   it('shows an error message when credentials are rejected', async () => {
     const user = userEvent.setup()
     renderLogin()
-    await user.type(screen.getByLabelText(/Email/i), 'fail@x')
+    await user.type(screen.getByLabelText(/Email/i), 'fail@x.com')
     await user.type(screen.getByLabelText(/Contraseña/i), 'wrong')
     await user.click(screen.getByRole('button', { name: /Ingresar/i }))
     await waitFor(() => {
@@ -51,10 +51,34 @@ describe('Login page', () => {
     })
   })
 
+  it('shows per-field required errors when submitting empty', async () => {
+    const user = userEvent.setup()
+    renderLogin()
+    await user.click(screen.getByRole('button', { name: /Ingresar/i }))
+    const messages = await screen.findAllByText(/Completá este campo/i)
+    expect(messages).toHaveLength(2)
+    expect(screen.getByLabelText(/Email/i)).toHaveAttribute('aria-invalid', 'true')
+    expect(screen.getByLabelText(/Contraseña/i)).toHaveAttribute('aria-invalid', 'true')
+  })
+
+  it('shows an email format error and clears it live once fixed', async () => {
+    const user = userEvent.setup()
+    renderLogin()
+    await user.type(screen.getByLabelText(/Email/i), 'not-an-email')
+    await user.type(screen.getByLabelText(/Contraseña/i), 'good')
+    await user.click(screen.getByRole('button', { name: /Ingresar/i }))
+    expect(await screen.findByText(/Ingresá un email válido/i)).toBeInTheDocument()
+    await user.clear(screen.getByLabelText(/Email/i))
+    await user.type(screen.getByLabelText(/Email/i), 'ok@x.com')
+    await waitFor(() => {
+      expect(screen.queryByText(/Ingresá un email válido/i)).not.toBeInTheDocument()
+    })
+  })
+
   it('shows the TOTP step for a 2FA user and logs in with a valid code', async () => {
     const user = userEvent.setup()
     renderLogin()
-    await user.type(screen.getByLabelText(/Email/i), '2fa@x')
+    await user.type(screen.getByLabelText(/Email/i), '2fa@x.com')
     await user.type(screen.getByLabelText(/Contraseña/i), 'good')
     await user.click(screen.getByRole('button', { name: /Ingresar/i }))
 
@@ -68,7 +92,7 @@ describe('Login page', () => {
   it('shows an error on an invalid TOTP code and lets the user go back', async () => {
     const user = userEvent.setup()
     renderLogin()
-    await user.type(screen.getByLabelText(/Email/i), '2fa@x')
+    await user.type(screen.getByLabelText(/Email/i), '2fa@x.com')
     await user.type(screen.getByLabelText(/Contraseña/i), 'good')
     await user.click(screen.getByRole('button', { name: /Ingresar/i }))
 
@@ -85,34 +109,5 @@ describe('Login page', () => {
     renderLogin()
     const link = screen.getByRole('link', { name: /Registrarse/i })
     expect(link).toHaveAttribute('href', '/register')
-  })
-
-  it('wires onInvalid + onInput custom-validity handlers on both fields', () => {
-    renderLogin()
-    const email = screen.getByLabelText(/Email/i) as HTMLInputElement
-    const password = screen.getByLabelText(/Contraseña/i) as HTMLInputElement
-    // Empty + required → fires onInvalid which sets a custom message via t().
-    fireEvent.invalid(email)
-    expect(email.validationMessage).not.toBe('')
-    fireEvent.input(email, { target: { value: 'a@b' } })
-    fireEvent.invalid(password)
-    expect(password.validationMessage).not.toBe('')
-    fireEvent.input(password, { target: { value: 'abc' } })
-  })
-
-  it('does not set a custom message when the invalid reason is not valueMissing', () => {
-    renderLogin()
-    const email = screen.getByLabelText(/Email/i) as HTMLInputElement
-    const password = screen.getByLabelText(/Contraseña/i) as HTMLInputElement
-    // Type a value so valueMissing is false but typeMismatch could still
-    // fire onInvalid via fireEvent (jsdom does not actually validate, but the
-    // handler still checks `valueMissing` which is false here).
-    fireEvent.input(email, { target: { value: 'not-an-email' } })
-    fireEvent.invalid(email)
-    fireEvent.input(password, { target: { value: 'pw' } })
-    fireEvent.invalid(password)
-    // No assertion needed — the goal is to exercise the false branch of the
-    // `if (valueMissing)` guard inside the onInvalid handlers.
-    expect(true).toBe(true)
   })
 })

--- a/client/src/features/user/pages/Login.test.tsx
+++ b/client/src/features/user/pages/Login.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Routes, Route } from 'react-router-dom'
+import { http, HttpResponse } from 'msw'
 import { server } from '../../../../tests/msw/server'
 import { userHandlers } from '../../../../tests/msw/handlers/user'
 import { renderWithProviders } from '../../../../tests/utils/render'
@@ -103,6 +104,102 @@ describe('Login page', () => {
     // back returns to the credentials step
     await user.click(screen.getByRole('button', { name: /Volver/i }))
     await waitFor(() => expect(screen.getByLabelText(/Email/i)).toBeInTheDocument())
+  })
+
+  it('maps a server validation error on email to the email field', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.post('/api/auth/login', () =>
+        HttpResponse.json(
+          {
+            error: {
+              code: 'VALIDATION_ERROR',
+              details: { issues: [{ path: ['email'], message: 'bad email' }] },
+            },
+          },
+          { status: 400 }
+        )
+      )
+    )
+    renderLogin()
+    await user.type(screen.getByLabelText(/Email/i), 'ok@x.com')
+    await user.type(screen.getByLabelText(/Contraseña/i), 'good')
+    await user.click(screen.getByRole('button', { name: /Ingresar/i }))
+    expect(await screen.findByText(/Ingresá un email válido/i)).toBeInTheDocument()
+  })
+
+  it('maps a server validation error on password to the password field', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.post('/api/auth/login', () =>
+        HttpResponse.json(
+          {
+            error: {
+              code: 'VALIDATION_ERROR',
+              details: { issues: [{ path: ['password'], message: 'bad password' }] },
+            },
+          },
+          { status: 400 }
+        )
+      )
+    )
+    renderLogin()
+    await user.type(screen.getByLabelText(/Email/i), 'ok@x.com')
+    await user.type(screen.getByLabelText(/Contraseña/i), 'good')
+    await user.click(screen.getByRole('button', { name: /Ingresar/i }))
+    expect(await screen.findByText(/Completá este campo/i)).toBeInTheDocument()
+  })
+
+  it('shows the server-provided message for unexpected non-auth failures', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.post('/api/auth/login', () =>
+        HttpResponse.json({ error: 'el servidor explotó' }, { status: 500 })
+      )
+    )
+    renderLogin()
+    await user.type(screen.getByLabelText(/Email/i), 'ok@x.com')
+    await user.type(screen.getByLabelText(/Contraseña/i), 'good')
+    await user.click(screen.getByRole('button', { name: /Ingresar/i }))
+    expect(await screen.findByText(/el servidor explotó/i)).toBeInTheDocument()
+  })
+
+  it('falls back to the generic login error when a failure has no message', async () => {
+    const user = userEvent.setup()
+    server.use(http.post('/api/auth/login', () => HttpResponse.json({}, { status: 500 })))
+    renderLogin()
+    await user.type(screen.getByLabelText(/Email/i), 'ok@x.com')
+    await user.type(screen.getByLabelText(/Contraseña/i), 'good')
+    await user.click(screen.getByRole('button', { name: /Ingresar/i }))
+    expect(await screen.findByText(/Email o contraseña incorrectos/i)).toBeInTheDocument()
+  })
+
+  it('shows the server message when TOTP verification fails with a non-auth error', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.post('/api/auth/login/totp', () =>
+        HttpResponse.json({ error: 'totp roto en el servidor' }, { status: 500 })
+      )
+    )
+    renderLogin()
+    await user.type(screen.getByLabelText(/Email/i), '2fa@x.com')
+    await user.type(screen.getByLabelText(/Contraseña/i), 'good')
+    await user.click(screen.getByRole('button', { name: /Ingresar/i }))
+    await user.type(await screen.findByLabelText(/Código de autenticación/i), '123456')
+    await user.click(screen.getByRole('button', { name: /Verificar/i }))
+    expect(await screen.findByText(/totp roto en el servidor/i)).toBeInTheDocument()
+  })
+
+  it('falls back to the TOTP error copy when a non-auth failure has no message', async () => {
+    const user = userEvent.setup()
+    server.use(http.post('/api/auth/login/totp', () => HttpResponse.json({}, { status: 500 })))
+    renderLogin()
+    await user.type(screen.getByLabelText(/Email/i), '2fa@x.com')
+    await user.type(screen.getByLabelText(/Contraseña/i), 'good')
+    await user.click(screen.getByRole('button', { name: /Ingresar/i }))
+    await user.type(await screen.findByLabelText(/Código de autenticación/i), '123456')
+    await user.click(screen.getByRole('button', { name: /Verificar/i }))
+    expect(await screen.findByText(/Código inválido/i)).toBeInTheDocument()
   })
 
   it('has a link to the register page', async () => {

--- a/client/src/features/user/pages/Login.tsx
+++ b/client/src/features/user/pages/Login.tsx
@@ -4,8 +4,20 @@ import { useAuth } from '../hooks/useAuth'
 import { Button } from '@/shared/ui/button'
 import { Input } from '@/shared/ui/input'
 import { Label } from '@/shared/ui/label'
+import { FormField } from '@/shared/ui/FormField'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card'
 import { useTranslation } from 'react-i18next'
+import { localizedApiError } from '@/shared/http/client'
+import { fieldErrorsFromApiError } from '../utils/serverFieldErrors'
+
+// 401 keeps the friendly translated copy while other failures such as 429 surface the server message
+function isAuthRejection(err: unknown): boolean {
+  return (err as { response?: { status?: number } })?.response?.status === 401
+}
+
+const emailPattern = /^\S+@\S+\.\S+$/
+
+type LoginErrors = { email?: string; password?: string; form?: string }
 
 export function Login() {
   const { login, completeTotpLogin } = useAuth()
@@ -13,15 +25,36 @@ export function Login() {
   const { t } = useTranslation(['user', 'common'])
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
-  const [error, setError] = useState('')
+  const [errors, setErrors] = useState<LoginErrors>({})
+  const [submitted, setSubmitted] = useState(false)
   const [loading, setLoading] = useState(false)
   const [stage, setStage] = useState<'credentials' | 'totp'>('credentials')
   const [challengeToken, setChallengeToken] = useState('')
   const [code, setCode] = useState('')
 
+  function validate(values: { email: string; password: string }): LoginErrors {
+    const next: LoginErrors = {}
+    if (!values.email.trim()) next.email = t('common:validation.required')
+    else if (!emailPattern.test(values.email)) next.email = t('errors.emailInvalid')
+    if (!values.password) next.password = t('common:validation.required')
+    return next
+  }
+
+  function updateField(field: 'email' | 'password', value: string) {
+    const setter = field === 'email' ? setEmail : setPassword
+    setter(value)
+    if (submitted) {
+      const next = validate({ email, password, [field]: value })
+      setErrors(next)
+    }
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
-    setError('')
+    setSubmitted(true)
+    const next = validate({ email, password })
+    setErrors(next)
+    if (next.email || next.password) return
     setLoading(true)
     try {
       const outcome = await login(email, password)
@@ -31,8 +64,20 @@ export function Login() {
         return
       }
       navigate('/')
-    } catch {
-      setError(t('login.error'))
+    } catch (err) {
+      if (isAuthRejection(err)) {
+        setErrors({ form: t('login.error') })
+        return
+      }
+      const fieldErrors = fieldErrorsFromApiError(err)
+      if (fieldErrors.email || fieldErrors.password) {
+        setErrors({
+          email: fieldErrors.email && t('errors.emailInvalid'),
+          password: fieldErrors.password && t('common:validation.required'),
+        })
+        return
+      }
+      setErrors({ form: localizedApiError(err) ?? t('login.error') })
     } finally {
       setLoading(false)
     }
@@ -40,13 +85,13 @@ export function Login() {
 
   async function handleTotpSubmit(e: React.FormEvent) {
     e.preventDefault()
-    setError('')
+    setErrors({})
     setLoading(true)
     try {
       await completeTotpLogin(challengeToken, code)
       navigate('/')
-    } catch {
-      setError(t('login.totp.error'))
+    } catch (err) {
+      setErrors({ form: isAuthRejection(err) ? t('login.totp.error') : localizedApiError(err) ?? t('login.totp.error') })
     } finally {
       setLoading(false)
     }
@@ -61,7 +106,8 @@ export function Login() {
             <CardDescription>{t('login.totp.subtitle')}</CardDescription>
           </CardHeader>
           <CardContent>
-            <form onSubmit={handleTotpSubmit} className="space-y-4">
+            {/* key prevents React from reusing these DOM nodes for the credentials form where the browser would run the click default action on a node already turned into a submit button */}
+            <form key="totp" onSubmit={handleTotpSubmit} className="space-y-4">
               <div className="space-y-2">
                 <Label htmlFor="totp-code">{t('login.totp.code')}</Label>
                 <Input
@@ -74,7 +120,7 @@ export function Login() {
                   required
                 />
               </div>
-              {error && <p className="text-sm text-destructive">{error}</p>}
+              {errors.form && <p className="text-sm text-destructive" role="alert">{errors.form}</p>}
               <Button type="submit" className="w-full" disabled={loading}>
                 {loading ? t('login.loading') : t('login.totp.submit')}
               </Button>
@@ -82,7 +128,7 @@ export function Login() {
                 type="button"
                 variant="ghost"
                 className="w-full"
-                onClick={() => { setStage('credentials'); setCode(''); setError('') }}
+                onClick={() => { setStage('credentials'); setCode(''); setErrors({}) }}
               >
                 {t('login.totp.back')}
               </Button>
@@ -101,40 +147,30 @@ export function Login() {
           <CardDescription>{t('login.subtitle')}</CardDescription>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="email">{t('login.email')}</Label>
+          <form key="credentials" onSubmit={handleSubmit} noValidate className="space-y-4">
+            <FormField label={t('login.email')} htmlFor="email" helpId="email-error" error={errors.email}>
               <Input
                 id="email"
                 type="email"
+                autoComplete="email"
                 value={email}
-                onChange={e => setEmail(e.target.value)}
-                required
-                onInvalid={e => {
-                  if (e.currentTarget.validity.valueMissing) {
-                    e.currentTarget.setCustomValidity(t('common:validation.required'))
-                  }
-                }}
-                onInput={e => e.currentTarget.setCustomValidity('')}
+                onChange={e => updateField('email', e.target.value)}
+                aria-invalid={errors.email ? true : undefined}
+                aria-describedby="email-error"
               />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="password">{t('login.password')}</Label>
+            </FormField>
+            <FormField label={t('login.password')} htmlFor="password" helpId="password-error" error={errors.password}>
               <Input
                 id="password"
                 type="password"
+                autoComplete="current-password"
                 value={password}
-                onChange={e => setPassword(e.target.value)}
-                required
-                onInvalid={e => {
-                  if (e.currentTarget.validity.valueMissing) {
-                    e.currentTarget.setCustomValidity(t('common:validation.required'))
-                  }
-                }}
-                onInput={e => e.currentTarget.setCustomValidity('')}
+                onChange={e => updateField('password', e.target.value)}
+                aria-invalid={errors.password ? true : undefined}
+                aria-describedby="password-error"
               />
-            </div>
-            {error && <p className="text-sm text-destructive">{error}</p>}
+            </FormField>
+            {errors.form && <p className="text-sm text-destructive" role="alert">{errors.form}</p>}
             <Button type="submit" className="w-full" disabled={loading}>
               {loading ? t('login.loading') : t('login.submit')}
             </Button>

--- a/client/src/features/user/pages/Register.test.tsx
+++ b/client/src/features/user/pages/Register.test.tsx
@@ -8,6 +8,8 @@ import { userHandlers } from '../../../../tests/msw/handlers/user'
 import { renderWithProviders } from '../../../../tests/utils/render'
 import { Register } from './Register'
 
+const VALID_PASSWORD = 'ValidPassword1'
+
 function renderRegister() {
   return renderWithProviders(
     <Routes>
@@ -26,8 +28,8 @@ describe('Register page', () => {
   it('navigates to /login on successful registration', async () => {
     const user = userEvent.setup()
     renderRegister()
-    await user.type(screen.getByLabelText(/Email/i), 'new@x')
-    await user.type(screen.getByLabelText(/Contraseña/i), 'pw')
+    await user.type(screen.getByLabelText(/Email/i), 'new@x.com')
+    await user.type(screen.getByLabelText(/Contraseña/i), VALID_PASSWORD)
     await user.click(screen.getByRole('button', { name: /^Registrar$/i }))
     await waitFor(() => {
       expect(screen.getByText('LOGIN_PAGE')).toBeInTheDocument()
@@ -39,25 +41,58 @@ describe('Register page', () => {
     server.use(
       http.post('/api/auth/register', async ({ request }) => {
         received = await request.json()
-        return HttpResponse.json({ id: 'x', email: 'x@x' })
+        return HttpResponse.json({ id: 'x', email: 'x@x.com' })
       })
     )
     const user = userEvent.setup()
     renderRegister()
     await user.type(screen.getByLabelText(/Nombre/i), 'Alice')
-    await user.type(screen.getByLabelText(/Email/i), 'x@x')
-    await user.type(screen.getByLabelText(/Contraseña/i), 'pw')
+    await user.type(screen.getByLabelText(/Email/i), 'x@x.com')
+    await user.type(screen.getByLabelText(/Contraseña/i), VALID_PASSWORD)
     await user.click(screen.getByRole('button', { name: /^Registrar$/i }))
     await waitFor(() => {
-      expect(received).toEqual({ email: 'x@x', password: 'pw', name: 'Alice' })
+      expect(received).toEqual({ email: 'x@x.com', password: VALID_PASSWORD, name: 'Alice' })
     })
+  })
+
+  it('shows password rules one at a time', async () => {
+    const user = userEvent.setup()
+    renderRegister()
+    const password = screen.getByLabelText(/Contraseña/i)
+    await user.type(screen.getByLabelText(/Email/i), 'x@x.com')
+    await user.type(password, 'corta')
+    await user.click(screen.getByRole('button', { name: /^Registrar$/i }))
+    // only the first failing rule is shown
+    expect(await screen.findByText(/al menos 12 caracteres/i)).toBeInTheDocument()
+    expect(screen.queryByText(/mayúscula/i)).not.toBeInTheDocument()
+
+    // fixing the length reveals the next rule (uppercase)
+    await user.clear(password)
+    await user.type(password, 'minusculas123')
+    expect(await screen.findByText(/letra mayúscula/i)).toBeInTheDocument()
+    expect(screen.queryByText(/al menos 12 caracteres/i)).not.toBeInTheDocument()
+
+    // a valid password clears the error
+    await user.clear(password)
+    await user.type(password, VALID_PASSWORD)
+    await waitFor(() => {
+      expect(screen.queryByText(/contraseña debe/i)).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows per-field required errors when submitting empty', async () => {
+    const user = userEvent.setup()
+    renderRegister()
+    await user.click(screen.getByRole('button', { name: /^Registrar$/i }))
+    const messages = await screen.findAllByText(/Completá este campo/i)
+    expect(messages).toHaveLength(2)
   })
 
   it('shows the server-provided error message on conflict', async () => {
     const user = userEvent.setup()
     renderRegister()
-    await user.type(screen.getByLabelText(/Email/i), 'taken@x')
-    await user.type(screen.getByLabelText(/Contraseña/i), 'pw')
+    await user.type(screen.getByLabelText(/Email/i), 'taken@x.com')
+    await user.type(screen.getByLabelText(/Contraseña/i), VALID_PASSWORD)
     await user.click(screen.getByRole('button', { name: /^Registrar$/i }))
     await waitFor(() => {
       expect(screen.getByText('Email already in use')).toBeInTheDocument()
@@ -72,8 +107,8 @@ describe('Register page', () => {
     )
     const user = userEvent.setup()
     renderRegister()
-    await user.type(screen.getByLabelText(/Email/i), 'x@x')
-    await user.type(screen.getByLabelText(/Contraseña/i), 'pw')
+    await user.type(screen.getByLabelText(/Email/i), 'x@x.com')
+    await user.type(screen.getByLabelText(/Contraseña/i), VALID_PASSWORD)
     await user.click(screen.getByRole('button', { name: /^Registrar$/i }))
     // server response error message "boom" propagated
     await waitFor(() => {
@@ -89,8 +124,8 @@ describe('Register page', () => {
     )
     const user = userEvent.setup()
     renderRegister()
-    await user.type(screen.getByLabelText(/Email/i), 'x@x')
-    await user.type(screen.getByLabelText(/Contraseña/i), 'pw')
+    await user.type(screen.getByLabelText(/Email/i), 'x@x.com')
+    await user.type(screen.getByLabelText(/Contraseña/i), VALID_PASSWORD)
     await user.click(screen.getByRole('button', { name: /^Registrar$/i }))
     await waitFor(() => {
       expect(

--- a/client/src/features/user/pages/Register.test.tsx
+++ b/client/src/features/user/pages/Register.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Routes, Route } from 'react-router-dom'
@@ -7,6 +7,22 @@ import { server } from '../../../../tests/msw/server'
 import { userHandlers } from '../../../../tests/msw/handlers/user'
 import { renderWithProviders } from '../../../../tests/utils/render'
 import { Register } from './Register'
+import { firstFailingPasswordRule } from '../utils/passwordRules'
+
+// Spy mode keeps the real implementation except where a test overrides it
+vi.mock('../utils/passwordRules', { spy: true })
+
+function passwordValidationError() {
+  return HttpResponse.json(
+    {
+      error: {
+        code: 'VALIDATION_ERROR',
+        details: { issues: [{ path: ['password'], message: 'server password message' }] },
+      },
+    },
+    { status: 400 }
+  )
+}
 
 const VALID_PASSWORD = 'ValidPassword1'
 
@@ -80,6 +96,15 @@ describe('Register page', () => {
     })
   })
 
+  it('shows an email format error when the email is malformed', async () => {
+    const user = userEvent.setup()
+    renderRegister()
+    await user.type(screen.getByLabelText(/Email/i), 'not-an-email')
+    await user.type(screen.getByLabelText(/Contraseña/i), VALID_PASSWORD)
+    await user.click(screen.getByRole('button', { name: /^Registrar$/i }))
+    expect(await screen.findByText(/Ingresá un email válido/i)).toBeInTheDocument()
+  })
+
   it('shows per-field required errors when submitting empty', async () => {
     const user = userEvent.setup()
     renderRegister()
@@ -132,6 +157,53 @@ describe('Register page', () => {
         screen.getByText(/Error al registrar el usuario/i)
       ).toBeInTheDocument()
     })
+  })
+
+  it('maps a server validation error on email to the email field', async () => {
+    server.use(
+      http.post('/api/auth/register', () =>
+        HttpResponse.json(
+          {
+            error: {
+              code: 'VALIDATION_ERROR',
+              details: { issues: [{ path: ['email'], message: 'bad email' }] },
+            },
+          },
+          { status: 400 }
+        )
+      )
+    )
+    const user = userEvent.setup()
+    renderRegister()
+    await user.type(screen.getByLabelText(/Email/i), 'x@x.com')
+    await user.type(screen.getByLabelText(/Contraseña/i), VALID_PASSWORD)
+    await user.click(screen.getByRole('button', { name: /^Registrar$/i }))
+    expect(await screen.findByText(/Ingresá un email válido/i)).toBeInTheDocument()
+  })
+
+  it('shows the server message for a password issue when local rules all pass', async () => {
+    server.use(http.post('/api/auth/register', () => passwordValidationError()))
+    const user = userEvent.setup()
+    renderRegister()
+    await user.type(screen.getByLabelText(/Email/i), 'x@x.com')
+    await user.type(screen.getByLabelText(/Contraseña/i), VALID_PASSWORD)
+    await user.click(screen.getByRole('button', { name: /^Registrar$/i }))
+    expect(await screen.findByText('server password message')).toBeInTheDocument()
+  })
+
+  it('shows the localized rule when the server rejects a password the mirror missed', async () => {
+    server.use(http.post('/api/auth/register', () => passwordValidationError()))
+    // Simulate the local mirror drifting behind the backend policy:
+    // it passes during client-side validation but fails when mapping the server error.
+    vi.mocked(firstFailingPasswordRule)
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce('minLength')
+    const user = userEvent.setup()
+    renderRegister()
+    await user.type(screen.getByLabelText(/Email/i), 'x@x.com')
+    await user.type(screen.getByLabelText(/Contraseña/i), VALID_PASSWORD)
+    await user.click(screen.getByRole('button', { name: /^Registrar$/i }))
+    expect(await screen.findByText(/al menos 12 caracteres/i)).toBeInTheDocument()
   })
 
   it('has a link back to login', () => {

--- a/client/src/features/user/pages/Register.tsx
+++ b/client/src/features/user/pages/Register.tsx
@@ -2,32 +2,71 @@ import { useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { toast } from 'sonner'
 import { register } from '../api/auth'
+import { localizedApiError } from '@/shared/http/client'
 import { Button } from '@/shared/ui/button'
 import { Input } from '@/shared/ui/input'
-import { Label } from '@/shared/ui/label'
+import { FormField } from '@/shared/ui/FormField'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card'
 import { useTranslation } from 'react-i18next'
+import { firstFailingPasswordRule } from '../utils/passwordRules'
+import { fieldErrorsFromApiError } from '../utils/serverFieldErrors'
+
+const emailPattern = /^\S+@\S+\.\S+$/
+
+type RegisterErrors = { email?: string; password?: string; form?: string }
 
 export function Register() {
   const navigate = useNavigate()
-  const { t } = useTranslation('user')
+  const { t } = useTranslation(['user', 'common'])
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
-  const [error, setError] = useState('')
+  const [errors, setErrors] = useState<RegisterErrors>({})
+  const [submitted, setSubmitted] = useState(false)
   const [loading, setLoading] = useState(false)
+
+  function validate(values: { email: string; password: string }): RegisterErrors {
+    const next: RegisterErrors = {}
+    if (!values.email.trim()) next.email = t('common:validation.required')
+    else if (!emailPattern.test(values.email)) next.email = t('errors.emailInvalid')
+    if (!values.password) {
+      next.password = t('common:validation.required')
+    } else {
+      // One rule at a time: only the first failing rule is shown; fixing it reveals the next
+      const rule = firstFailingPasswordRule(values.password)
+      if (rule) next.password = t(`passwordRules.${rule}`)
+    }
+    return next
+  }
+
+  function updateField(field: 'email' | 'password', value: string) {
+    const setter = field === 'email' ? setEmail : setPassword
+    setter(value)
+    if (submitted) setErrors(validate({ email, password, [field]: value }))
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
-    setError('')
+    setSubmitted(true)
+    const next = validate({ email, password })
+    setErrors(next)
+    if (next.email || next.password) return
     setLoading(true)
     try {
       await register({ email, password, name: name || undefined })
       toast.success(t('register.success'))
       navigate('/login')
     } catch (err: unknown) {
-      const message = (err as { response?: { data?: { error?: string } } })?.response?.data?.error
-      setError(message ?? t('register.defaultError'))
+      const fieldErrors = fieldErrorsFromApiError(err)
+      if (fieldErrors.email || fieldErrors.password) {
+        const passwordRule = fieldErrors.password ? firstFailingPasswordRule(password) : null
+        setErrors({
+          email: fieldErrors.email && t('errors.emailInvalid'),
+          password: passwordRule ? t(`passwordRules.${passwordRule}`) : fieldErrors.password,
+        })
+        return
+      }
+      setErrors({ form: localizedApiError(err) ?? t('register.defaultError') })
     } finally {
       setLoading(false)
     }
@@ -41,37 +80,39 @@ export function Register() {
           <CardDescription>{t('register.subtitle')}</CardDescription>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="name">{t('register.name')}</Label>
+          <form onSubmit={handleSubmit} noValidate className="space-y-4">
+            <FormField label={t('register.name')} htmlFor="name">
               <Input
                 id="name"
                 type="text"
+                autoComplete="name"
                 value={name}
                 onChange={e => setName(e.target.value)}
               />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="email">{t('register.email')}</Label>
+            </FormField>
+            <FormField label={t('register.email')} htmlFor="email" helpId="email-error" error={errors.email}>
               <Input
                 id="email"
                 type="email"
+                autoComplete="email"
                 value={email}
-                onChange={e => setEmail(e.target.value)}
-                required
+                onChange={e => updateField('email', e.target.value)}
+                aria-invalid={errors.email ? true : undefined}
+                aria-describedby="email-error"
               />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="password">{t('register.password')}</Label>
+            </FormField>
+            <FormField label={t('register.password')} htmlFor="password" helpId="password-error" error={errors.password}>
               <Input
                 id="password"
                 type="password"
+                autoComplete="new-password"
                 value={password}
-                onChange={e => setPassword(e.target.value)}
-                required
+                onChange={e => updateField('password', e.target.value)}
+                aria-invalid={errors.password ? true : undefined}
+                aria-describedby="password-error"
               />
-            </div>
-            {error && <p className="text-sm text-destructive">{error}</p>}
+            </FormField>
+            {errors.form && <p className="text-sm text-destructive" role="alert">{errors.form}</p>}
             <Button type="submit" className="w-full" disabled={loading}>
               {loading ? t('register.loading') : t('register.submit')}
             </Button>

--- a/client/src/features/user/utils/passwordRules.test.ts
+++ b/client/src/features/user/utils/passwordRules.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { firstFailingPasswordRule } from './passwordRules'
+
+describe('firstFailingPasswordRule', () => {
+  it('returns minLength for short passwords', () => {
+    expect(firstFailingPasswordRule('Short1')).toBe('minLength')
+  })
+
+  it('returns maxLength for passwords over 32 characters', () => {
+    expect(firstFailingPasswordRule('A1' + 'a'.repeat(32))).toBe('maxLength')
+  })
+
+  it('returns lowercase when no lowercase letter present', () => {
+    expect(firstFailingPasswordRule('UPPERCASE12345')).toBe('lowercase')
+  })
+
+  it('returns uppercase when no uppercase letter present', () => {
+    expect(firstFailingPasswordRule('lowercase12345')).toBe('uppercase')
+  })
+
+  it('returns number when no digit present', () => {
+    expect(firstFailingPasswordRule('NoNumbersHereAtAll')).toBe('number')
+  })
+
+  it('reports one rule at a time in order', () => {
+    expect(firstFailingPasswordRule('abc')).toBe('minLength')
+    expect(firstFailingPasswordRule('abcdefghijkl')).toBe('uppercase')
+    expect(firstFailingPasswordRule('Abcdefghijkl')).toBe('number')
+  })
+
+  it('returns null for a valid password', () => {
+    expect(firstFailingPasswordRule('ValidPassword1')).toBeNull()
+  })
+})

--- a/client/src/features/user/utils/passwordRules.ts
+++ b/client/src/features/user/utils/passwordRules.ts
@@ -1,0 +1,15 @@
+// Mirrors the backend password policy in src/api/routes/auth.routes.ts.
+// Ordered so the user is shown one failing rule at a time.
+export type PasswordRule = 'minLength' | 'maxLength' | 'lowercase' | 'uppercase' | 'number'
+
+const rules: Array<{ key: PasswordRule; test: (pw: string) => boolean }> = [
+  { key: 'minLength', test: pw => pw.length >= 12 },
+  { key: 'maxLength', test: pw => pw.length <= 32 },
+  { key: 'lowercase', test: pw => /[a-z]/.test(pw) },
+  { key: 'uppercase', test: pw => /[A-Z]/.test(pw) },
+  { key: 'number', test: pw => /[0-9]/.test(pw) },
+]
+
+export function firstFailingPasswordRule(pw: string): PasswordRule | null {
+  return rules.find(r => !r.test(pw))?.key ?? null
+}

--- a/client/src/features/user/utils/serverFieldErrors.test.ts
+++ b/client/src/features/user/utils/serverFieldErrors.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { fieldErrorsFromApiError } from './serverFieldErrors'
+
+function validationError(issues: Array<{ path?: unknown[]; message?: unknown }>) {
+  return { response: { data: { error: { code: 'VALIDATION_ERROR', details: { issues } } } } }
+}
+
+describe('fieldErrorsFromApiError', () => {
+  it('returns {} for non-axios errors without a response payload', () => {
+    expect(fieldErrorsFromApiError(new Error('boom'))).toEqual({})
+    expect(fieldErrorsFromApiError(undefined)).toEqual({})
+  })
+
+  it('returns {} when the error payload is not an object', () => {
+    expect(fieldErrorsFromApiError({ response: { data: { error: 'plain string' } } })).toEqual({})
+  })
+
+  it('returns {} for non-validation error codes', () => {
+    expect(
+      fieldErrorsFromApiError({ response: { data: { error: { code: 'CONFLICT' } } } })
+    ).toEqual({})
+  })
+
+  it('returns {} when a validation error carries no issues', () => {
+    expect(
+      fieldErrorsFromApiError({ response: { data: { error: { code: 'VALIDATION_ERROR' } } } })
+    ).toEqual({})
+  })
+
+  it('maps each issue to its first path segment', () => {
+    const err = validationError([
+      { path: ['email'], message: 'Invalid email' },
+      { path: ['password'], message: 'Too short' },
+    ])
+    expect(fieldErrorsFromApiError(err)).toEqual({ email: 'Invalid email', password: 'Too short' })
+  })
+
+  it('skips issues whose path segment or message is not a string', () => {
+    const err = validationError([
+      { path: [0], message: 'numeric path' },
+      { message: 'no path at all' },
+      { path: ['email'], message: 42 },
+      { path: ['email'], message: 'kept' },
+    ])
+    expect(fieldErrorsFromApiError(err)).toEqual({ email: 'kept' })
+  })
+
+  it('keeps the first message when a field has multiple issues', () => {
+    const err = validationError([
+      { path: ['password'], message: 'first' },
+      { path: ['password'], message: 'second' },
+    ])
+    expect(fieldErrorsFromApiError(err)).toEqual({ password: 'first' })
+  })
+})

--- a/client/src/features/user/utils/serverFieldErrors.ts
+++ b/client/src/features/user/utils/serverFieldErrors.ts
@@ -1,0 +1,18 @@
+// Maps a backend VALIDATION_ERROR (central error middleware shape) to per-field messages,
+// keyed by the first segment of each issue path (e.g. 'email', 'password').
+export function fieldErrorsFromApiError(err: unknown): Partial<Record<string, string>> {
+  const error = (err as { response?: { data?: { error?: unknown } } })?.response?.data?.error
+  if (!error || typeof error !== 'object') return {}
+  const { code, details } = error as {
+    code?: unknown
+    details?: { issues?: Array<{ path?: unknown[]; message?: unknown }> }
+  }
+  if (code !== 'VALIDATION_ERROR') return {}
+  const fields: Partial<Record<string, string>> = {}
+  for (const issue of details?.issues ?? []) {
+    const field = issue.path?.[0]
+    if (typeof field !== 'string' || typeof issue.message !== 'string') continue
+    if (!fields[field]) fields[field] = issue.message
+  }
+  return fields
+}

--- a/client/src/shared/http/client.test.ts
+++ b/client/src/shared/http/client.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, beforeEach, afterEach } from 'vitest'
 import { http, HttpResponse } from 'msw'
 import { server } from '../../../tests/msw/server'
-import { httpClient, resolveApiBaseUrl } from './client'
+import { httpClient, resolveApiBaseUrl, apiErrorMessage, localizedApiError } from './client'
+import i18n from '@/shared/i18n'
 
 describe('httpClient', () => {
   it('uses the api prefix by default', () => {
@@ -15,6 +16,58 @@ describe('httpClient', () => {
 
   it('uses a custom api base url when configured', () => {
     expect(resolveApiBaseUrl('https://api.example.com')).toBe('https://api.example.com')
+  })
+})
+
+describe('apiErrorMessage', () => {
+  const axiosErr = (error: unknown) => ({ response: { data: { error } } })
+
+  it('returns string errors from ad hoc middlewares as is', () => {
+    expect(apiErrorMessage(axiosErr('Unauthorized'))).toBe('Unauthorized')
+  })
+
+  it('returns the message of structured errors', () => {
+    expect(apiErrorMessage(axiosErr({ code: 'RATE_LIMITED', message: 'Too many requests' }))).toBe('Too many requests')
+  })
+
+  it('joins validation issue messages', () => {
+    const error = {
+      code: 'VALIDATION_ERROR',
+      message: 'Invalid body',
+      details: { source: 'body', issues: [{ message: 'Invalid email address' }, { message: 'Password too short' }] },
+    }
+    expect(apiErrorMessage(axiosErr(error))).toBe('Invalid email address. Password too short')
+  })
+
+  it('falls back to message when issues are malformed', () => {
+    const error = { message: 'Invalid body', details: { issues: [{ message: 42 }] } }
+    expect(apiErrorMessage(axiosErr(error))).toBe('Invalid body')
+  })
+
+  it('returns undefined for malformed or non axios errors', () => {
+    expect(apiErrorMessage(axiosErr({ code: 'X' }))).toBeUndefined()
+    expect(apiErrorMessage(axiosErr(null))).toBeUndefined()
+    expect(apiErrorMessage(new Error('boom'))).toBeUndefined()
+    expect(apiErrorMessage(undefined)).toBeUndefined()
+  })
+})
+
+describe('localizedApiError', () => {
+  const axiosErr = (error: unknown) => ({ response: { data: { error } } })
+
+  it('returns the localized message for known codes when the language is spanish', async () => {
+    await i18n.changeLanguage('es')
+    expect(localizedApiError(axiosErr({ code: 'RATE_LIMITED', message: 'Too many requests' }))).toBe(
+      'Demasiados intentos. Probá de nuevo en unos minutos'
+    )
+  })
+
+  it('falls back to the raw message for unknown codes', () => {
+    expect(localizedApiError(axiosErr({ code: 'WEIRD_CODE', message: 'Something odd' }))).toBe('Something odd')
+  })
+
+  it('falls back to the string error from ad hoc middlewares', () => {
+    expect(localizedApiError(axiosErr('plain failure'))).toBe('plain failure')
   })
 })
 

--- a/client/src/shared/http/client.ts
+++ b/client/src/shared/http/client.ts
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import i18n from '@/shared/i18n'
 
 export function resolveApiBaseUrl(value: string | undefined): string {
   const normalized = value?.trim()
@@ -8,6 +9,33 @@ export function resolveApiBaseUrl(value: string | undefined): string {
 export const httpClient = axios.create({
   baseURL: resolveApiBaseUrl(import.meta.env.VITE_API_BASE_URL),
 })
+
+// The backend returns error as a plain string from ad hoc middlewares and as { code, message, details } from the central error middleware
+export function apiErrorMessage(err: unknown): string | undefined {
+  const data = (err as { response?: { data?: { error?: unknown } } })?.response?.data
+  const error = data?.error
+  if (typeof error === 'string') return error
+  if (!error || typeof error !== 'object') return undefined
+  const { message, details } = error as { message?: unknown; details?: { issues?: { message?: unknown }[] } }
+  const issues = details?.issues
+    ?.map(i => i.message)
+    .filter((m): m is string => typeof m === 'string')
+  if (issues?.length) return issues.join('. ')
+  return typeof message === 'string' ? message : undefined
+}
+
+// Prefers a localized message for known backend error codes and falls back to apiErrorMessage
+export function localizedApiError(err: unknown): string | undefined {
+  const data = (err as { response?: { data?: { error?: unknown } } })?.response?.data
+  const error = data?.error
+  if (error && typeof error === 'object') {
+    const { code } = error as { code?: unknown }
+    if (typeof code === 'string' && i18n.exists(`apiErrors.${code}`)) {
+      return i18n.t(`apiErrors.${code}`)
+    }
+  }
+  return apiErrorMessage(err)
+}
 
 httpClient.interceptors.request.use(config => {
   const token = localStorage.getItem('token')

--- a/client/src/shared/i18n/common.ts
+++ b/client/src/shared/i18n/common.ts
@@ -71,6 +71,26 @@ export const commonEs = {
   validation: {
     required: 'Completá este campo',
   },
+  errors: {
+    generic: 'Algo salió mal',
+    loadFailed: 'No se pudieron cargar los datos',
+    retry: 'Reintentar',
+  },
+  apiErrors: {
+    RATE_LIMITED: 'Demasiados intentos. Probá de nuevo en unos minutos',
+    UNAUTHORIZED: 'No autorizado',
+    INVALID_TOKEN: 'Sesión inválida o expirada',
+    INVALID_API_KEY: 'API key inválida',
+    FORBIDDEN: 'No tenés permisos para esta acción',
+    NOT_FOUND: 'No encontrado',
+    CONFLICT: 'Ya existe un registro con esos datos',
+    INTERNAL_ERROR: 'Error interno del servidor. Probá más tarde',
+  },
+  errorBoundary: {
+    title: 'Algo salió mal',
+    description: 'Ocurrió un error inesperado. Podés volver al inicio e intentar de nuevo.',
+    goHome: 'Ir al inicio',
+  },
 }
 
 export const commonEn = {
@@ -144,5 +164,25 @@ export const commonEn = {
   },
   validation: {
     required: 'Please fill out this field',
+  },
+  errors: {
+    generic: 'Something went wrong',
+    loadFailed: 'Could not load the data',
+    retry: 'Retry',
+  },
+  apiErrors: {
+    RATE_LIMITED: 'Too many attempts. Try again in a few minutes',
+    UNAUTHORIZED: 'Unauthorized',
+    INVALID_TOKEN: 'Invalid or expired session',
+    INVALID_API_KEY: 'Invalid API key',
+    FORBIDDEN: 'You do not have permission for this action',
+    NOT_FOUND: 'Not found',
+    CONFLICT: 'A record with that data already exists',
+    INTERNAL_ERROR: 'Internal server error. Try again later',
+  },
+  errorBoundary: {
+    title: 'Something went wrong',
+    description: 'An unexpected error occurred. You can go back home and try again.',
+    goHome: 'Go home',
   },
 }

--- a/client/src/shared/ui/ErrorBoundary.test.tsx
+++ b/client/src/shared/ui/ErrorBoundary.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ErrorBoundary } from './ErrorBoundary'
+import '@/shared/i18n'
+import i18n from '@/shared/i18n'
+
+function Bomb(): never {
+  throw new Error('boom')
+}
+
+describe('ErrorBoundary', () => {
+  it('renders children when nothing throws', () => {
+    render(
+      <ErrorBoundary>
+        <p>all good</p>
+      </ErrorBoundary>
+    )
+    expect(screen.getByText('all good')).toBeInTheDocument()
+  })
+
+  it('shows the fallback instead of a blank screen when a child throws', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>
+    )
+    expect(screen.getByText(i18n.t('errorBoundary.title'))).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: i18n.t('errorBoundary.goHome') })).toBeInTheDocument()
+    spy.mockRestore()
+  })
+})

--- a/client/src/shared/ui/ErrorBoundary.test.tsx
+++ b/client/src/shared/ui/ErrorBoundary.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { ErrorBoundary } from './ErrorBoundary'
 import '@/shared/i18n'
 import i18n from '@/shared/i18n'
@@ -27,6 +28,19 @@ describe('ErrorBoundary', () => {
     )
     expect(screen.getByText(i18n.t('errorBoundary.title'))).toBeInTheDocument()
     expect(screen.getByRole('button', { name: i18n.t('errorBoundary.goHome') })).toBeInTheDocument()
+    spy.mockRestore()
+  })
+
+  it('sends the user home when the go-home button is clicked', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const user = userEvent.setup()
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>
+    )
+    // jsdom does not implement navigation, so clicking only needs to run the handler without throwing
+    await user.click(screen.getByRole('button', { name: i18n.t('errorBoundary.goHome') }))
     spy.mockRestore()
   })
 })

--- a/client/src/shared/ui/ErrorBoundary.tsx
+++ b/client/src/shared/ui/ErrorBoundary.tsx
@@ -1,0 +1,35 @@
+import { Component, type ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/shared/ui/button'
+
+function ErrorFallback() {
+  const { t } = useTranslation('common')
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center gap-4 bg-background p-6 text-center">
+      <h1 className="text-xl font-semibold">{t('errorBoundary.title')}</h1>
+      <p className="text-sm text-muted-foreground max-w-md">{t('errorBoundary.description')}</p>
+      <Button onClick={() => { window.location.href = '/' }}>{t('errorBoundary.goHome')}</Button>
+    </div>
+  )
+}
+
+interface Props { children: ReactNode }
+interface State { hasError: boolean }
+
+// Last resort safety net so a render crash shows a recoverable screen instead of a blank page
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error('Unhandled render error', error)
+  }
+
+  render() {
+    if (this.state.hasError) return <ErrorFallback />
+    return this.props.children
+  }
+}

--- a/client/src/shared/ui/FormField.test.tsx
+++ b/client/src/shared/ui/FormField.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { FormField } from './FormField'
+import { Input } from './input'
+
+describe('FormField', () => {
+  it('renders the label linked to the input', () => {
+    render(
+      <FormField label="Email" htmlFor="email">
+        <Input id="email" />
+      </FormField>
+    )
+    expect(screen.getByLabelText('Email')).toBeInTheDocument()
+  })
+
+  it('shows the hint when there is no error', () => {
+    render(
+      <FormField label="Email" hint="We never share it">
+        <Input />
+      </FormField>
+    )
+    expect(screen.getByText('We never share it')).toBeInTheDocument()
+  })
+
+  it('replaces the hint with the error message', () => {
+    render(
+      <FormField label="Email" hint="We never share it" error="Required">
+        <Input />
+      </FormField>
+    )
+    expect(screen.getByText('Required')).toBeInTheDocument()
+    expect(screen.queryByText('We never share it')).not.toBeInTheDocument()
+  })
+
+  it('renders a required asterisk', () => {
+    render(
+      <FormField label="Email" required>
+        <Input />
+      </FormField>
+    )
+    expect(screen.getByText('*')).toBeInTheDocument()
+  })
+
+  it('exposes the help paragraph under the given helpId for aria-describedby', () => {
+    render(
+      <FormField label="Email" helpId="email-help" error="Required">
+        <Input aria-describedby="email-help" />
+      </FormField>
+    )
+    expect(document.getElementById('email-help')).toHaveTextContent('Required')
+  })
+})

--- a/client/src/shared/ui/FormField.tsx
+++ b/client/src/shared/ui/FormField.tsx
@@ -1,0 +1,50 @@
+import { type ReactNode } from 'react'
+import { Label } from '@/shared/ui/label'
+import { cn } from '@/shared/lib/utils'
+import { AlertCircle, Info } from 'lucide-react'
+
+interface FormFieldProps {
+  label: ReactNode
+  htmlFor?: string
+  helpId?: string
+  required?: boolean
+  hint?: string
+  error?: string
+  children: ReactNode
+}
+
+// Field wrapper where the input carries the error ring via aria-invalid and the label tints destructive on error
+export function FormField({ label, htmlFor, helpId, required, hint, error, children }: FormFieldProps) {
+  const hasError = Boolean(error)
+  return (
+    <div className="grid gap-1.5">
+      <Label
+        htmlFor={htmlFor}
+        className={cn('text-[13px] transition-colors flex items-center gap-1', hasError && 'text-destructive')}
+      >
+        <span>{label}</span>
+        {required && (
+          <span className="text-destructive" aria-hidden>*</span>
+        )}
+      </Label>
+      {children}
+      {(hasError || hint || helpId) && (
+        <p
+          id={helpId}
+          aria-live="polite"
+          className={cn(
+            'flex items-center gap-1 text-[11px] leading-4 min-h-4 transition-colors',
+            hasError ? 'text-destructive' : 'text-muted-foreground',
+          )}
+        >
+          {hasError ? (
+            <AlertCircle className="size-3 shrink-0" aria-hidden />
+          ) : hint ? (
+            <Info className="size-3 shrink-0 opacity-60" aria-hidden />
+          ) : null}
+          <span>{hasError ? error : hint}</span>
+        </p>
+      )}
+    </div>
+  )
+}

--- a/client/src/shared/ui/QueryError.test.tsx
+++ b/client/src/shared/ui/QueryError.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { QueryError } from './QueryError'
+import i18n from '@/shared/i18n'
+
+describe('QueryError', () => {
+  it('renders the load failed message and a retry button', () => {
+    render(<QueryError onRetry={() => {}} />)
+    expect(screen.getByText(i18n.t('errors.loadFailed'))).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: i18n.t('errors.retry') })).toBeInTheDocument()
+  })
+
+  it('calls onRetry when the button is clicked', () => {
+    const onRetry = vi.fn()
+    render(<QueryError onRetry={onRetry} />)
+    fireEvent.click(screen.getByRole('button', { name: i18n.t('errors.retry') }))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+})

--- a/client/src/shared/ui/QueryError.tsx
+++ b/client/src/shared/ui/QueryError.tsx
@@ -1,0 +1,15 @@
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/shared/ui/button'
+
+// Shown in place of page content when a query fails so the user can retry
+export function QueryError({ onRetry }: { onRetry: () => void }) {
+  const { t } = useTranslation('common')
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+      <p className="text-sm text-muted-foreground">{t('errors.loadFailed')}</p>
+      <Button variant="outline" onClick={onRetry}>
+        {t('errors.retry')}
+      </Button>
+    </div>
+  )
+}

--- a/client/tests/msw/handlers/user.ts
+++ b/client/tests/msw/handlers/user.ts
@@ -12,13 +12,13 @@ export const userHandlers = [
   ),
   http.post('/api/auth/login', async ({ request }) => {
     const body = (await request.json()) as { email: string; password: string }
-    if (body.email === 'fail@x' || body.password === 'wrong') {
+    if (body.email.startsWith('fail@x') || body.password === 'wrong') {
       return new HttpResponse(JSON.stringify({ error: 'invalid' }), {
         status: 401,
         headers: { 'Content-Type': 'application/json' },
       })
     }
-    if (body.email === '2fa@x') {
+    if (body.email.startsWith('2fa@x')) {
       return HttpResponse.json({ requiresTotp: true, challengeToken: 'challenge-token' })
     }
     return HttpResponse.json({
@@ -48,7 +48,7 @@ export const userHandlers = [
   http.delete('/api/me/2fa', () => new HttpResponse(null, { status: 204 })),
   http.post('/api/auth/register', async ({ request }) => {
     const body = (await request.json()) as { email: string }
-    if (body.email === 'taken@x') {
+    if (body.email.startsWith('taken@x')) {
       return new HttpResponse(
         JSON.stringify({ error: 'Email already in use' }),
         {

--- a/package.json
+++ b/package.json
@@ -52,5 +52,10 @@
     "typescript": "^6.0.3",
     "vitest": "^4.1.6"
   },
-  "type": "module"
+  "type": "module",
+  "pnpm": {
+    "overrides": {
+      "esbuild": ">=0.28.1"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  fast-uri: ^3.1.2
+  esbuild: '>=0.28.1'
 
 importers:
 
@@ -13,7 +13,7 @@ importers:
     dependencies:
       '@tailwindcss/vite':
         specifier: ^4.2.4
-        version: 4.2.4(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))
+        version: 4.2.4(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
@@ -101,7 +101,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.6.0)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))
+        version: 4.1.6(@types/node@25.6.0)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))
 
   client:
     dependencies:
@@ -113,7 +113,7 @@ importers:
         version: 5.2.8
       '@tailwindcss/vite':
         specifier: ^4.2.2
-        version: 4.2.2(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))
+        version: 4.2.2(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))
       '@tanstack/react-query':
         specifier: ^5.96.2
         version: 5.96.2(react@19.2.4)
@@ -189,7 +189,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))
+        version: 6.0.1(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))
       '@vitest/coverage-v8':
         specifier: ^4.1.6
         version: 4.1.6(vitest@4.1.6)
@@ -222,10 +222,10 @@ importers:
         version: 8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.2)
       vite:
         specifier: ^8.0.4
-        version: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)
+        version: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@24.12.2)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@24.12.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))
+        version: 4.1.6(@types/node@24.12.2)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@24.12.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))
 
 packages:
 
@@ -488,158 +488,158 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2009,8 +2009,8 @@ packages:
   es-toolkit@1.45.1:
     resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
 
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3695,7 +3695,7 @@ packages:
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.0
-      esbuild: ^0.27.0 || ^0.28.0
+      esbuild: '>=0.28.1'
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -4216,82 +4216,82 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.7':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.7':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.7':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.7':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.7':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.7':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.7':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/win32-x64@0.27.7':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
@@ -4779,19 +4779,19 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.4
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.4
 
-  '@tailwindcss/vite@4.2.2(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))':
+  '@tailwindcss/vite@4.2.2(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)
 
-  '@tailwindcss/vite@4.2.4(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))':
+  '@tailwindcss/vite@4.2.4(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))':
     dependencies:
       '@tailwindcss/node': 4.2.4
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
-      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)
 
   '@tanstack/query-core@5.96.2': {}
 
@@ -5079,10 +5079,10 @@ snapshots:
       '@typescript-eslint/types': 8.58.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)
 
   '@vitest/coverage-v8@4.1.6(vitest@4.1.6)':
     dependencies:
@@ -5096,7 +5096,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@25.6.0)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))
+      vitest: 4.1.6(@types/node@25.6.0)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))
 
   '@vitest/expect@4.1.6':
     dependencies:
@@ -5107,23 +5107,23 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.6(msw@2.14.6(@types/node@24.12.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.6(msw@2.14.6(@types/node@24.12.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.14.6(@types/node@24.12.2)(typescript@6.0.2)
-      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)
 
-  '@vitest/mocker@4.1.6(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.6(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.14.6(@types/node@25.6.0)(typescript@6.0.3)
-      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.6':
     dependencies:
@@ -5152,7 +5152,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@25.6.0)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))
+      vitest: 4.1.6(@types/node@25.6.0)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))
 
   '@vitest/utils@4.1.6':
     dependencies:
@@ -5600,34 +5600,34 @@ snapshots:
 
   es-toolkit@1.45.1: {}
 
-  esbuild@0.27.7:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -7237,7 +7237,7 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3
@@ -7324,7 +7324,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0):
+  vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -7333,7 +7333,7 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.12.2
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.21.0
@@ -7341,7 +7341,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0):
+  vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -7350,7 +7350,7 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.6.0
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.21.0
@@ -7358,10 +7358,10 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.6(@types/node@24.12.2)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@24.12.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)):
+  vitest@4.1.6(@types/node@24.12.2)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@24.12.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(msw@2.14.6(@types/node@24.12.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.6(msw@2.14.6(@types/node@24.12.2)(typescript@6.0.2))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.6
       '@vitest/runner': 4.1.6
       '@vitest/snapshot': 4.1.6
@@ -7378,7 +7378,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.2
@@ -7388,10 +7388,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.6(@types/node@25.6.0)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)):
+  vitest@4.1.6(@types/node@25.6.0)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.6(msw@2.14.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.6
       '@vitest/runner': 4.1.6
       '@vitest/snapshot': 4.1.6
@@ -7408,7 +7408,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0

--- a/src/api/http/validate.test.ts
+++ b/src/api/http/validate.test.ts
@@ -20,6 +20,9 @@ describe('validate helpers', () => {
       expect(e).toBeInstanceOf(ValidationError)
       expect((e as ValidationError).details?.source).toBe('body')
       expect(Array.isArray((e as ValidationError).details?.issues)).toBe(true)
+      const issue = ((e as ValidationError).details?.issues as object[])[0]
+      // Sanitized issues expose only safe fields so schema internals never leak
+      expect(Object.keys(issue).sort()).toEqual(['code', 'message', 'path'])
     }
   })
 

--- a/src/api/http/validate.ts
+++ b/src/api/http/validate.ts
@@ -7,7 +7,7 @@ function parse<T>(schema: ZodType<T>, data: unknown, source: string): T {
   if (!result.success) {
     throw new ValidationError(`Invalid ${source}`, {
       source,
-      issues: result.error.issues,
+      issues: result.error.issues.map((i) => ({ path: i.path, message: i.message, code: i.code })),
     })
   }
   return result.data

--- a/src/api/middlewares/auth.middleware.test.ts
+++ b/src/api/middlewares/auth.middleware.test.ts
@@ -40,7 +40,7 @@ describe('buildAuthMiddleware', () => {
     await middleware(makeReq(), res, next)
 
     expect(res.status).toHaveBeenCalledWith(401)
-    expect(res.json).toHaveBeenCalledWith({ error: 'Unauthorized' })
+    expect(res.json).toHaveBeenCalledWith({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } })
     expect(next).not.toHaveBeenCalled()
     expect(tokenIssuer.verify).not.toHaveBeenCalled()
   })
@@ -51,7 +51,7 @@ describe('buildAuthMiddleware', () => {
     await middleware(makeReq({ authorization: 'Basic xyz' }), res, next)
 
     expect(res.status).toHaveBeenCalledWith(401)
-    expect(res.json).toHaveBeenCalledWith({ error: 'Unauthorized' })
+    expect(res.json).toHaveBeenCalledWith({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } })
     expect(next).not.toHaveBeenCalled()
   })
 
@@ -63,7 +63,7 @@ describe('buildAuthMiddleware', () => {
 
     expect(tokenIssuer.verify).toHaveBeenCalledWith('bad-token')
     expect(res.status).toHaveBeenCalledWith(401)
-    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid token' })
+    expect(res.json).toHaveBeenCalledWith({ error: { code: 'INVALID_TOKEN', message: 'Invalid token' } })
     expect(next).not.toHaveBeenCalled()
   })
 
@@ -99,7 +99,7 @@ describe('buildAuthMiddleware', () => {
     await middleware(req, res, next)
 
     expect(res.status).toHaveBeenCalledWith(401)
-    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid token' })
+    expect(res.json).toHaveBeenCalledWith({ error: { code: 'INVALID_TOKEN', message: 'Invalid token' } })
     expect(req.userId).toBeUndefined()
     expect(next).not.toHaveBeenCalled()
   })
@@ -113,7 +113,7 @@ describe('buildAuthMiddleware', () => {
     await middleware(makeReq({ authorization: 'Bearer weird' }), res, next)
 
     expect(res.status).toHaveBeenCalledWith(401)
-    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid token' })
+    expect(res.json).toHaveBeenCalledWith({ error: { code: 'INVALID_TOKEN', message: 'Invalid token' } })
     expect(next).not.toHaveBeenCalled()
   })
 
@@ -148,7 +148,7 @@ describe('buildAuthMiddleware', () => {
       await middleware(makeReq({ authorization: 'Bearer good-token' }), res, next)
 
       expect(res.status).toHaveBeenCalledWith(401)
-      expect(res.json).toHaveBeenCalledWith({ error: 'Invalid token' })
+      expect(res.json).toHaveBeenCalledWith({ error: { code: 'INVALID_TOKEN', message: 'Invalid token' } })
       expect(next).not.toHaveBeenCalled()
     })
 

--- a/src/api/middlewares/auth.middleware.ts
+++ b/src/api/middlewares/auth.middleware.ts
@@ -19,22 +19,22 @@ export function buildAuthMiddleware(
   return async (req: AuthRequest, res: Response, next: NextFunction) => {
     const header = req.headers.authorization
     if (!header?.startsWith('Bearer ')) {
-      res.status(401).json({ error: 'Unauthorized' })
+      res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } })
       return
     }
     const payload = tokenIssuer.verify(header.slice(7))
     if (!payload) {
-      res.status(401).json({ error: 'Invalid token' })
+      res.status(401).json({ error: { code: 'INVALID_TOKEN', message: 'Invalid token' } })
       return
     }
     // 2fa_pending challenge tokens only authorize the TOTP step, never the API.
     if ((payload.scope ?? 'access') !== 'access') {
-      res.status(401).json({ error: 'Invalid token' })
+      res.status(401).json({ error: { code: 'INVALID_TOKEN', message: 'Invalid token' } })
       return
     }
     try {
       if (denylist && payload.jti && (await denylist.isRevoked(payload.jti))) {
-        res.status(401).json({ error: 'Invalid token' })
+        res.status(401).json({ error: { code: 'INVALID_TOKEN', message: 'Invalid token' } })
         return
       }
     } catch (err) {

--- a/src/api/middlewares/requireAdmin.middleware.ts
+++ b/src/api/middlewares/requireAdmin.middleware.ts
@@ -12,13 +12,13 @@ export interface RoleReader {
 export function buildRequireAdmin(roleReader: RoleReader): RequestHandler {
   return async (req: AuthRequest, res: Response, next: NextFunction) => {
     if (!req.userId) {
-      res.status(401).json({ error: 'Unauthorized' })
+      res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } })
       return
     }
     try {
       const role = await roleReader.getRole(req.userId)
       if (role !== 'admin') {
-        res.status(403).json({ error: 'Forbidden' })
+        res.status(403).json({ error: { code: 'FORBIDDEN', message: 'Forbidden' } })
         return
       }
       next()

--- a/src/api/routes/auth.routes.test.ts
+++ b/src/api/routes/auth.routes.test.ts
@@ -115,7 +115,7 @@ describe('auth.routes', () => {
 
     it('returns 409 when the use case throws ConflictError', async () => {
       user.registerUser.execute.mockRejectedValue(
-        new ConflictError('Email already exists', { email: 'a@b.com' }),
+        new ConflictError('Email already exists'),
       )
 
       const res = await request(makeApp(user))
@@ -127,7 +127,6 @@ describe('auth.routes', () => {
         error: {
           code: 'CONFLICT',
           message: 'Email already exists',
-          details: { email: 'a@b.com' },
         },
       })
     })

--- a/src/api/routes/auth.routes.ts
+++ b/src/api/routes/auth.routes.ts
@@ -10,7 +10,7 @@ import type { ITokenDenylist } from '../../contexts/user/domain/ports/ITokenDeny
 const passwordPolicy = z
   .string()
   .min(12, 'Password must be at least 12 characters')
-  .max(128, 'Password must be at most 128 characters')
+  .max(32, 'Password must be at most 32 characters')
   .regex(/[a-z]/, 'Password must contain a lowercase letter')
   .regex(/[A-Z]/, 'Password must contain an uppercase letter')
   .regex(/[0-9]/, 'Password must contain a number')

--- a/src/api/routes/bank-movements.routes.test.ts
+++ b/src/api/routes/bank-movements.routes.test.ts
@@ -117,15 +117,15 @@ describe('bank-movements.routes', () => {
       expect(res.status).toBe(400)
     })
 
-    it('returns 403 when account is not owned by the user', async () => {
+    it('returns 404 when account is not owned by the user', async () => {
       accountRepo.findByIdForUser.mockResolvedValue(null)
 
       const res = await request(makeApp(banking, accountRepo))
         .get(`/accounts/${ACCOUNT_ID}/movements`)
         .set('Authorization', AUTH_HEADER)
 
-      expect(res.status).toBe(403)
-      expect(res.body.error.code).toBe('FORBIDDEN')
+      expect(res.status).toBe(404)
+      expect(res.body.error.code).toBe('NOT_FOUND')
       expect(banking.listBankMovements.execute).not.toHaveBeenCalled()
     })
 
@@ -201,18 +201,18 @@ describe('bank-movements.routes', () => {
       expect(res.status).toBe(400)
     })
 
-    it('returns 403 when account is not owned', async () => {
+    it('returns 404 when account is not owned', async () => {
       accountRepo.findByIdForUser.mockResolvedValue(null)
 
       const res = await request(makeApp(banking, accountRepo))
         .post(`/accounts/${ACCOUNT_ID}/movements/${MOVEMENT_ID}/notify`)
         .set('Authorization', AUTH_HEADER)
 
-      expect(res.status).toBe(403)
+      expect(res.status).toBe(404)
       expect(banking.bankTransactionRepository.findById).not.toHaveBeenCalled()
     })
 
-    it('returns 403 when movement does not exist', async () => {
+    it('returns 404 when movement does not exist', async () => {
       accountRepo.findByIdForUser.mockResolvedValue({ id: ACCOUNT_ID })
       banking.bankTransactionRepository.findById.mockResolvedValue(null)
 
@@ -220,13 +220,13 @@ describe('bank-movements.routes', () => {
         .post(`/accounts/${ACCOUNT_ID}/movements/${MOVEMENT_ID}/notify`)
         .set('Authorization', AUTH_HEADER)
 
-      expect(res.status).toBe(403)
-      expect(res.body.error.code).toBe('FORBIDDEN')
+      expect(res.status).toBe(404)
+      expect(res.body.error.code).toBe('NOT_FOUND')
       expect(res.body.error.message).toMatch(/Movement not found/)
       expect(banking.reNotifyBankMovement.execute).not.toHaveBeenCalled()
     })
 
-    it('returns 403 when movement belongs to a different account', async () => {
+    it('returns 404 when movement belongs to a different account', async () => {
       accountRepo.findByIdForUser.mockResolvedValue({ id: ACCOUNT_ID })
       banking.bankTransactionRepository.findById.mockResolvedValue({
         id: MOVEMENT_ID,
@@ -237,7 +237,7 @@ describe('bank-movements.routes', () => {
         .post(`/accounts/${ACCOUNT_ID}/movements/${MOVEMENT_ID}/notify`)
         .set('Authorization', AUTH_HEADER)
 
-      expect(res.status).toBe(403)
+      expect(res.status).toBe(404)
       expect(banking.reNotifyBankMovement.execute).not.toHaveBeenCalled()
     })
 

--- a/src/api/routes/bank-movements.routes.ts
+++ b/src/api/routes/bank-movements.routes.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { AuthRequest } from '../middlewares/auth.middleware.js'
 import { controller } from '../http/controller.js'
 import { validateParams, validateQuery } from '../http/validate.js'
-import { UnauthorizedError, ForbiddenError } from '../../shared/errors/index.js'
+import { UnauthorizedError, NotFoundError } from '../../shared/errors/index.js'
 import type { BankingModule } from '../../composition/bankingModule.js'
 import type { IAccountRepository } from '../../contexts/account/domain/IAccountRepository.js'
 
@@ -38,7 +38,7 @@ export function buildBankMovementsRouter(deps: BankMovementsRouterDeps): Router 
     const userId = requireUserId(req)
     const { accountId } = validateParams(req, paramsSchema)
     const { limit, offset } = validateQuery(req, listQuerySchema)
-    if (!(await ownsAccount(accountId, userId))) throw new ForbiddenError('Account not found')
+    if (!(await ownsAccount(accountId, userId))) throw new NotFoundError('Account not found')
     const movements = await deps.banking.listBankMovements.execute({ accountId, limit, offset })
     res.json(movements)
   }))
@@ -46,7 +46,7 @@ export function buildBankMovementsRouter(deps: BankMovementsRouterDeps): Router 
   router.get('/dead-letters', controller(async (req: AuthRequest, res) => {
     const userId = requireUserId(req)
     const { accountId } = validateParams(req, paramsSchema)
-    if (!(await ownsAccount(accountId, userId))) throw new ForbiddenError('Account not found')
+    if (!(await ownsAccount(accountId, userId))) throw new NotFoundError('Account not found')
     const deadLetters = await deps.banking.listWebhookDeadLetters.execute(accountId)
     res.json(deadLetters)
   }))
@@ -54,9 +54,9 @@ export function buildBankMovementsRouter(deps: BankMovementsRouterDeps): Router 
   router.post('/:movementId/notify', controller(async (req: AuthRequest, res) => {
     const userId = requireUserId(req)
     const { accountId, movementId } = validateParams(req, paramsWithMovementSchema)
-    if (!(await ownsAccount(accountId, userId))) throw new ForbiddenError('Account not found')
+    if (!(await ownsAccount(accountId, userId))) throw new NotFoundError('Account not found')
     const tx = await deps.banking.bankTransactionRepository.findById(movementId)
-    if (!tx || tx.accountId !== accountId) throw new ForbiddenError('Movement not found for this account')
+    if (!tx || tx.accountId !== accountId) throw new NotFoundError('Movement not found for this account')
     await deps.banking.reNotifyBankMovement.execute(movementId)
     res.status(202).json({ queued: true })
   }))

--- a/src/api/routes/user.routes.test.ts
+++ b/src/api/routes/user.routes.test.ts
@@ -84,7 +84,7 @@ describe('user.routes', () => {
       const res = await request(makeApp(user)).get('/users/me')
 
       expect(res.status).toBe(401)
-      expect(res.body).toEqual({ error: 'Unauthorized' })
+      expect(res.body).toEqual({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } })
       expect(user.getCurrentUser.execute).not.toHaveBeenCalled()
     })
 
@@ -94,7 +94,7 @@ describe('user.routes', () => {
         .set('Authorization', AUTH_HEADER)
 
       expect(res.status).toBe(401)
-      expect(res.body).toEqual({ error: 'Invalid token' })
+      expect(res.body).toEqual({ error: { code: 'INVALID_TOKEN', message: 'Invalid token' } })
     })
 
     it('returns 401 from requireUserId when req.userId is missing', async () => {
@@ -166,7 +166,7 @@ describe('user.routes', () => {
         .send({ mode: 'reconcile' })
 
       expect(res.status).toBe(401)
-      expect(res.body).toEqual({ error: 'Unauthorized' })
+      expect(res.body).toEqual({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } })
     })
 
     it('returns 401 from requireUserId when req.userId is missing', async () => {

--- a/src/api/server.test.ts
+++ b/src/api/server.test.ts
@@ -66,14 +66,14 @@ describe('createServer routing', () => {
     const res = await request(createServer(fakeContainer())).get('/api/accounts')
 
     expect(res.status).toBe(401)
-    expect(res.body).toEqual({ error: 'Unauthorized' })
+    expect(res.body).toEqual({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } })
   })
 
   it('returns json not found for unknown api routes', async () => {
     const res = await request(createServer(fakeContainer())).get('/api/unknown')
 
     expect(res.status).toBe(404)
-    expect(res.body).toEqual({ error: 'Not found' })
+    expect(res.body).toEqual({ error: { code: 'NOT_FOUND', message: 'Not found' } })
   })
 
   it.each(['/', '/banks', '/accounts'])(

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -79,7 +79,7 @@ export function createServer(container: Container = buildContainer()) {
 
   bindRoutes(app, container);
 
-  app.use("/api", (_req, res) => res.status(404).json({ error: "Not found" }));
+  app.use("/api", (_req, res) => res.status(404).json({ error: { code: "NOT_FOUND", message: "Not found" } }));
 
   app.use(errorMiddleware);
 

--- a/src/contexts/user/application/RegisterUserUseCase.ts
+++ b/src/contexts/user/application/RegisterUserUseCase.ts
@@ -18,7 +18,7 @@ export class RegisterUserUseCase {
 
   async execute(input: Input): Promise<{ id: string; email: string }> {
     const existing = await this.userRepo.findByEmail(input.email)
-    if (existing) throw new ConflictError('Email already exists', { email: input.email })
+    if (existing) throw new ConflictError('Email already exists')
 
     const passwordHash = await this.passwordHasher.hash(input.password)
     const user = User.create(crypto.randomUUID(), input.email, passwordHash, input.name)

--- a/src/contexts/user/domain/User.ts
+++ b/src/contexts/user/domain/User.ts
@@ -31,7 +31,7 @@ export class User extends AggregateRoot<string> {
   static create(id: string, email: string, passwordHash: string, name?: string | null): User {
     const trimmedEmail = email?.trim().toLowerCase()
     if (!trimmedEmail || !EMAIL_RE.test(trimmedEmail)) {
-      throw new ValidationError('email is invalid', { email })
+      throw new ValidationError('email is invalid')
     }
     if (!passwordHash) throw new ValidationError('passwordHash is required')
     return new User(id, {


### PR DESCRIPTION
This pull request implements structured error responses on the API and clearer error feedback in the frontend. Backend errors now return `{ code, message, details }`, ownership checks return 404 instead of 403, and the password policy maximum is lowered to 32 characters. The client gains localized API error helpers, an ErrorBoundary, a QueryError retry component, per-field validation on Login and Register (password rules shown one at a time), a shared FormField component reused in the account forms, and error toasts on mutations that previously failed silently.

Merge order: this PR first; the OTP and API keys PRs build on its error helpers.