### PR TITLE
Harden backend against audit findings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,11 @@ JWT_EXPIRES_IN=12h
 CREDENTIALS_ENCRYPTION_KEY=change_this_generate_with_openssl_rand_base64_32
 # Comma-separated allowed browser origins for CORS (required in production)
 CORS_ORIGINS=https://app.example.com
+# Optional: shared secret used to HMAC-sign outbound webhooks. When set, each
+# delivery carries X-Webhook-Timestamp and X-Signature-256 (sha256 of
+# `<timestamp>.<body>`) so recipients can verify authenticity. Generate:
+# openssl rand -base64 32
+# WEBHOOK_SIGNING_SECRET=
 # Force Playwright headless in server environments (set to false only for local assisted login)
 PLAYWRIGHT_HEADLESS=true
 # Optional: require TLS to PostgreSQL when the DB is remote (set to require)

--- a/src/api/middlewares/rateLimit.middleware.ts
+++ b/src/api/middlewares/rateLimit.middleware.ts
@@ -25,6 +25,15 @@ export const loginRateLimiter = buildRateLimiter({
   skip: skipInTest,
 })
 
+// Brute-force protection for the 2FA code endpoints (enrollment confirm and
+// disable). Without it those routes would inherit only the coarse 300/15min
+// global cap, far looser than login's 5 attempts.
+export const totpRateLimiter = buildRateLimiter({
+  windowMs: 15 * 60 * 1000,
+  limit: Number(process.env.RATE_LIMIT_TOTP_MAX ?? 5),
+  skip: skipInTest,
+})
+
 // Slows down account enumeration and mass registration
 export const registerRateLimiter = buildRateLimiter({
   windowMs: 60 * 60 * 1000,

--- a/src/api/realtime/RealtimeGateway.test.ts
+++ b/src/api/realtime/RealtimeGateway.test.ts
@@ -4,12 +4,13 @@ import type { Duplex } from 'node:stream'
 
 const handleUpgrade = vi.fn()
 const wssClose = vi.fn()
+let wssOpts: Record<string, unknown> | undefined
 
 vi.mock('ws', () => {
   class WebSocketServer {
     handleUpgrade = handleUpgrade
     close = wssClose
-    constructor(_opts: unknown) {}
+    constructor(opts: Record<string, unknown>) { wssOpts = opts }
   }
   class WebSocket { static OPEN = 1 }
   return { WebSocketServer, WebSocket }
@@ -21,13 +22,15 @@ import type { RealtimeBus } from '../../shared/infrastructure/realtime/RealtimeB
 import type { SystemEvent } from '../../shared/infrastructure/realtime/events.js'
 
 type Handlers = Record<string, (...a: unknown[]) => void>
-function fakeWs(readyState = 1) {
+function fakeWs(readyState = 1, bufferedAmount = 0) {
   const handlers: Handlers = {}
   return {
-    readyState, OPEN: 1,
+    readyState, OPEN: 1, bufferedAmount,
     on: vi.fn((ev: string, cb: (...a: unknown[]) => void) => { handlers[ev] = cb }),
     send: vi.fn(),
     close: vi.fn(),
+    ping: vi.fn(),
+    terminate: vi.fn(),
     fire: (ev: string, ...a: unknown[]) => handlers[ev]?.(...a),
   }
 }
@@ -36,11 +39,17 @@ function fakeSocket() {
   return { write: vi.fn(), destroy: vi.fn() } as unknown as Duplex & { write: ReturnType<typeof vi.fn>; destroy: ReturnType<typeof vi.fn> }
 }
 
-function req(url: string, protocol?: string): IncomingMessage {
-  return { url, headers: protocol ? { 'sec-websocket-protocol': protocol } : {} } as unknown as IncomingMessage
+function req(url: string, protocol?: string, origin?: string): IncomingMessage {
+  const headers: Record<string, string> = {}
+  if (protocol) headers['sec-websocket-protocol'] = protocol
+  if (origin) headers.origin = origin
+  return { url, headers } as unknown as IncomingMessage
 }
 
-function setup(verify: ITokenIssuer['verify'] = () => ({ sub: 'u-1', email: '', scope: 'ws' })) {
+function setup(
+  verify: ITokenIssuer['verify'] = () => ({ sub: 'u-1', email: '', scope: 'ws' }),
+  allowedOrigins?: string[],
+) {
   const tokenIssuer = { issue: vi.fn(), verify: vi.fn(verify) } as unknown as ITokenIssuer
   let routeCb: ((e: SystemEvent) => void) | undefined
   const dispose = vi.fn(async () => {})
@@ -48,7 +57,7 @@ function setup(verify: ITokenIssuer['verify'] = () => ({ sub: 'u-1', email: '', 
     subscribeAllUserEvents: vi.fn((cb: (e: SystemEvent) => void) => { routeCb = cb; return dispose }),
   } as unknown as RealtimeBus
   const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() }
-  const gateway = new RealtimeGateway(tokenIssuer, bus, logger as never)
+  const gateway = new RealtimeGateway(tokenIssuer, bus, logger as never, allowedOrigins)
   const server = { on: vi.fn() }
   gateway.attach(server as never)
   const upgrade = server.on.mock.calls[0][1] as (r: IncomingMessage, s: Duplex, h: Buffer) => void
@@ -137,5 +146,89 @@ describe('RealtimeGateway', () => {
     expect(dispose).toHaveBeenCalled()
     expect(ws.close).toHaveBeenCalled()
     expect(wssClose).toHaveBeenCalled()
+  })
+
+  it('caps the inbound frame size', () => {
+    setup()
+    expect(wssOpts?.maxPayload).toBe(64 * 1024)
+  })
+
+  it('closes the socket if the client sends a message (unidirectional channel)', () => {
+    const { upgrade } = setup()
+    const ws = fakeWs()
+    handleUpgrade.mockImplementation((_r, _s, _h, cb) => cb(ws))
+    upgrade(req('/realtime', 'realtime.v1, tkt'), fakeSocket(), head)
+
+    ws.fire('message', Buffer.from('anything'))
+    expect(ws.close).toHaveBeenCalledWith(1003)
+  })
+
+  it('skips sending to a socket that is backed up (backpressure)', () => {
+    const { upgrade, getRoute } = setup()
+    const slow = fakeWs(1, 2 * 1024 * 1024) // bufferedAmount well over the cap
+    handleUpgrade.mockImplementation((_r, _s, _h, cb) => cb(slow))
+    upgrade(req('/realtime', 'realtime.v1, tkt'), fakeSocket(), head)
+
+    getRoute()({ type: 'session.started', userId: 'u-1', accountId: 'a-1', occurredAt: 'now' })
+    expect(slow.send).not.toHaveBeenCalled()
+  })
+
+  it('skips the Origin check when no allowlist is configured', () => {
+    // resolveCorsOrigins() returns [] in production without CORS_ORIGINS set.
+    handleUpgrade.mockImplementation((_r, _s, _h, cb) => cb(fakeWs()))
+    const { upgrade } = setup(undefined, [])
+    upgrade(req('/realtime', 'realtime.v1, tkt', 'https://anything.example.com'), fakeSocket(), head)
+    expect(handleUpgrade).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects an upgrade whose Origin is not allow-listed', () => {
+    const { upgrade } = setup(undefined, ['https://app.example.com'])
+    const socket = fakeSocket()
+    upgrade(req('/realtime', 'realtime.v1, tkt', 'https://evil.example.com'), socket, head)
+    expect(socket.write).toHaveBeenCalledWith('HTTP/1.1 403 Forbidden\r\n\r\n')
+    expect(socket.destroy).toHaveBeenCalled()
+    expect(handleUpgrade).not.toHaveBeenCalled()
+  })
+
+  it('accepts an allow-listed Origin and a request without one', () => {
+    handleUpgrade.mockImplementation((_r, _s, _h, cb) => cb(fakeWs()))
+    const allowed = setup(undefined, ['https://app.example.com'])
+    allowed.upgrade(req('/realtime', 'realtime.v1, tkt', 'https://app.example.com'), fakeSocket(), head)
+    expect(handleUpgrade).toHaveBeenCalledTimes(1)
+
+    // Non-browser clients send no Origin header and must still connect.
+    handleUpgrade.mockClear()
+    const noOrigin = setup(undefined, ['https://app.example.com'])
+    noOrigin.upgrade(req('/realtime', 'realtime.v1, tkt'), fakeSocket(), head)
+    expect(handleUpgrade).toHaveBeenCalledTimes(1)
+  })
+
+  it('pings live sockets and terminates ones that miss a pong', () => {
+    vi.useFakeTimers()
+    try {
+      const { gateway, upgrade } = setup()
+      const ws = fakeWs()
+      handleUpgrade.mockImplementation((_r, _s, _h, cb) => cb(ws))
+      upgrade(req('/realtime', 'realtime.v1, tkt'), fakeSocket(), head)
+
+      // First beat: still alive from the open, so it gets pinged.
+      vi.advanceTimersByTime(30_000)
+      expect(ws.ping).toHaveBeenCalledTimes(1)
+      expect(ws.terminate).not.toHaveBeenCalled()
+
+      // A pong arrives, keeping it alive across the next beat.
+      ws.fire('pong')
+      vi.advanceTimersByTime(30_000)
+      expect(ws.terminate).not.toHaveBeenCalled()
+      expect(ws.ping).toHaveBeenCalledTimes(2)
+
+      // No pong this time: the next beat reaps it.
+      vi.advanceTimersByTime(30_000)
+      expect(ws.terminate).toHaveBeenCalledTimes(1)
+
+      return gateway.close()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/api/realtime/RealtimeGateway.ts
+++ b/src/api/realtime/RealtimeGateway.ts
@@ -8,26 +8,44 @@ import type { ILogger } from '../../shared/logger/ILogger.js'
 
 const WS_PATH = '/realtime'
 const SUBPROTOCOL = 'realtime.v1'
+// Drop a frame larger than this on the floor: the channel is server→client only,
+// so the client never has a legitimate reason to send anything sizeable.
+const MAX_PAYLOAD_BYTES = 64 * 1024
+// Shed a consumer that has let this many bytes queue up rather than buffer events
+// in memory unboundedly behind a stalled socket.
+const MAX_BUFFERED_BYTES = 1024 * 1024
+const HEARTBEAT_MS = 30_000
+
+// `ws` does not type the per-socket liveness flag we attach for the heartbeat.
+type LiveSocket = WebSocket & { isAlive?: boolean }
 
 // The ws ticket travels as the second WebSocket subprotocol so it never lands in the URL or server logs and Redis pub/sub upstream fans out so each instance routes only to the sockets it holds
 export class RealtimeGateway {
-  private readonly wss = new WebSocketServer({ noServer: true })
+  private readonly wss = new WebSocketServer({ noServer: true, maxPayload: MAX_PAYLOAD_BYTES })
   private readonly byUser = new Map<string, Set<WebSocket>>()
   private disposeBus?: () => Promise<void>
+  private heartbeat?: ReturnType<typeof setInterval>
 
   constructor(
     private readonly tokenIssuer: ITokenIssuer,
     private readonly bus: RealtimeBus,
     private readonly logger?: ILogger,
+    // When set, browser upgrades whose Origin is not listed are rejected. Empty/undefined
+    // disables the check so non-browser clients (which omit Origin) keep working.
+    private readonly allowedOrigins?: string[],
   ) {}
 
   attach(server: HttpServer): void {
     server.on('upgrade', (req, socket, head) => this.onUpgrade(req, socket, head))
     this.disposeBus = this.bus.subscribeAllUserEvents((event) => this.route(event))
+    this.heartbeat = setInterval(() => this.beat(), HEARTBEAT_MS)
+    // Don't keep the event loop alive just for the heartbeat.
+    this.heartbeat.unref?.()
     this.logger?.info('realtime gateway attached', { path: WS_PATH })
   }
 
   async close(): Promise<void> {
+    if (this.heartbeat) clearInterval(this.heartbeat)
     await this.disposeBus?.()
     for (const set of this.byUser.values()) for (const ws of set) ws.close()
     this.wss.close()
@@ -36,6 +54,11 @@ export class RealtimeGateway {
   private onUpgrade(req: IncomingMessage, socket: Duplex, head: Buffer): void {
     if (new URL(req.url ?? '', 'http://localhost').pathname !== WS_PATH) {
       // No other upgrade handler exists so close rather than leave the client hanging
+      socket.destroy()
+      return
+    }
+    if (!this.originAllowed(req)) {
+      socket.write('HTTP/1.1 403 Forbidden\r\n\r\n')
       socket.destroy()
       return
     }
@@ -48,6 +71,15 @@ export class RealtimeGateway {
     this.wss.handleUpgrade(req, socket, head, (ws) => {
       this.register(userId, ws)
     })
+  }
+
+  // Defence-in-depth alongside the bearer ticket: reject cross-origin browsers up front.
+  // A missing Origin (non-browser clients) is allowed; the ticket still gates access.
+  private originAllowed(req: IncomingMessage): boolean {
+    if (!this.allowedOrigins || this.allowedOrigins.length === 0) return true
+    const origin = req.headers.origin
+    if (!origin) return true
+    return this.allowedOrigins.includes(origin)
   }
 
   // The ticket is the second offered subprotocol after `realtime.v1`
@@ -65,6 +97,10 @@ export class RealtimeGateway {
     let set = this.byUser.get(userId)
     if (!set) { set = new Set(); this.byUser.set(userId, set) }
     set.add(ws)
+    ;(ws as LiveSocket).isAlive = true
+    ws.on('pong', () => { (ws as LiveSocket).isAlive = true })
+    // Unidirectional channel: any client frame is protocol abuse, so hang up (1003).
+    ws.on('message', () => ws.close(1003))
     ws.on('close', () => {
       set!.delete(ws)
       if (set!.size === 0) this.byUser.delete(userId)
@@ -72,12 +108,27 @@ export class RealtimeGateway {
     ws.on('error', () => ws.close())
   }
 
+  // Ping every live socket each beat; reap any that missed the previous ping's pong.
+  private beat(): void {
+    for (const set of this.byUser.values()) {
+      for (const ws of set) {
+        const live = ws as LiveSocket
+        if (live.isAlive === false) { ws.terminate(); continue }
+        live.isAlive = false
+        ws.ping()
+      }
+    }
+  }
+
   private route(event: SystemEvent): void {
     const set = this.byUser.get(event.userId)
     if (!set) return
     const payload = JSON.stringify(event)
     for (const ws of set) {
-      if (ws.readyState === ws.OPEN) ws.send(payload)
+      if (ws.readyState !== ws.OPEN) continue
+      // Drop a backed-up consumer instead of letting events pile up in its send buffer.
+      if (ws.bufferedAmount > MAX_BUFFERED_BYTES) { ws.close(1013); continue }
+      ws.send(payload)
     }
   }
 }

--- a/src/api/routes/user.routes.ts
+++ b/src/api/routes/user.routes.ts
@@ -4,6 +4,7 @@ import { AuthRequest } from '../middlewares/auth.middleware.js'
 import { controller } from '../http/controller.js'
 import { validateBody } from '../http/validate.js'
 import { UnauthorizedError } from '../../shared/errors/index.js'
+import { totpRateLimiter } from '../middlewares/rateLimit.middleware.js'
 import type { UserModule } from '../../composition/userModule.js'
 
 const operationModeSchema = z.object({
@@ -54,7 +55,7 @@ export function buildUserRouter(user: UserModule): Router {
   }))
 
   // Confirm enrollment with a code; returns one-time backup codes (shown once).
-  router.post('/2fa/confirm', controller(async (req: AuthRequest, res) => {
+  router.post('/2fa/confirm', totpRateLimiter, controller(async (req: AuthRequest, res) => {
     const userId = requireUserId(req)
     const { code } = validateBody(req, totpCodeSchema)
     const { backupCodes } = await user.confirmTotpEnrollment.execute({ userId, code })
@@ -62,7 +63,7 @@ export function buildUserRouter(user: UserModule): Router {
   }))
 
   // Disable 2FA: requires current password + a valid TOTP/backup code.
-  router.delete('/2fa', controller(async (req: AuthRequest, res) => {
+  router.delete('/2fa', totpRateLimiter, controller(async (req: AuthRequest, res) => {
     const userId = requireUserId(req)
     const { password, code } = validateBody(req, disableTotpSchema)
     await user.disableTotp.execute({ userId, password, code })

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -14,7 +14,7 @@ const clientDist = path.resolve(__dirname, "../../client/dist")
 
 const DEV_CORS_ORIGINS = ["http://localhost:5173", "http://localhost:5174"]
 
-function resolveCorsOrigins(): string[] {
+export function resolveCorsOrigins(): string[] {
   const fromEnv = process.env.CORS_ORIGINS?.split(",").map((o) => o.trim()).filter(Boolean)
   if (fromEnv && fromEnv.length > 0) return fromEnv
   // No origins configured: only fall back to localhost outside production.

--- a/src/composition/conciliationModule.ts
+++ b/src/composition/conciliationModule.ts
@@ -65,7 +65,7 @@ export function buildConciliationModule(container: ContainerBase): ConciliationM
   const accountRepo = container.account.accountRepository
   const userRepo = container.user.userRepository
 
-  const bankTransactionFinder = new BankTransactionFinderAdapter(container.pool, bankTxRepo)
+  const bankTransactionFinder = new BankTransactionFinderAdapter(exec, bankTxRepo)
   const configReader = new AccountConfigReaderAdapter(container.pool)
   const accountReader = new AccountReaderAdapter(accountRepo)
   const userModeReader = new UserOperationModeReaderAdapter(userRepo)

--- a/src/composition/userModule.ts
+++ b/src/composition/userModule.ts
@@ -77,10 +77,10 @@ export function buildUserModule(container: ContainerBase): UserModule {
     verifyTotpLogin: new VerifyTotpLoginUseCase(userRepository, tokenIssuer, twoFactor),
     startTotpEnrollment: new StartTotpEnrollmentUseCase(userRepository, totp),
     confirmTotpEnrollment: new ConfirmTotpEnrollmentUseCase(
-      userRepository, totp, backupCodeRepository, passwordHasher
+      userRepository, totp, backupCodeRepository, passwordHasher, container.unitOfWork
     ),
     disableTotp: new DisableTotpUseCase(
-      userRepository, passwordHasher, backupCodeRepository, twoFactor
+      userRepository, passwordHasher, backupCodeRepository, twoFactor, container.unitOfWork
     ),
     getCurrentUser: new GetCurrentUserUseCase(userRepository),
     changeOperationMode: new ChangeOperationModeUseCase(

--- a/src/contexts/banking/application/IngestTransactionsUseCase.test.ts
+++ b/src/contexts/banking/application/IngestTransactionsUseCase.test.ts
@@ -35,4 +35,23 @@ describe('IngestTransactionsUseCase', () => {
     expect(saved).toBe(1)
     expect(txRepo.store.size).toBe(2)
   })
+
+  it('does not publish an event when the insert was a no-op (lost the concurrent dedup race)', async () => {
+    const eventBus = new InMemoryEventBus()
+    const handler = vi.fn().mockResolvedValue(undefined)
+    eventBus.subscribe('TransactionIngested', handler)
+    // The row looks absent at check time, but ON CONFLICT DO NOTHING means the
+    // INSERT did not actually persist (a concurrent process won the race).
+    const txRepo: any = {
+      withTx: () => txRepo,
+      findByExternalId: vi.fn().mockResolvedValue(null),
+      save: vi.fn().mockResolvedValue(false),
+    }
+    const useCase = new IngestTransactionsUseCase({ txRepo, eventBus })
+
+    const saved = await useCase.execute('acc-1', 'script-1', [sample('ext-1')])
+
+    expect(saved).toBe(0)
+    expect(handler).not.toHaveBeenCalled()
+  })
 })

--- a/src/contexts/banking/application/IngestTransactionsUseCase.ts
+++ b/src/contexts/banking/application/IngestTransactionsUseCase.ts
@@ -37,7 +37,10 @@ export class IngestTransactionsUseCase {
         scriptId,
         rawPayload: tx.raw,
       })
-      await txRepo.save(bankTx)
+      const inserted = await txRepo.save(bankTx)
+      // The INSERT uses ON CONFLICT DO NOTHING; if a concurrent ingest already
+      // persisted this externalId, skip the event so it is published once.
+      if (!inserted) continue
       await eventBus.publishAll(bankTx.domainEvents)
       bankTx.clearDomainEvents()
       saved += 1

--- a/src/contexts/banking/domain/IBankTransactionRepository.ts
+++ b/src/contexts/banking/domain/IBankTransactionRepository.ts
@@ -1,10 +1,15 @@
 import { BankTransaction } from './BankTransaction.js'
+import type { Tx } from '../../../shared/persistence/index.js'
 
 export interface IBankTransactionRepository {
+  withTx(tx: Tx): IBankTransactionRepository
   findById(id: string, opts?: { forUpdate?: boolean }): Promise<BankTransaction | null>
   findByExternalId(accountId: string, externalId: string): Promise<BankTransaction | null>
   findLatestExternalId(accountId: string): Promise<string | null>
-  save(tx: BankTransaction): Promise<void>
+  // Returns true only if this call actually inserted the row. False means a
+  // concurrent writer already had it (ON CONFLICT DO NOTHING) — callers must
+  // not re-publish ingestion events in that case.
+  save(tx: BankTransaction): Promise<boolean>
   markExcluded(id: string): Promise<void>
   isExcluded(id: string): Promise<boolean>
   markNotified(id: string): Promise<void>

--- a/src/contexts/banking/infrastructure/BankTransactionRepository.ts
+++ b/src/contexts/banking/infrastructure/BankTransactionRepository.ts
@@ -89,8 +89,8 @@ export class BankTransactionRepository implements IBankTransactionRepository {
     )
   }
 
-  async save(tx: BankTransaction): Promise<void> {
-    await this.executor.query(
+  async save(tx: BankTransaction): Promise<boolean> {
+    const result = await this.executor.query(
       `INSERT INTO bank_transactions
          (id, account_id, external_id, reference_hash, amount, currency, sender_name, received_at, script_id, ingested_at, raw_payload)
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,now(),$10)
@@ -108,5 +108,6 @@ export class BankTransactionRepository implements IBankTransactionRepository {
         JSON.stringify(tx.rawPayload),
       ]
     )
+    return (result.rowCount ?? 0) > 0
   }
 }

--- a/src/contexts/banking/infrastructure/SessionManager.test.ts
+++ b/src/contexts/banking/infrastructure/SessionManager.test.ts
@@ -174,6 +174,19 @@ describe('SessionManager', () => {
     expect(log.warn).toHaveBeenCalledWith('session stopped', { accountId: 'acc-1', reason: 'auth_timeout' })
   })
 
+  it('catches a failure while recording the stop so it is not an unhandled rejection', async () => {
+    const repo = { markRunning: vi.fn().mockResolvedValue(undefined), markStopped: vi.fn().mockRejectedValue(new Error('db down')) }
+    const log = fakeLogger()
+    const startFn = vi.fn().mockResolvedValue({ stop: vi.fn(), done: Promise.reject(new Error('boom')) } as SessionHandle)
+    const mgr = new SessionManager(startFn, repo as any, log)
+
+    await mgr.ensureRunning('acc-1')
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(repo.markStopped).toHaveBeenCalled()
+    expect(log.error).toHaveBeenCalledWith('failed to record session stop', expect.objectContaining({ accountId: 'acc-1' }))
+  })
+
   it('coerces non-Error rejections from startFn to a string for markStopped', async () => {
     const repo = sessionRepo()
     const startFn = vi.fn().mockRejectedValue('login_failed: raw string')

--- a/src/contexts/banking/infrastructure/SessionManager.ts
+++ b/src/contexts/banking/infrastructure/SessionManager.ts
@@ -86,6 +86,15 @@ export class SessionManager {
         return this.recordStop(accountId, error)
       })
       .finally(() => { this.live.delete(accountId) })
+      // recordStop itself can reject (e.g. DB down); finally does not absorb it,
+      // so without this trailing catch the rejection would be unhandled and can
+      // (Node 18+) crash the process.
+      .catch((err) => {
+        this.logger?.error('failed to record session stop', {
+          accountId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      })
   }
 
   stopAll(): void {

--- a/src/contexts/conciliation/application/OnTransactionIngestedUseCase.test.ts
+++ b/src/contexts/conciliation/application/OnTransactionIngestedUseCase.test.ts
@@ -12,6 +12,7 @@ describe('OnTransactionIngestedUseCase', () => {
     const useCase = new OnTransactionIngestedUseCase({
       requestRepo: repo,
       bankTransactionFinder: {
+        withTx() { return this },
         findCandidatesForAccount: async () => [],
         findById: async () => null,
         isExcluded: async () => false,
@@ -35,6 +36,7 @@ describe('OnTransactionIngestedUseCase', () => {
     const useCase = new OnTransactionIngestedUseCase({
       requestRepo: repo,
       bankTransactionFinder: {
+        withTx() { return this },
         findCandidatesForAccount: async () => [],
         findById: async () => null,
         isExcluded: async () => false,

--- a/src/contexts/conciliation/application/PollPendingOrdersUseCase.test.ts
+++ b/src/contexts/conciliation/application/PollPendingOrdersUseCase.test.ts
@@ -101,6 +101,24 @@ describe('PollPendingOrdersUseCase', () => {
     expect(deps.logger.info).not.toHaveBeenCalled()
   })
 
+  it('creates and enqueues only once when the same external id appears twice (idempotent create)', async () => {
+    const deps = buildDeps({
+      config: { accountId: 'acc-1', pendingOrdersEndpoint: 'https://x', pollingMethod: 'GET', authType: null, authToken: null },
+      account: { id: 'acc-1', userId: 'u-1' },
+      mode: 'reconcile',
+      orders: [
+        { externalId: 'dup', amount: 100, currency: 'USD', senderName: 'Alice' },
+        { externalId: 'dup', amount: 100, currency: 'USD', senderName: 'Alice' },
+      ],
+      cancelledCount: 0,
+    })
+    const useCase = new PollPendingOrdersUseCase(deps as any)
+    await useCase.execute({ accountId: 'acc-1' })
+
+    expect(deps.enqueueRun).toHaveBeenCalledTimes(1)
+    expect([...deps.requestRepo.store.values()].filter((r) => r.externalId === 'dup')).toHaveLength(1)
+  })
+
   it('logs cancellations when cancelledCount > 0', async () => {
     const deps = buildDeps({
       config: { accountId: 'acc-1', pendingOrdersEndpoint: 'https://x', pollingMethod: 'GET', authType: null, authToken: null },

--- a/src/contexts/conciliation/application/PollPendingOrdersUseCase.ts
+++ b/src/contexts/conciliation/application/PollPendingOrdersUseCase.ts
@@ -52,8 +52,11 @@ export class PollPendingOrdersUseCase {
         currency: order.currency,
         senderName: order.senderName,
       })
-      await requestRepo.save(request)
-      await enqueueRun(request.id)
+      // Conflict-safe insert: under concurrent polls only the winner inserts
+      // and enqueues, so a duplicate (account_id, external_id) never crashes the
+      // job nor double-enqueues.
+      const created = await requestRepo.createIfAbsent(request)
+      if (created) await enqueueRun(request.id)
     }
 
     const cancelledCount = await requestRepo.cancelMissing(accountId, seenExternalIds)

--- a/src/contexts/conciliation/application/ProcessIncomingTransactionUseCase.test.ts
+++ b/src/contexts/conciliation/application/ProcessIncomingTransactionUseCase.test.ts
@@ -41,12 +41,15 @@ function makeDeps(overrides: {
     publish: vi.fn().mockResolvedValue(undefined),
     publishAll: vi.fn().mockResolvedValue(undefined),
   }
-  const bankTransactionFinder = {
+  const bankTransactionFinder: any = {
     findCandidatesForAccount: vi.fn(),
     findById: vi.fn().mockResolvedValue(overrides.view === undefined ? null : overrides.view),
     isExcluded: vi.fn().mockResolvedValue(overrides.excluded ?? false),
     markExcluded: vi.fn().mockResolvedValue(undefined),
   }
+  // The finder must be rebound to the unit-of-work transaction so its
+  // FOR UPDATE lock and markExcluded run on the transaction's connection.
+  bankTransactionFinder.withTx = vi.fn(() => bankTransactionFinder)
   const engine = {
     evaluate: vi.fn().mockReturnValue(overrides.engineResult ?? MatchResult.notFound()),
   }
@@ -135,6 +138,60 @@ describe('ProcessIncomingTransactionUseCase', () => {
     expect(winning.status).toBe('matched')
     expect(winning.domainEvents).toHaveLength(0)
     expect(deps.engine.evaluate).toHaveBeenCalledTimes(1)
+  })
+
+  it('aborts cleanly (no throw, no events) when another request already claimed the transaction', async () => {
+    const winning = ConciliationRequest.create('req-win', {
+      accountId: 'acc-1', externalId: 'ext-win',
+      expectedAmount: 100, currency: 'USD', senderName: 'Alice',
+    })
+    const deps = makeDeps({
+      view: { id: 'tx-1', accountId: 'acc-1', amount: 100, currency: 'USD', senderName: 'Alice', receivedAt: new Date() },
+      pending: [winning],
+    })
+    deps.engine.evaluate.mockReturnValueOnce(MatchResult.matched('tx-1', ['tx-1']))
+    // The 043 unique index fires because a concurrent execution won the race.
+    deps.matchRepo.save.mockImplementation(async () => {
+      const e: any = new Error('duplicate key value violates unique constraint')
+      e.code = '23505'
+      e.constraint = 'uq_conciliated_bank_tx_primary'
+      throw e
+    })
+
+    const useCase = new ProcessIncomingTransactionUseCase(deps as any)
+    await expect(useCase.execute({ transactionId: 'tx-1' })).resolves.toBeUndefined()
+    expect(deps.eventBus.publishAll).not.toHaveBeenCalled()
+  })
+
+  it('rethrows a non-unique-violation persistence error', async () => {
+    const winning = ConciliationRequest.create('req-win', {
+      accountId: 'acc-1', externalId: 'ext-win',
+      expectedAmount: 100, currency: 'USD', senderName: 'Alice',
+    })
+    const deps = makeDeps({
+      view: { id: 'tx-1', accountId: 'acc-1', amount: 100, currency: 'USD', senderName: 'Alice', receivedAt: new Date() },
+      pending: [winning],
+    })
+    deps.engine.evaluate.mockReturnValueOnce(MatchResult.matched('tx-1', ['tx-1']))
+    deps.matchRepo.save.mockRejectedValue(new Error('connection terminated'))
+
+    const useCase = new ProcessIncomingTransactionUseCase(deps as any)
+    await expect(useCase.execute({ transactionId: 'tx-1' })).rejects.toThrow(/connection terminated/)
+  })
+
+  it('binds the bank-transaction finder to the unit-of-work transaction', async () => {
+    const req = ConciliationRequest.create('req-1', {
+      accountId: 'acc-1', externalId: 'ext-1',
+      expectedAmount: 100, currency: 'USD', senderName: 'Alice',
+    })
+    const deps = makeDeps({
+      view: { id: 'tx-1', accountId: 'acc-1', amount: 100, currency: 'USD', senderName: 'Alice', receivedAt: new Date() },
+      pending: [req],
+      engineResult: MatchResult.matched('tx-1', ['tx-1']),
+    })
+    const useCase = new ProcessIncomingTransactionUseCase(deps as any)
+    await useCase.execute({ transactionId: 'tx-1' })
+    expect(deps.bankTransactionFinder.withTx).toHaveBeenCalledTimes(1)
   })
 
   it('breaks early on first matching candidate without evaluating remaining', async () => {

--- a/src/contexts/conciliation/application/ProcessIncomingTransactionUseCase.ts
+++ b/src/contexts/conciliation/application/ProcessIncomingTransactionUseCase.ts
@@ -1,5 +1,7 @@
 import crypto from 'crypto'
 import { IUnitOfWork } from '../../../shared/persistence/IUnitOfWork.js'
+import { isUniqueViolation } from '../../../shared/persistence/pgErrors.js'
+import { logger } from '../../../shared/logger/index.js'
 import { IEventBus } from '../../../shared/events/IEventBus.js'
 import {
   ConciliationEngine,
@@ -29,14 +31,17 @@ export class ProcessIncomingTransactionUseCase {
   async execute({ transactionId }: JobData): Promise<void> {
     const { unitOfWork, eventBus, engine, requestRepo, attemptRepo, matchRepo, bankTransactionFinder } = this.deps
 
-    const matchedRequest = await unitOfWork.run(async (tx) => {
+    let matchedRequest
+    try {
+      matchedRequest = await unitOfWork.run(async (tx) => {
       const txRequestRepo = requestRepo.withTx(tx)
       const txAttemptRepo = attemptRepo.withTx(tx)
       const txMatchRepo = matchRepo.withTx(tx)
+      const txFinder = bankTransactionFinder.withTx(tx)
 
-      const view = await bankTransactionFinder.findById(transactionId, { forUpdate: true })
+      const view = await txFinder.findById(transactionId, { forUpdate: true })
       if (!view) return null
-      if (await bankTransactionFinder.isExcluded(transactionId)) return null
+      if (await txFinder.isExcluded(transactionId)) return null
 
       const candidate: CandidateTransaction = {
         id: view.id,
@@ -64,7 +69,7 @@ export class ProcessIncomingTransactionUseCase {
       }
 
       if (!winner) {
-        await bankTransactionFinder.markExcluded(transactionId)
+        await txFinder.markExcluded(transactionId)
         return null
       }
 
@@ -89,9 +94,19 @@ export class ProcessIncomingTransactionUseCase {
       })
 
       await txRequestRepo.save(winner)
-      await bankTransactionFinder.markExcluded(transactionId)
+      await txFinder.markExcluded(transactionId)
       return winner
-    })
+      })
+    } catch (err) {
+      // The 043 partial unique index means a concurrent execution already
+      // conciliated this transaction as primary. Abort cleanly: the unit of work
+      // rolled back, leaving the winning match intact.
+      if (isUniqueViolation(err, 'uq_conciliated_bank_tx_primary')) {
+        logger.info('[conciliation] lost double-match race; transaction already conciliated', { transactionId })
+        return
+      }
+      throw err
+    }
 
     if (!matchedRequest) return
 

--- a/src/contexts/conciliation/application/RunConciliationUseCase.test.ts
+++ b/src/contexts/conciliation/application/RunConciliationUseCase.test.ts
@@ -17,22 +17,25 @@ function buildSut(candidates: any[]) {
   const attemptRepo = new InMemoryConciliationAttemptRepository()
   const eventBus = new InMemoryEventBus()
   const excluded = new Set<string>()
-  const finder: IBankTransactionFinder = {
+  const finder: any = {
     findCandidatesForAccount: async () => candidates,
     findById: async () => null,
-    isExcluded: async (id) => excluded.has(id),
-    markExcluded: async (id) => { excluded.add(id) },
+    isExcluded: async (id: string) => excluded.has(id),
+    markExcluded: async (id: string) => { excluded.add(id) },
   }
+  // Rebound to the transaction so candidate reads and markExcluded share the
+  // unit-of-work connection. The fake returns itself.
+  finder.withTx = vi.fn(() => finder)
   const uow = new InMemoryUnitOfWork()
   const useCase = new RunConciliationUseCase({
     unitOfWork: uow, eventBus,
     requestRepo: requestRepo as any,
     attemptRepo: attemptRepo as any,
     matchRepo: matchRepo as any,
-    bankTransactionFinder: finder,
+    bankTransactionFinder: finder as IBankTransactionFinder,
     engine: new ConciliationEngine(),
   })
-  return { useCase, requestRepo, matchRepo, attemptRepo, eventBus, excluded }
+  return { useCase, requestRepo, matchRepo, attemptRepo, eventBus, excluded, finder }
 }
 
 describe('RunConciliationUseCase', () => {
@@ -105,6 +108,56 @@ describe('RunConciliationUseCase', () => {
     expect(requestRepo.store.get('req-1')!.status).toBe('ambiguous')
     expect(attemptRepo.attempts[0].status).toBe('ambiguous')
     expect(attemptRepo.attempts[0].failureType).toBe('multiple_candidates')
+  })
+
+  it('binds the bank-transaction finder to the unit-of-work transaction', async () => {
+    const req = ConciliationRequest.create('req-1', {
+      accountId: 'acc-1', externalId: 'ext-1',
+      expectedAmount: 100, currency: 'USD', senderName: 'Alice',
+    })
+    const { useCase, requestRepo, finder } = buildSut([
+      { id: 'tx-1', amount: 100, currency: 'USD', senderName: 'Alice', receivedAt: new Date() },
+    ])
+    requestRepo.store.set(req.id, req)
+    await useCase.execute({ requestId: 'req-1' })
+    expect(finder.withTx).toHaveBeenCalledTimes(1)
+  })
+
+  it('aborts cleanly (no throw, no events) when another request already claimed the transaction', async () => {
+    const req = ConciliationRequest.create('req-1', {
+      accountId: 'acc-1', externalId: 'ext-1',
+      expectedAmount: 100, currency: 'USD', senderName: 'Alice',
+    })
+    const { useCase, requestRepo, matchRepo, eventBus } = buildSut([
+      { id: 'tx-1', amount: 100, currency: 'USD', senderName: 'Alice', receivedAt: new Date() },
+    ])
+    requestRepo.store.set(req.id, req)
+    const handler = vi.fn().mockResolvedValue(undefined)
+    eventBus.subscribe('ConciliationMatched', handler)
+    // The DB backstop fires because a concurrent execution won the race.
+    matchRepo.save = async () => {
+      const e: any = new Error('duplicate key value violates unique constraint')
+      e.code = '23505'
+      e.constraint = 'uq_conciliated_bank_tx_primary'
+      throw e
+    }
+
+    await expect(useCase.execute({ requestId: 'req-1' })).resolves.toBeUndefined()
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('rethrows a non-unique-violation persistence error', async () => {
+    const req = ConciliationRequest.create('req-1', {
+      accountId: 'acc-1', externalId: 'ext-1',
+      expectedAmount: 100, currency: 'USD', senderName: 'Alice',
+    })
+    const { useCase, requestRepo, matchRepo } = buildSut([
+      { id: 'tx-1', amount: 100, currency: 'USD', senderName: 'Alice', receivedAt: new Date() },
+    ])
+    requestRepo.store.set(req.id, req)
+    matchRepo.save = async () => { throw new Error('connection terminated') }
+
+    await expect(useCase.execute({ requestId: 'req-1' })).rejects.toThrow(/connection terminated/)
   })
 
   it('publishes domain events when match occurs', async () => {

--- a/src/contexts/conciliation/application/RunConciliationUseCase.ts
+++ b/src/contexts/conciliation/application/RunConciliationUseCase.ts
@@ -1,5 +1,7 @@
 import crypto from 'crypto'
 import { IUnitOfWork } from '../../../shared/persistence/IUnitOfWork.js'
+import { isUniqueViolation } from '../../../shared/persistence/pgErrors.js'
+import { logger } from '../../../shared/logger/index.js'
 import { IEventBus } from '../../../shared/events/IEventBus.js'
 import { ConciliationEngine } from '../domain/ConciliationEngine.js'
 import { ConciliationRequestRepository } from '../infrastructure/ConciliationRequestRepository.js'
@@ -25,16 +27,19 @@ export class RunConciliationUseCase {
   async execute({ requestId }: JobData): Promise<void> {
     const { unitOfWork, eventBus, engine, requestRepo, attemptRepo, matchRepo, bankTransactionFinder } = this.deps
 
-    const outcome = await unitOfWork.run(async (tx) => {
+    let outcome: { request: import('../domain/ConciliationRequest.js').ConciliationRequest; resultStatus: string } | null
+    try {
+      outcome = await unitOfWork.run(async (tx) => {
       const txRequestRepo = requestRepo.withTx(tx)
       const txAttemptRepo = attemptRepo.withTx(tx)
       const txMatchRepo = matchRepo.withTx(tx)
+      const txFinder = bankTransactionFinder.withTx(tx)
 
       const request = await txRequestRepo.findByIdForUpdate(requestId)
       if (!request) return null
       if (request.isTerminal()) return null
 
-      const candidates = await bankTransactionFinder.findCandidatesForAccount(request.accountId)
+      const candidates = await txFinder.findCandidatesForAccount(request.accountId)
 
       const result = engine.evaluate(
         {
@@ -59,7 +64,7 @@ export class RunConciliationUseCase {
           requestId,
           bankTransactionId: result.transactionId!,
         })
-        await bankTransactionFinder.markExcluded(result.transactionId!)
+        await txFinder.markExcluded(result.transactionId!)
         await txAttemptRepo.save({
           id: attemptId,
           accountId: request.accountId,
@@ -85,7 +90,18 @@ export class RunConciliationUseCase {
 
       await txRequestRepo.save(request)
       return { request, resultStatus: result.status }
-    })
+      })
+    } catch (err) {
+      // The 043 partial unique index (the loser of a concurrent double-match)
+      // means another execution already conciliated this transaction. Abort
+      // cleanly: the unit of work rolled back, and a later run re-evaluates the
+      // request against the now-excluded transaction.
+      if (isUniqueViolation(err, 'uq_conciliated_bank_tx_primary')) {
+        logger.info('[conciliation] lost double-match race; another request claimed the transaction', { requestId })
+        return
+      }
+      throw err
+    }
 
     if (!outcome) return
 

--- a/src/contexts/conciliation/domain/IConciliationRequestRepository.ts
+++ b/src/contexts/conciliation/domain/IConciliationRequestRepository.ts
@@ -13,5 +13,9 @@ export interface IConciliationRequestRepository {
   findStale(olderThan: Date, limit?: number): Promise<StaleRequestRef[]>
   hasActiveRequests(accountId: string): Promise<boolean>
   save(request: ConciliationRequest): Promise<void>
+  // Inserts a brand-new request, tolerating a concurrent insert of the same
+  // (account_id, external_id). Returns true only if this call inserted the row,
+  // so the caller enqueues processing exactly once.
+  createIfAbsent(request: ConciliationRequest): Promise<boolean>
   cancelMissing(accountId: string, presentExternalIds: string[]): Promise<number>
 }

--- a/src/contexts/conciliation/domain/ports/IBankTransactionFinder.ts
+++ b/src/contexts/conciliation/domain/ports/IBankTransactionFinder.ts
@@ -15,7 +15,13 @@ export interface BankTransactionView {
   receivedAt: Date
 }
 
+import type { Tx } from '../../../../shared/persistence/index.js'
+
 export interface IBankTransactionFinder {
+  // Rebinds every query to the given transaction so FOR UPDATE locks and
+  // markExcluded run on the unit-of-work connection (not an autocommit pooled
+  // one, where the lock would release immediately).
+  withTx(tx: Tx): IBankTransactionFinder
   findCandidatesForAccount(accountId: string): Promise<BankTransactionCandidate[]>
   findById(id: string, opts?: { forUpdate?: boolean }): Promise<BankTransactionView | null>
   isExcluded(id: string): Promise<boolean>

--- a/src/contexts/conciliation/domain/rules/DateWindowRule.ts
+++ b/src/contexts/conciliation/domain/rules/DateWindowRule.ts
@@ -1,7 +1,16 @@
 import { CandidateTransaction, RequestData } from '../ConciliationEngine.js'
 
 export function applyDateWindowRule(request: RequestData, candidates: CandidateTransaction[], windowDays = 5): CandidateTransaction[] {
-  const from = new Date(request.createdAt)
-  from.setDate(from.getDate() - windowDays)
-  return candidates.filter(t => t.receivedAt >= from)
+  // Bounded on both sides around createdAt: a small backward window absorbs
+  // clock skew, and the forward bound stops a request from matching a
+  // transaction received arbitrarily far in the future. Millisecond math keeps
+  // the window timezone-independent (setDate/getDate would shift by local TZ).
+  const windowMs = windowDays * 24 * 60 * 60 * 1000
+  const created = request.createdAt.getTime()
+  const from = created - windowMs
+  const to = created + windowMs
+  return candidates.filter(t => {
+    const at = t.receivedAt.getTime()
+    return at >= from && at <= to
+  })
 }

--- a/src/contexts/conciliation/domain/rules/rules.test.ts
+++ b/src/contexts/conciliation/domain/rules/rules.test.ts
@@ -37,6 +37,16 @@ describe('applyDateWindowRule', () => {
     const tooOld = tx({ receivedAt: new Date('2023-12-01T00:00:00Z') })
     expect(applyDateWindowRule(request(), [tooOld])).toEqual([])
   })
+
+  it('rejects transactions received far after createdAt (window is bounded forward too)', () => {
+    const future = tx({ id: 'future', receivedAt: new Date('2024-02-01T00:00:00Z') })
+    expect(applyDateWindowRule(request(), [future])).toEqual([])
+  })
+
+  it('keeps a transaction received shortly after createdAt within the forward window', () => {
+    const justAfter = tx({ id: 'after', receivedAt: new Date('2024-01-18T00:00:00Z') })
+    expect(applyDateWindowRule(request(), [justAfter]).map((t) => t.id)).toEqual(['after'])
+  })
 })
 
 describe('applyExactAmountRule', () => {

--- a/src/contexts/conciliation/infrastructure/ConciliationRequestRepository.ts
+++ b/src/contexts/conciliation/infrastructure/ConciliationRequestRepository.ts
@@ -21,6 +21,31 @@ export class ConciliationRequestRepository implements IConciliationRequestReposi
     return rows[0] ? ConciliationRequestRowMapper.toAggregate(rows[0]) : null
   }
 
+  async createIfAbsent(request: ConciliationRequest): Promise<boolean> {
+    // ON CONFLICT on the natural key (not id) so two concurrent polls inserting
+    // the same order do not raise a unique violation — the loser is a no-op.
+    const result = await this.executor.query(
+      `INSERT INTO conciliation_requests
+         (id, account_id, external_id, expected_amount, currency, sender_name, status, idempotency_key, retry_count, last_checked_at, created_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+       ON CONFLICT (account_id, external_id) DO NOTHING`,
+      [
+        request.id,
+        request.accountId,
+        request.externalId,
+        request.expectedAmount,
+        request.currency,
+        request.senderName ?? null,
+        request.status,
+        request.idempotencyKey ?? null,
+        request.retryCount,
+        request.lastCheckedAt ?? null,
+        request.createdAt,
+      ]
+    )
+    return (result.rowCount ?? 0) > 0
+  }
+
   async findByIdForUpdate(id: string): Promise<ConciliationRequest | null> {
     const { rows } = await this.executor.query<ConciliationRequestRow>(
       `SELECT * FROM conciliation_requests WHERE id = $1 FOR UPDATE SKIP LOCKED`,

--- a/src/contexts/conciliation/infrastructure/adapters/BankTransactionFinderAdapter.test.ts
+++ b/src/contexts/conciliation/infrastructure/adapters/BankTransactionFinderAdapter.test.ts
@@ -103,4 +103,26 @@ describe('BankTransactionFinderAdapter', () => {
     await adapter.markExcluded('tx-1')
     expect(repo.markExcluded).toHaveBeenCalledWith('tx-1')
   })
+
+  describe('withTx', () => {
+    it('rebinds both the executor and the repo to the transaction', async () => {
+      const txRepo = { markExcluded: vi.fn().mockResolvedValue(undefined) }
+      const baseRepo = { withTx: vi.fn(() => txRepo) }
+      const tx = { query: vi.fn().mockResolvedValue({ rows: [] }) }
+      const poolExec = { query: vi.fn().mockResolvedValue({ rows: [] }) }
+      const adapter = new BankTransactionFinderAdapter(poolExec as any, baseRepo as any)
+
+      const bound = adapter.withTx(tx as any)
+      expect(baseRepo.withTx).toHaveBeenCalledWith(tx)
+
+      // Candidate query now runs on the transaction's connection, not the pool.
+      await bound.findCandidatesForAccount('acc-1')
+      expect(tx.query).toHaveBeenCalledTimes(1)
+      expect(poolExec.query).not.toHaveBeenCalled()
+
+      // Delegated writes go through the transaction-bound repo.
+      await bound.markExcluded('tx-1')
+      expect(txRepo.markExcluded).toHaveBeenCalledWith('tx-1')
+    })
+  })
 })

--- a/src/contexts/conciliation/infrastructure/adapters/BankTransactionFinderAdapter.ts
+++ b/src/contexts/conciliation/infrastructure/adapters/BankTransactionFinderAdapter.ts
@@ -1,5 +1,6 @@
-import type pg from 'pg'
 import type { IBankTransactionRepository } from '../../../banking/domain/IBankTransactionRepository.js'
+import type { Tx } from '../../../../shared/persistence/index.js'
+import { Executor } from '../../infrastructure/Executor.js'
 import {
   IBankTransactionFinder,
   BankTransactionCandidate,
@@ -8,12 +9,19 @@ import {
 
 export class BankTransactionFinderAdapter implements IBankTransactionFinder {
   constructor(
-    private readonly pool: pg.Pool,
+    private readonly executor: Executor,
     private readonly bankTxRepo: IBankTransactionRepository
   ) {}
 
+  // All four methods share the same connection. Inside a unit of work the
+  // caller passes the transaction so FOR UPDATE / markExcluded are serialized
+  // against concurrent conciliation; outside one, the pool is fine.
+  withTx(tx: Tx): IBankTransactionFinder {
+    return new BankTransactionFinderAdapter(tx, this.bankTxRepo.withTx(tx))
+  }
+
   async findCandidatesForAccount(accountId: string): Promise<BankTransactionCandidate[]> {
-    const { rows } = await this.pool.query(
+    const { rows } = await this.executor.query(
       `SELECT id, amount, currency, sender_name, received_at
          FROM bank_transactions
         WHERE account_id = $1 AND excluded_at IS NULL`,

--- a/src/contexts/conciliation/infrastructure/adapters/HttpOrderSource.test.ts
+++ b/src/contexts/conciliation/infrastructure/adapters/HttpOrderSource.test.ts
@@ -1,4 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// assertSafeUrl has its own SSRF tests and does real DNS; mock it here so these
+// tests stay offline and we can drive the "blocked at send time" path.
+const { assertSafeUrlMock } = vi.hoisted(() => ({ assertSafeUrlMock: vi.fn() }))
+vi.mock('../../../../shared/net/assertSafeUrl.js', () => ({ assertSafeUrl: assertSafeUrlMock }))
+
 import { HttpOrderSource } from './HttpOrderSource.js'
 import { ValidationError } from '../../../../shared/errors/index.js'
 
@@ -28,10 +34,56 @@ describe('HttpOrderSource', () => {
   beforeEach(() => {
     fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
+    assertSafeUrlMock.mockReset()
+    assertSafeUrlMock.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
     vi.unstubAllGlobals()
+  })
+
+  it('re-validates the endpoint right before polling (closes the config→poll TOCTOU window)', async () => {
+    fetchMock.mockResolvedValue(makeResponse({ contentType: 'application/json', json: async () => [] }))
+    const src = new HttpOrderSource()
+    await src.fetch({
+      accountId: 'acc-1',
+      pendingOrdersEndpoint: 'https://example.com/pending',
+      pollingMethod: 'GET',
+      pollingBody: null,
+      authType: null,
+      authToken: null,
+    } as any)
+    expect(assertSafeUrlMock).toHaveBeenCalledWith('https://example.com/pending', expect.any(String))
+  })
+
+  it('does not poll when the endpoint now resolves to a blocked address', async () => {
+    assertSafeUrlMock.mockRejectedValueOnce(new Error('blocked: private address'))
+    const src = new HttpOrderSource()
+    await expect(
+      src.fetch({
+        accountId: 'acc-1',
+        pendingOrdersEndpoint: 'https://rebound.example.com/pending',
+        pollingMethod: 'GET',
+        pollingBody: null,
+        authType: null,
+        authToken: null,
+      } as any),
+    ).rejects.toThrow(/blocked/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('disallows following redirects (SSRF: a polling endpoint must not 3xx us to an internal IP)', async () => {
+    fetchMock.mockResolvedValue(makeResponse({ contentType: 'application/json', json: async () => [] }))
+    const src = new HttpOrderSource()
+    await src.fetch({
+      accountId: 'acc-1',
+      pendingOrdersEndpoint: 'https://example.com/pending',
+      pollingMethod: 'GET',
+      pollingBody: null,
+      authType: null,
+      authToken: null,
+    })
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ redirect: 'error' })
   })
 
   it('returns [] without calling fetch when no endpoint is configured', async () => {

--- a/src/contexts/conciliation/infrastructure/adapters/HttpOrderSource.ts
+++ b/src/contexts/conciliation/infrastructure/adapters/HttpOrderSource.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { IOrderSource, PendingOrder } from '../../domain/ports/IOrderSource.js'
 import { PollingConfig } from '../../domain/ports/IAccountConfigReader.js'
 import { ValidationError } from '../../../../shared/errors/index.js'
+import { assertSafeUrl } from '../../../../shared/net/assertSafeUrl.js'
 import type { ILogger } from '../../../../shared/logger/ILogger.js'
 
 // Validates a single order from the ERP polling response. external_id may arrive
@@ -27,6 +28,11 @@ export class HttpOrderSource implements IOrderSource {
   async fetch(config: PollingConfig): Promise<PendingOrder[]> {
     if (!config.pendingOrdersEndpoint) return []
 
+    // Re-validate at poll time, not just at config write: the host may now
+    // resolve to an internal address (DNS change / TOCTOU) even if it was safe
+    // when the operator configured it.
+    await assertSafeUrl(config.pendingOrdersEndpoint, 'pending_orders_endpoint')
+
     const headers: Record<string, string> = { 'Content-Type': 'application/json' }
     if (config.authToken) {
       headers['Authorization'] =
@@ -40,6 +46,9 @@ export class HttpOrderSource implements IOrderSource {
       method: config.pollingMethod,
       headers,
       body: isPost ? JSON.stringify(config.pollingBody ?? {}) : undefined,
+      // redirect: 'error' prevents a polling endpoint from 3xx-redirecting us to
+      // an internal address after assertSafeUrl validated the configured host.
+      redirect: 'error',
       signal: AbortSignal.timeout(Number(process.env.POLLING_TIMEOUT_MS ?? 15_000)),
     })
 

--- a/src/contexts/script-engine/infrastructure/PersistentPlaywrightRunner.test.ts
+++ b/src/contexts/script-engine/infrastructure/PersistentPlaywrightRunner.test.ts
@@ -116,6 +116,16 @@ describe('PersistentPlaywrightRunner', () => {
     expect(close).toHaveBeenCalled()
   })
 
+  it('closes the context when the script body throws before the monitor starts', async () => {
+    const { close } = buildContext()
+    const runner = new PersistentPlaywrightRunner()
+
+    await expect(
+      runner.start({ ...baseInput(), scriptCode: 'throw new Error("script boom")' }),
+    ).rejects.toThrow('script boom')
+    expect(close).toHaveBeenCalled()
+  })
+
   it('stop() flips the shouldStop predicate forwarded to runMonitor', async () => {
     buildContext()
     let captured: any

--- a/src/contexts/script-engine/infrastructure/PersistentPlaywrightRunner.ts
+++ b/src/contexts/script-engine/infrastructure/PersistentPlaywrightRunner.ts
@@ -37,32 +37,39 @@ export class PersistentPlaywrightRunner {
       args: CHROMIUM_ARGS,
     })
 
-    const page = browserContext.pages()[0] ?? (await browserContext.newPage())
-    await applyAntiWebdriver(page)
+    // Once the monitor starts its .finally closes the context. Until then any
+    // failure (page setup, the script body throwing, or missing hooks) must
+    // close it here, or the browser process + on-disk profile leak.
+    try {
+      const page = browserContext.pages()[0] ?? (await browserContext.newPage())
+      await applyAntiWebdriver(page)
 
-    // Execute the script body; a hook-based script returns the hooks object.
-    const fn = new Function('page', 'context', `return (async function(page, context){\n${input.scriptCode}\n})(page, context)`)
-    const result = await fn(page, input.context)
-    if (!result || typeof result.poll !== 'function') {
-      await browserContext.close()
-      throw new Error('persistent script did not return a hooks object with a poll() function')
-    }
-    const hooks = result as ScriptHooks
+      // Execute the script body; a hook-based script returns the hooks object.
+      const fn = new Function('page', 'context', `return (async function(page, context){\n${input.scriptCode}\n})(page, context)`)
+      const result = await fn(page, input.context)
+      if (!result || typeof result.poll !== 'function') {
+        throw new Error('persistent script did not return a hooks object with a poll() function')
+      }
+      const hooks = result as ScriptHooks
 
-    let stopped = false
-    const done = runMonitor({
-      hooks,
-      page,
-      context: input.context,
-      onTransactions: input.onTransactions,
-      shouldStop: () => stopped || input.shouldStop(),
-      getBankDay: input.getBankDay,
-      pollIntervalMs: input.pollIntervalMs,
-      authTimeoutMs: input.loginMode === 'assisted' ? 300_000 : 30_000,
-    }).finally(async () => {
+      let stopped = false
+      const done = runMonitor({
+        hooks,
+        page,
+        context: input.context,
+        onTransactions: input.onTransactions,
+        shouldStop: () => stopped || input.shouldStop(),
+        getBankDay: input.getBankDay,
+        pollIntervalMs: input.pollIntervalMs,
+        authTimeoutMs: input.loginMode === 'assisted' ? 300_000 : 30_000,
+      }).finally(async () => {
+        await browserContext.close().catch(() => {})
+      })
+
+      return { stop: () => { stopped = true }, done }
+    } catch (err) {
       await browserContext.close().catch(() => {})
-    })
-
-    return { stop: () => { stopped = true }, done }
+      throw err
+    }
   }
 }

--- a/src/contexts/script-engine/infrastructure/PlaywrightRunner.test.ts
+++ b/src/contexts/script-engine/infrastructure/PlaywrightRunner.test.ts
@@ -115,6 +115,30 @@ describe('PlaywrightRunner', () => {
     expect(close).toHaveBeenCalled()
   })
 
+  it('closes the browser when context/page setup fails after launch', async () => {
+    dbQueryMock.mockResolvedValueOnce({ rows: [{ username: 'u', encrypted_password: 'p' }] })
+    const close = vi.fn().mockResolvedValue(undefined)
+    launchMock.mockResolvedValue({
+      newContext: vi.fn().mockRejectedValue(new Error('context boom')),
+      close,
+    })
+    const runner = new PlaywrightRunner()
+    await expect(
+      runner.execute({ id: 's', codeSnapshot: 'return []' } as any, { accountId: 'a', lastExternalId: null }),
+    ).rejects.toThrow('context boom')
+    expect(close).toHaveBeenCalled()
+  })
+
+  it('clears the timeout timer after the script completes (no lingering 10-min timer)', async () => {
+    dbQueryMock.mockResolvedValueOnce({ rows: [{ username: 'u', encrypted_password: 'p' }] })
+    buildBrowserChain('')
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout')
+    const runner = new PlaywrightRunner()
+    await runner.execute({ id: 's', codeSnapshot: 'return []' } as any, { accountId: 'a', lastExternalId: null })
+    expect(clearSpy).toHaveBeenCalled()
+    clearSpy.mockRestore()
+  })
+
   it('exercises the addInitScript navigator.webdriver guard', async () => {
     dbQueryMock.mockResolvedValueOnce({ rows: [{ username: 'u', encrypted_password: 'p' }] })
     const { page } = buildBrowserChain('')

--- a/src/contexts/script-engine/infrastructure/PlaywrightRunner.ts
+++ b/src/contexts/script-engine/infrastructure/PlaywrightRunner.ts
@@ -39,33 +39,37 @@ export class PlaywrightRunner {
       args: CHROMIUM_ARGS,
     })
 
-    const ctx = await browser.newContext({
-      userAgent: USER_AGENT,
-      viewport: VIEWPORT,
-      locale: 'es-UY',
-    })
-
-    const page = await ctx.newPage()
-
-    await applyAntiWebdriver(page)
-
-    const scriptContext = {
-      accountId: context.accountId,
-      username: creds.username,
-      password: credentialsCipher().decrypt(creds.encrypted_password),
-      lastExternalId: context.lastExternalId,
-      debugLog: this.logger
-        ? makeDebugLogSink(this.logger.child('[bank-scrape-script]'), { accountId: context.accountId })
-        : undefined,
-    }
-
     const TIMEOUT_MS = 10 * 60 * 1000 // 10 minutes
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
 
-    const timeout = new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error(`Script execution timed out after ${TIMEOUT_MS / 1000}s`)), TIMEOUT_MS)
-    )
-
+    // Everything after launch is wrapped so the browser is always closed — even
+    // if newContext/newPage/applyAntiWebdriver throws — and the timeout timer is
+    // always cleared (a finished scrape must not leave a 10-min timer running).
     try {
+      const ctx = await browser.newContext({
+        userAgent: USER_AGENT,
+        viewport: VIEWPORT,
+        locale: 'es-UY',
+      })
+
+      const page = await ctx.newPage()
+
+      await applyAntiWebdriver(page)
+
+      const scriptContext = {
+        accountId: context.accountId,
+        username: creds.username,
+        password: credentialsCipher().decrypt(creds.encrypted_password),
+        lastExternalId: context.lastExternalId,
+        debugLog: this.logger
+          ? makeDebugLogSink(this.logger.child('[bank-scrape-script]'), { accountId: context.accountId })
+          : undefined,
+      }
+
+      const timeout = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error(`Script execution timed out after ${TIMEOUT_MS / 1000}s`)), TIMEOUT_MS)
+      })
+
       const wrappedCode = `
         return (async function(page, context) {
           ${script.codeSnapshot}
@@ -75,6 +79,7 @@ export class PlaywrightRunner {
       const transactions: ScrapedTransaction[] = await Promise.race([fn(page, scriptContext), timeout])
       return transactions ?? []
     } finally {
+      if (timeoutId) clearTimeout(timeoutId)
       await browser.close()
     }
   }

--- a/src/contexts/script-engine/infrastructure/ScriptLoader.test.ts
+++ b/src/contexts/script-engine/infrastructure/ScriptLoader.test.ts
@@ -104,6 +104,29 @@ describe('ScriptLoader', () => {
     ).rejects.toThrow(/Script file not found/i)
   })
 
+  it('rejects a bank slug containing path-traversal characters before touching the filesystem', async () => {
+    dbQueryMock
+      .mockResolvedValueOnce({ rows: [{ id: 'bank-id' }] })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'script-id',
+          bank_code: '../../../etc/passwd',
+          flow_type: 'extract_transactions',
+          version: '1.0.0',
+          status: 'active',
+          origin: 'system',
+          base_script_id: null,
+          selector_map: {},
+          created_at: new Date(),
+        }],
+      })
+
+    await expect(
+      ScriptLoader.loadActive('whatever', 'extract_transactions'),
+    ).rejects.toThrow(/invalid bank/i)
+    expect(existsSyncMock).not.toHaveBeenCalled()
+  })
+
   it('slugifies bank names with internal whitespace before resolving the file path', async () => {
     dbQueryMock
       .mockResolvedValueOnce({ rows: [{ id: 'bank-id' }] })

--- a/src/contexts/script-engine/infrastructure/ScriptLoader.ts
+++ b/src/contexts/script-engine/infrastructure/ScriptLoader.ts
@@ -8,8 +8,15 @@ const scriptsDir = path.resolve(fileURLToPath(new URL('.', import.meta.url)), 's
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
+const BANK_SLUG_RE = /^[a-z0-9-]+$/
+
 function loadScriptCode(bank: string, flowType: string, version: string): string {
   const bankSlug = bank.toLowerCase().replace(/\s+/g, '')
+  // The slug is interpolated into a filesystem path; reject anything that could
+  // traverse out of scriptsDir (e.g. "../") before touching disk.
+  if (!BANK_SLUG_RE.test(bankSlug)) {
+    throw new Error(`invalid bank slug: ${bank}`)
+  }
   const filePath = path.join(scriptsDir, bankSlug, `${flowType}.v${version}.js`)
   if (!existsSync(filePath)) {
     throw new Error(`Script file not found: ${filePath}`)

--- a/src/contexts/user/application/ConfirmTotpEnrollmentUseCase.ts
+++ b/src/contexts/user/application/ConfirmTotpEnrollmentUseCase.ts
@@ -2,6 +2,7 @@ import { IUserRepository } from '../domain/IUserRepository.js'
 import { ITotpProvider } from '../domain/ports/ITotpProvider.js'
 import { IBackupCodeRepository } from '../domain/IBackupCodeRepository.js'
 import { IPasswordHasher } from '../domain/ports/IPasswordHasher.js'
+import { IUnitOfWork } from '../../../shared/persistence/IUnitOfWork.js'
 import { ConflictError, NotFoundError, UnauthorizedError, ValidationError } from '../../../shared/errors/index.js'
 import { generateBackupCodes, normalizeBackupCode } from './backupCodes.js'
 
@@ -25,6 +26,7 @@ export class ConfirmTotpEnrollmentUseCase {
     private readonly totp: ITotpProvider,
     private readonly backupCodes: IBackupCodeRepository,
     private readonly hasher: IPasswordHasher,
+    private readonly unitOfWork: IUnitOfWork,
   ) {}
 
   async execute(input: Input): Promise<Output> {
@@ -33,17 +35,25 @@ export class ConfirmTotpEnrollmentUseCase {
     if (user.isTotpEnabled()) throw new ConflictError('2FA is already enabled')
     if (!user.totpSecret) throw new ValidationError('No enrollment in progress')
 
-    const ok = await this.totp.verify(user.totpSecret, input.code)
-    if (!ok) throw new UnauthorizedError('Invalid code')
+    const { valid, timeStep } = await this.totp.verify(user.totpSecret, input.code)
+    if (!valid) throw new UnauthorizedError('Invalid code')
 
     user.confirmTotp()
-    await this.userRepo.save(user)
+    // Consume the verified step now so this same code can't be replayed at the
+    // user's first login (verifyTwoFactorCode rejects steps <= totpLastStep).
+    if (timeStep !== undefined) user.recordTotpStep(timeStep)
 
     const codes = generateBackupCodes()
     const hashes = await Promise.all(
       codes.map((c) => this.hasher.hash(normalizeBackupCode(c))),
     )
-    await this.backupCodes.replaceForUser(user.id, hashes)
+
+    // Enabling 2FA and writing the backup codes must be atomic: a partial
+    // failure would otherwise leave 2FA enabled with no recovery codes.
+    await this.unitOfWork.run(async (tx) => {
+      await this.userRepo.withTx(tx).save(user)
+      await this.backupCodes.withTx(tx).replaceForUser(user.id, hashes)
+    })
 
     return { backupCodes: codes }
   }

--- a/src/contexts/user/application/DisableTotpUseCase.ts
+++ b/src/contexts/user/application/DisableTotpUseCase.ts
@@ -1,6 +1,7 @@
 import { IUserRepository } from '../domain/IUserRepository.js'
 import { IPasswordHasher } from '../domain/ports/IPasswordHasher.js'
 import { IBackupCodeRepository } from '../domain/IBackupCodeRepository.js'
+import { IUnitOfWork } from '../../../shared/persistence/IUnitOfWork.js'
 import { NotFoundError, UnauthorizedError, ValidationError } from '../../../shared/errors/index.js'
 import { verifyTwoFactorCode, TwoFactorDeps } from './verifyTwoFactorCode.js'
 
@@ -20,6 +21,7 @@ export class DisableTotpUseCase {
     private readonly passwordHasher: IPasswordHasher,
     private readonly backupCodes: IBackupCodeRepository,
     private readonly twoFactor: TwoFactorDeps,
+    private readonly unitOfWork: IUnitOfWork,
   ) {}
 
   async execute(input: Input): Promise<void> {
@@ -34,7 +36,11 @@ export class DisableTotpUseCase {
     if (!codeOk) throw new UnauthorizedError('Invalid code')
 
     user.disableTotp()
-    await this.userRepo.save(user)
-    await this.backupCodes.deleteForUser(user.id)
+    // Clearing the secret and deleting backup codes must be atomic so we never
+    // leave stale recovery codes behind a disabled 2FA.
+    await this.unitOfWork.run(async (tx) => {
+      await this.userRepo.withTx(tx).save(user)
+      await this.backupCodes.withTx(tx).deleteForUser(user.id)
+    })
   }
 }

--- a/src/contexts/user/application/TotpEnrollment.test.ts
+++ b/src/contexts/user/application/TotpEnrollment.test.ts
@@ -5,6 +5,7 @@ import { DisableTotpUseCase } from './DisableTotpUseCase.js'
 import { User } from '../domain/User.js'
 import { InMemoryUserRepository } from '../../../../tests/helpers/inMemoryUserRepo.js'
 import { InMemoryBackupCodeRepository } from '../../../../tests/helpers/inMemoryBackupCodeRepo.js'
+import { InMemoryUnitOfWork } from '../../../../tests/helpers/inMemoryUnitOfWork.js'
 import { ConflictError, NotFoundError, UnauthorizedError, ValidationError } from '../../../shared/errors/index.js'
 import type { TwoFactorDeps } from './verifyTwoFactorCode.js'
 
@@ -16,7 +17,10 @@ const hasher = {
 const totp = {
   generateSecret: () => 'SECRET',
   keyUri: (secret: string, label: string) => `otpauth://totp/ReconBanker:${label}?secret=${secret}`,
-  verify: async (secret: string, token: string) => secret === 'SECRET' && token === '123456',
+  verify: async (secret: string, token: string) => ({
+    valid: secret === 'SECRET' && token === '123456',
+    timeStep: 100,
+  }),
 }
 
 function makeRepos() {
@@ -73,12 +77,42 @@ describe('ConfirmTotpEnrollmentUseCase', () => {
     user.beginTotpEnrollment('SECRET')
     repo.store.set(user.id, user)
 
-    const result = await new ConfirmTotpEnrollmentUseCase(repo, totp, backupCodes, hasher)
+    const result = await new ConfirmTotpEnrollmentUseCase(repo, totp, backupCodes, hasher, new InMemoryUnitOfWork())
       .execute({ userId: 'id-1', code: '123456' })
 
     expect(result.backupCodes).toHaveLength(10)
     expect((await repo.findById('id-1'))?.isTotpEnabled()).toBe(true)
     expect(await backupCodes.listActive('id-1')).toHaveLength(10)
+  })
+
+  it('records the consumed time step so the enrollment code cannot be replayed at login', async () => {
+    const { repo, backupCodes } = makeRepos()
+    const user = User.create('id-1', 'a@b.com', 'hashed:pw')
+    user.beginTotpEnrollment('SECRET')
+    repo.store.set(user.id, user)
+
+    await new ConfirmTotpEnrollmentUseCase(repo, totp, backupCodes, hasher, new InMemoryUnitOfWork())
+      .execute({ userId: 'id-1', code: '123456' })
+
+    // The provider matched time step 100; persisting it lets verifyTwoFactorCode
+    // reject a replay of the same code at the user's first login.
+    expect((await repo.findById('id-1'))?.totpLastStep).toBe(100)
+  })
+
+  it('still enables 2FA when the provider reports no time step', async () => {
+    const { repo, backupCodes } = makeRepos()
+    const user = User.create('id-1', 'a@b.com', 'hashed:pw')
+    user.beginTotpEnrollment('SECRET')
+    repo.store.set(user.id, user)
+    // A provider variant that validates but does not return a time step.
+    const totpNoStep = { ...totp, verify: async () => ({ valid: true }) }
+
+    await new ConfirmTotpEnrollmentUseCase(repo, totpNoStep, backupCodes, hasher, new InMemoryUnitOfWork())
+      .execute({ userId: 'id-1', code: '123456' })
+
+    const stored = await repo.findById('id-1')
+    expect(stored?.isTotpEnabled()).toBe(true)
+    expect(stored?.totpLastStep).toBeNull()
   })
 
   it('rejects an invalid code and keeps 2FA disabled', async () => {
@@ -88,7 +122,7 @@ describe('ConfirmTotpEnrollmentUseCase', () => {
     repo.store.set(user.id, user)
 
     await expect(
-      new ConfirmTotpEnrollmentUseCase(repo, totp, backupCodes, hasher).execute({ userId: 'id-1', code: '000000' }),
+      new ConfirmTotpEnrollmentUseCase(repo, totp, backupCodes, hasher, new InMemoryUnitOfWork()).execute({ userId: 'id-1', code: '000000' }),
     ).rejects.toBeInstanceOf(UnauthorizedError)
     expect((await repo.findById('id-1'))?.isTotpEnabled()).toBe(false)
   })
@@ -98,7 +132,7 @@ describe('ConfirmTotpEnrollmentUseCase', () => {
     const user = User.create('id-1', 'a@b.com', 'hashed:pw')
     repo.store.set(user.id, user)
     await expect(
-      new ConfirmTotpEnrollmentUseCase(repo, totp, backupCodes, hasher).execute({ userId: 'id-1', code: '123456' }),
+      new ConfirmTotpEnrollmentUseCase(repo, totp, backupCodes, hasher, new InMemoryUnitOfWork()).execute({ userId: 'id-1', code: '123456' }),
     ).rejects.toBeInstanceOf(ValidationError)
   })
 })
@@ -117,7 +151,7 @@ describe('DisableTotpUseCase', () => {
     enabledUser(repo)
     await backupCodes.replaceForUser('id-1', ['hashed:ABCDEFGHJK'])
 
-    await new DisableTotpUseCase(repo, hasher, backupCodes, deps)
+    await new DisableTotpUseCase(repo, hasher, backupCodes, deps, new InMemoryUnitOfWork())
       .execute({ userId: 'id-1', password: 'pw', code: '123456' })
 
     expect((await repo.findById('id-1'))?.isTotpEnabled()).toBe(false)
@@ -128,7 +162,7 @@ describe('DisableTotpUseCase', () => {
     const { repo, backupCodes, deps } = makeRepos()
     enabledUser(repo)
     await expect(
-      new DisableTotpUseCase(repo, hasher, backupCodes, deps).execute({ userId: 'id-1', password: 'wrong', code: '123456' }),
+      new DisableTotpUseCase(repo, hasher, backupCodes, deps, new InMemoryUnitOfWork()).execute({ userId: 'id-1', password: 'wrong', code: '123456' }),
     ).rejects.toBeInstanceOf(UnauthorizedError)
     expect((await repo.findById('id-1'))?.isTotpEnabled()).toBe(true)
   })
@@ -137,7 +171,7 @@ describe('DisableTotpUseCase', () => {
     const { repo, backupCodes, deps } = makeRepos()
     enabledUser(repo)
     await expect(
-      new DisableTotpUseCase(repo, hasher, backupCodes, deps).execute({ userId: 'id-1', password: 'pw', code: '000000' }),
+      new DisableTotpUseCase(repo, hasher, backupCodes, deps, new InMemoryUnitOfWork()).execute({ userId: 'id-1', password: 'pw', code: '000000' }),
     ).rejects.toBeInstanceOf(UnauthorizedError)
   })
 
@@ -146,7 +180,7 @@ describe('DisableTotpUseCase', () => {
     const user = User.create('id-1', 'a@b.com', 'hashed:pw')
     repo.store.set(user.id, user)
     await expect(
-      new DisableTotpUseCase(repo, hasher, backupCodes, deps).execute({ userId: 'id-1', password: 'pw', code: '123456' }),
+      new DisableTotpUseCase(repo, hasher, backupCodes, deps, new InMemoryUnitOfWork()).execute({ userId: 'id-1', password: 'pw', code: '123456' }),
     ).rejects.toBeInstanceOf(ValidationError)
   })
 })

--- a/src/contexts/user/application/VerifyTotpLoginUseCase.test.ts
+++ b/src/contexts/user/application/VerifyTotpLoginUseCase.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { VerifyTotpLoginUseCase } from './VerifyTotpLoginUseCase.js'
 import { User } from '../domain/User.js'
 import { InMemoryUserRepository } from '../../../../tests/helpers/inMemoryUserRepo.js'
@@ -14,7 +14,10 @@ const hasher = {
 const totp = {
   generateSecret: () => 'SECRET',
   keyUri: () => 'otpauth://totp/x',
-  verify: async (secret: string, token: string) => secret === 'SECRET' && token === '123456',
+  verify: async (secret: string, token: string) => ({
+    valid: secret === 'SECRET' && token === '123456',
+    timeStep: 100,
+  }),
 }
 
 const issuer = {
@@ -42,6 +45,14 @@ describe('VerifyTotpLoginUseCase', () => {
     const result = await useCase.execute({ challengeToken: 'token:2fa_pending:id-1', code: '123456' })
     expect(result.token).toBe('token:access:id-1')
     expect(result.user.email).toBe('alice@example.com')
+  })
+
+  it('persists the verified TOTP time step so the code cannot be replayed', async () => {
+    const { useCase, repo, user } = setup()
+    const saveSpy = vi.spyOn(repo, 'save')
+    await useCase.execute({ challengeToken: 'token:2fa_pending:id-1', code: '123456' })
+    expect(saveSpy).toHaveBeenCalledWith(user)
+    expect(user.totpLastStep).toBe(100)
   })
 
   it('accepts a valid backup code and consumes it', async () => {

--- a/src/contexts/user/application/VerifyTotpLoginUseCase.ts
+++ b/src/contexts/user/application/VerifyTotpLoginUseCase.ts
@@ -35,6 +35,10 @@ export class VerifyTotpLoginUseCase {
     const ok = await verifyTwoFactorCode(user, input.code, this.twoFactor)
     if (!ok) throw new UnauthorizedError('Invalid code')
 
+    // Persist the consumed TOTP time step (recorded on the user during verify)
+    // so the same code cannot be replayed on a subsequent challenge.
+    await this.userRepo.save(user)
+
     const token = this.tokenIssuer.issue({ sub: user.id, email: user.email })
     return { token, user: { id: user.id, email: user.email, name: user.name } }
   }

--- a/src/contexts/user/application/backupCodes.randomInt.test.ts
+++ b/src/contexts/user/application/backupCodes.randomInt.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Unbiased character selection must come from crypto.randomInt (uniform over the
+// alphabet), not `byte % alphabet.length` (which is biased because 256 is not a
+// multiple of 31). Controlling randomInt lets us assert the mapping directly.
+const randomIntMock = vi.fn()
+vi.mock('node:crypto', async () => {
+  const actual = await vi.importActual<typeof import('node:crypto')>('node:crypto')
+  return { ...actual, default: actual, randomInt: (...args: unknown[]) => randomIntMock(...args) }
+})
+
+const { generateBackupCode } = await import('./backupCodes.js')
+const ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789'
+
+describe('generateBackupCode unbiased selection', () => {
+  it('maps each crypto.randomInt index to the alphabet (no modulo bias)', () => {
+    let i = 0
+    // Return indices 0..9 across the 10 characters.
+    randomIntMock.mockImplementation(() => i++)
+    const code = generateBackupCode()
+    const expected = ALPHABET.slice(0, 10).split('').map((c) => c).join('')
+    expect(code).toBe(`${expected.slice(0, 5)}-${expected.slice(5)}`)
+    // randomInt called once per character with the alphabet length as bound.
+    expect(randomIntMock).toHaveBeenCalledTimes(10)
+    expect(randomIntMock).toHaveBeenCalledWith(0, ALPHABET.length)
+  })
+})

--- a/src/contexts/user/application/backupCodes.ts
+++ b/src/contexts/user/application/backupCodes.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'node:crypto'
+import { randomInt } from 'node:crypto'
 
 // Crockford-ish alphabet without easily confused characters (0/O, 1/I/L).
 const ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789'
@@ -6,9 +6,10 @@ const CODE_LEN = 10
 
 /** Generates a single human-friendly backup code, e.g. "ABCDE-FGHJK". */
 export function generateBackupCode(): string {
-  const bytes = randomBytes(CODE_LEN)
+  // randomInt is uniform over [0, length); `byte % 31` would be biased because
+  // 256 is not a multiple of the 31-character alphabet.
   let out = ''
-  for (const b of bytes) out += ALPHABET[b % ALPHABET.length]
+  for (let i = 0; i < CODE_LEN; i++) out += ALPHABET[randomInt(0, ALPHABET.length)]
   return `${out.slice(0, 5)}-${out.slice(5)}`
 }
 

--- a/src/contexts/user/application/verifyTwoFactorCode.test.ts
+++ b/src/contexts/user/application/verifyTwoFactorCode.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { verifyTwoFactorCode, type TwoFactorDeps } from './verifyTwoFactorCode.js'
 import { User } from '../domain/User.js'
 import { InMemoryBackupCodeRepository } from '../../../../tests/helpers/inMemoryBackupCodeRepo.js'
@@ -12,7 +12,10 @@ const hasher = {
 const totp = {
   generateSecret: () => 'SECRET',
   keyUri: () => 'otpauth://totp/x',
-  verify: async (secret: string, token: string) => secret === 'SECRET' && token === '123456',
+  verify: async (secret: string, token: string) => ({
+    valid: secret === 'SECRET' && token === '123456',
+    timeStep: 100,
+  }),
 }
 
 function enabledUser(): User {
@@ -37,6 +40,28 @@ describe('verifyTwoFactorCode', () => {
   it('trims surrounding whitespace before matching the TOTP code', async () => {
     const { deps } = setup()
     expect(await verifyTwoFactorCode(enabledUser(), '  123456  ', deps)).toBe(true)
+  })
+
+  it('records the matched TOTP time step on the user and forwards the last step as afterTimeStep', async () => {
+    const { backupCodes } = setup()
+    const verify = vi.fn().mockResolvedValue({ valid: true, timeStep: 55 })
+    const deps: TwoFactorDeps = { totp: { ...totp, verify } as any, backupCodes, hasher }
+    const user = enabledUser()
+    user.recordTotpStep(40)
+
+    expect(await verifyTwoFactorCode(user, '123456', deps)).toBe(true)
+    expect(verify).toHaveBeenCalledWith('SECRET', '123456', { afterTimeStep: 40 })
+    expect(user.totpLastStep).toBe(55)
+  })
+
+  it('checks every backup code without early-returning (constant-time)', async () => {
+    const { backupCodes } = setup()
+    await backupCodes.replaceForUser('id-1', ['hashed:AAAAAAAAAA', 'hashed:BBBBBBBBBB', 'hashed:CCCCCCCCCC'])
+    const verifySpy = vi.fn(async (plain: string, hash: string) => hash === `hashed:${plain}`)
+    const deps: TwoFactorDeps = { totp, backupCodes, hasher: { ...hasher, verify: verifySpy } }
+    // The first code matches, but every code must still be checked.
+    expect(await verifyTwoFactorCode(enabledUser(), 'AAAAA-AAAAA', deps)).toBe(true)
+    expect(verifySpy).toHaveBeenCalledTimes(3)
   })
 
   it('accepts a backup code and consumes it (single-use)', async () => {

--- a/src/contexts/user/application/verifyTwoFactorCode.ts
+++ b/src/contexts/user/application/verifyTwoFactorCode.ts
@@ -20,19 +20,26 @@ export async function verifyTwoFactorCode(
   deps: TwoFactorDeps,
 ): Promise<boolean> {
   const trimmed = code.trim()
-  if (user.totpSecret && (await deps.totp.verify(user.totpSecret, trimmed))) {
-    return true
+  if (user.totpSecret) {
+    // afterTimeStep rejects a code whose time step was already consumed, so the
+    // same TOTP cannot be replayed within its validity window.
+    const res = await deps.totp.verify(user.totpSecret, trimmed, { afterTimeStep: user.totpLastStep })
+    if (res.valid) {
+      if (res.timeStep !== undefined) user.recordTotpStep(res.timeStep)
+      return true
+    }
   }
   const normalized = normalizeBackupCode(trimmed)
   if (!normalized) return false
   const active = await deps.backupCodes.listActive(user.id)
+  // Check every code (no early return) so response time does not reveal which
+  // position matched. Codes are unique, so at most one matches.
+  let matched: { id: string } | null = null
   for (const bc of active) {
-    if (await deps.hasher.verify(normalized, bc.codeHash)) {
-      // Consume atomically: markUsed only succeeds if the code was still
-      // unused, so two concurrent requests racing on the same code cannot
-      // both be accepted.
-      return await deps.backupCodes.markUsed(bc.id)
-    }
+    if (await deps.hasher.verify(normalized, bc.codeHash)) matched = bc
   }
-  return false
+  if (!matched) return false
+  // Consume atomically: markUsed only succeeds if the code was still unused, so
+  // two concurrent requests racing on the same code cannot both be accepted.
+  return await deps.backupCodes.markUsed(matched.id)
 }

--- a/src/contexts/user/domain/IBackupCodeRepository.ts
+++ b/src/contexts/user/domain/IBackupCodeRepository.ts
@@ -1,3 +1,5 @@
+import type { Tx } from '../../../shared/persistence/index.js'
+
 export interface BackupCode {
   id: string
   codeHash: string
@@ -8,6 +10,8 @@ export interface BackupCode {
  * hashes; consumption is single-use via markUsed.
  */
 export interface IBackupCodeRepository {
+  /** Rebinds to a unit-of-work transaction so writes are atomic with the user save. */
+  withTx(tx: Tx): IBackupCodeRepository
   /** Replaces all of a user's codes with a fresh batch (used on enrollment confirm). */
   replaceForUser(userId: string, codeHashes: string[]): Promise<void>
   /** Returns the user's unused codes. */

--- a/src/contexts/user/domain/IUserRepository.ts
+++ b/src/contexts/user/domain/IUserRepository.ts
@@ -1,6 +1,8 @@
 import { User, OperationMode } from './User.js'
+import type { Tx } from '../../../shared/persistence/index.js'
 
 export interface IUserRepository {
+  withTx(tx: Tx): IUserRepository
   findById(id: string): Promise<User | null>
   findByEmail(email: string): Promise<User | null>
   save(user: User): Promise<void>

--- a/src/contexts/user/domain/User.ts
+++ b/src/contexts/user/domain/User.ts
@@ -16,6 +16,8 @@ interface UserProps {
   totpSecret?: string | null
   totpEnabled?: boolean
   totpConfirmedAt?: Date | null
+  /** Last successfully verified TOTP time step; blocks replay of the same code. */
+  totpLastStep?: number | null
 }
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
@@ -44,6 +46,7 @@ export class User extends AggregateRoot<string> {
       totpSecret: null,
       totpEnabled: false,
       totpConfirmedAt: null,
+      totpLastStep: null,
     })
   }
 
@@ -59,6 +62,12 @@ export class User extends AggregateRoot<string> {
   get createdAt()     { return this.props.createdAt }
   get totpSecret()      { return this.props.totpSecret ?? null }
   get totpConfirmedAt() { return this.props.totpConfirmedAt ?? null }
+  get totpLastStep()    { return this.props.totpLastStep ?? null }
+
+  /** Records the time step of a successful TOTP verification (replay guard). */
+  recordTotpStep(step: number): void {
+    this.props.totpLastStep = step
+  }
 
   isActive(): boolean { return this.props.status === 'active' }
 
@@ -86,6 +95,7 @@ export class User extends AggregateRoot<string> {
     this.props.totpSecret = null
     this.props.totpEnabled = false
     this.props.totpConfirmedAt = null
+    this.props.totpLastStep = null
   }
 
   changeOperationMode(mode: OperationMode): void {

--- a/src/contexts/user/domain/ports/ITotpProvider.ts
+++ b/src/contexts/user/domain/ports/ITotpProvider.ts
@@ -1,3 +1,17 @@
+export interface TotpVerifyOptions {
+  /**
+   * Reject any time step <= this value (replay protection). Pass the time step
+   * of the user's last successful verification so a code cannot be reused.
+   */
+  afterTimeStep?: number | null
+}
+
+export interface TotpVerifyResult {
+  valid: boolean
+  /** The matched time step when valid; persist it to block replay next time. */
+  timeStep?: number
+}
+
 /**
  * Time-based one-time password operations, kept behind a port so the domain and
  * use cases stay free of the concrete TOTP library.
@@ -9,6 +23,10 @@ export interface ITotpProvider {
   /** Builds an otpauth:// URI the frontend renders as a QR code. */
   keyUri(secret: string, accountLabel: string): string
 
-  /** True when `token` is a valid current code for `secret` (small clock drift allowed). */
-  verify(secret: string, token: string): Promise<boolean>
+  /**
+   * Validates `token` against `secret` (small backward clock drift allowed, no
+   * forward window). Returns the matched time step so callers can persist it and
+   * reject replays via `afterTimeStep`.
+   */
+  verify(secret: string, token: string, opts?: TotpVerifyOptions): Promise<TotpVerifyResult>
 }

--- a/src/contexts/user/infrastructure/BackupCodeRepository.ts
+++ b/src/contexts/user/infrastructure/BackupCodeRepository.ts
@@ -9,6 +9,10 @@ interface BackupCodeRow {
 export class BackupCodeRepository implements IBackupCodeRepository {
   constructor(private readonly executor: Executor) {}
 
+  withTx(tx: Executor): BackupCodeRepository {
+    return new BackupCodeRepository(tx)
+  }
+
   async replaceForUser(userId: string, codeHashes: string[]): Promise<void> {
     await this.executor.query(`DELETE FROM user_backup_codes WHERE user_id = $1`, [userId])
     for (const hash of codeHashes) {

--- a/src/contexts/user/infrastructure/UserRepository.ts
+++ b/src/contexts/user/infrastructure/UserRepository.ts
@@ -6,7 +6,7 @@ import { credentialsCipher } from '../../../shared/infrastructure/crypto/Credent
 
 const SELECT_COLUMNS =
   `id, email, name, password_hash, operation_mode, status, created_at,
-   totp_secret, totp_enabled, totp_confirmed_at`
+   totp_secret, totp_enabled, totp_confirmed_at, totp_last_step`
 
 export class UserRepository implements IUserRepository {
   constructor(private readonly executor: Executor) {}
@@ -44,8 +44,8 @@ export class UserRepository implements IUserRepository {
     await this.executor.query(
       `INSERT INTO users
          (id, email, password_hash, name, operation_mode, status, created_at,
-          totp_secret, totp_enabled, totp_confirmed_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+          totp_secret, totp_enabled, totp_confirmed_at, totp_last_step)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
        ON CONFLICT (id) DO UPDATE SET
          email             = $2,
          password_hash     = $3,
@@ -54,11 +54,12 @@ export class UserRepository implements IUserRepository {
          status            = $6,
          totp_secret       = $8,
          totp_enabled      = $9,
-         totp_confirmed_at = $10`,
+         totp_confirmed_at = $10,
+         totp_last_step    = $11`,
       [
         user.id, user.email, user.passwordHash, user.name,
         user.operationMode, user.status, user.createdAt,
-        encryptedSecret, user.isTotpEnabled(), user.totpConfirmedAt,
+        encryptedSecret, user.isTotpEnabled(), user.totpConfirmedAt, user.totpLastStep,
       ]
     )
   }

--- a/src/contexts/user/infrastructure/adapters/OtplibTotpProvider.test.ts
+++ b/src/contexts/user/infrastructure/adapters/OtplibTotpProvider.test.ts
@@ -18,34 +18,52 @@ describe('OtplibTotpProvider', () => {
     expect(uri).toContain('secret=JBSWY3DPEHPK3PXP')
   })
 
-  it('verifies a freshly generated code', async () => {
+  it('verifies a freshly generated code and reports its time step', async () => {
     const secret = provider.generateSecret()
     const code = generateSync({ secret })
-    expect(await provider.verify(secret, code)).toBe(true)
+    const result = await provider.verify(secret, code)
+    expect(result.valid).toBe(true)
+    expect(typeof result.timeStep).toBe('number')
   })
 
   it('rejects an obviously wrong code', async () => {
     const secret = provider.generateSecret()
-    expect(await provider.verify(secret, '000000')).toBe(false)
+    expect((await provider.verify(secret, '000000')).valid).toBe(false)
   })
 
   it('rejects malformed (non 6-digit) input without calling the verifier', async () => {
     const secret = provider.generateSecret()
-    expect(await provider.verify(secret, 'abcdef')).toBe(false)
-    expect(await provider.verify(secret, '12345')).toBe(false)
+    expect((await provider.verify(secret, 'abcdef')).valid).toBe(false)
+    expect((await provider.verify(secret, '12345')).valid).toBe(false)
   })
 
   it('trims surrounding whitespace before verifying', async () => {
     const secret = provider.generateSecret()
     const code = generateSync({ secret })
-    expect(await provider.verify(secret, `  ${code} `)).toBe(true)
+    expect((await provider.verify(secret, `  ${code} `)).valid).toBe(true)
   })
 
   it('rejects a code from a stale time window (beyond drift tolerance)', async () => {
     const secret = provider.generateSecret()
     const nowSec = Math.floor(Date.now() / 1000)
     const staleCode = generateSync({ secret, epoch: nowSec - 120 }) // 4 steps back
-    expect(await provider.verify(secret, staleCode)).toBe(false)
+    expect((await provider.verify(secret, staleCode)).valid).toBe(false)
+  })
+
+  it('rejects a future code (past-only tolerance, no forward window)', async () => {
+    const secret = provider.generateSecret()
+    const nowSec = Math.floor(Date.now() / 1000)
+    const futureCode = generateSync({ secret, epoch: nowSec + 60 }) // 2 steps ahead
+    expect((await provider.verify(secret, futureCode)).valid).toBe(false)
+  })
+
+  it('rejects replay of an already-used time step via afterTimeStep', async () => {
+    const secret = provider.generateSecret()
+    const code = generateSync({ secret })
+    const first = await provider.verify(secret, code)
+    expect(first.valid).toBe(true)
+    const replay = await provider.verify(secret, code, { afterTimeStep: first.timeStep })
+    expect(replay.valid).toBe(false)
   })
 
   it('uses a custom issuer in the otpauth URI when configured', () => {

--- a/src/contexts/user/infrastructure/adapters/OtplibTotpProvider.ts
+++ b/src/contexts/user/infrastructure/adapters/OtplibTotpProvider.ts
@@ -1,12 +1,15 @@
 import { generateSecret, generateURI, verify } from 'otplib'
-import { ITotpProvider } from '../../domain/ports/ITotpProvider.js'
+import { ITotpProvider, TotpVerifyOptions, TotpVerifyResult } from '../../domain/ports/ITotpProvider.js'
 
 const ISSUER = 'ReconBanker'
 
 /**
  * otplib-backed TOTP provider. Uses the library's default pure-JS crypto plugin
- * so it works without native modules. Verification allows ±30s of clock drift
- * (one time step) to tolerate small clock differences between server and phone.
+ * so it works without native modules.
+ *
+ * Tolerance is past-only ([5, 0]) — a few seconds of backward clock drift but no
+ * forward window — and `afterTimeStep` rejects already-consumed steps, so a code
+ * cannot be replayed (RFC 6238 §5.2, banking posture).
  */
 export class OtplibTotpProvider implements ITotpProvider {
   constructor(private readonly issuer: string = ISSUER) {}
@@ -19,10 +22,18 @@ export class OtplibTotpProvider implements ITotpProvider {
     return generateURI({ issuer: this.issuer, label: accountLabel, secret })
   }
 
-  async verify(secret: string, token: string): Promise<boolean> {
+  async verify(secret: string, token: string, opts?: TotpVerifyOptions): Promise<TotpVerifyResult> {
     const code = token.trim()
-    if (!/^\d{6}$/.test(code)) return false
-    const result = await verify({ secret, token: code, epochTolerance: 30 })
-    return result.valid
+    if (!/^\d{6}$/.test(code)) return { valid: false }
+    const result = await verify({
+      secret,
+      token: code,
+      epochTolerance: [5, 0],
+      ...(opts?.afterTimeStep != null ? { afterTimeStep: opts.afterTimeStep } : {}),
+    })
+    // otplib's VerifyResult unions TOTP (has timeStep) with HOTP (does not);
+    // narrow structurally — at runtime this is always the TOTP variant.
+    if (!result.valid) return { valid: false }
+    return { valid: true, timeStep: 'timeStep' in result ? result.timeStep : undefined }
   }
 }

--- a/src/contexts/user/infrastructure/mappers/UserRowMapper.ts
+++ b/src/contexts/user/infrastructure/mappers/UserRowMapper.ts
@@ -11,6 +11,8 @@ export interface UserRow {
   totp_secret?: string | null
   totp_enabled?: boolean | null
   totp_confirmed_at?: Date | null
+  // pg returns BIGINT as a string; the mapper coerces it to a number.
+  totp_last_step?: number | string | null
 }
 
 export const UserRowMapper = {
@@ -29,6 +31,7 @@ export const UserRowMapper = {
       totpSecret: row.totp_secret ?? null,
       totpEnabled: row.totp_enabled ?? false,
       totpConfirmedAt: row.totp_confirmed_at ?? null,
+      totpLastStep: row.totp_last_step != null ? Number(row.totp_last_step) : null,
     })
   },
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config'
 import './shared/config/runValidateEnv.js'
-import { createServer } from './api/server.js'
+import { createServer, resolveCorsOrigins } from './api/server.js'
 import { buildContainer } from './composition/container.js'
 import { createBankScrapeWorker } from './shared/infrastructure/queues/workers/bank-scrape.worker.js'
 import { createConciliationWorkers } from './shared/infrastructure/queues/workers/conciliation.worker.js'
@@ -15,6 +15,21 @@ import { startNotifier } from './shared/infrastructure/realtime/Notifier.js'
 
 const container = buildContainer({ redis })
 const log = container.logger.child('[app]')
+
+// Last-resort safety net. A stray unhandled rejection (Node 18+) or uncaught
+// exception would otherwise terminate the process silently. Log it with full
+// context; for an uncaught exception the process state is undefined, so exit
+// and let the supervisor restart cleanly.
+process.on('unhandledRejection', (reason) => {
+  log.error('unhandled promise rejection', {
+    error: reason instanceof Error ? reason.message : String(reason),
+    stack: reason instanceof Error ? reason.stack : undefined,
+  })
+})
+process.on('uncaughtException', (err) => {
+  log.error('uncaught exception', { error: err.message, stack: err.stack })
+  process.exit(1)
+})
 
 container.eventBus.subscribe<TransactionIngestedEvent>('TransactionIngested', (event) =>
   container.conciliation.onTransactionIngested.execute(event)
@@ -47,7 +62,7 @@ const PORT = process.env.PORT ?? 3000
 const app = createServer(container)
 const scheduler = new Scheduler(container)
 
-const realtimeGateway = new RealtimeGateway(container.user.tokenIssuer, realtimeBus, container.logger.child('[realtime]'))
+const realtimeGateway = new RealtimeGateway(container.user.tokenIssuer, realtimeBus, container.logger.child('[realtime]'), resolveCorsOrigins())
 
 // Consumes the notify stream and POSTs to each account's notification endpoint in-process alongside the workers
 const notifier = startNotifier(container)

--- a/src/shared/events/InMemoryEventBus.test.ts
+++ b/src/shared/events/InMemoryEventBus.test.ts
@@ -20,7 +20,7 @@ describe('InMemoryEventBus', () => {
     expect(b).toHaveBeenCalledTimes(1)
   })
 
-  it('does not throw when a handler rejects and still calls others', async () => {
+  it('runs every handler even if one rejects, logs, then surfaces the failure', async () => {
     const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() }
     log.child.mockReturnValue(log as any)
     const bus = new InMemoryEventBus(log as any)
@@ -28,7 +28,9 @@ describe('InMemoryEventBus', () => {
     const b = vi.fn().mockResolvedValue(undefined)
     bus.subscribe('Foo', a)
     bus.subscribe('Foo', b)
-    await expect(bus.publish(evt('Foo'))).resolves.toBeUndefined()
+    // The failure must not be swallowed: callers (workers) need it to fail the
+    // job loudly rather than silently lose the side-effect.
+    await expect(bus.publish(evt('Foo'))).rejects.toThrow()
     expect(b).toHaveBeenCalled()
     expect(log.error).toHaveBeenCalled()
   })
@@ -51,7 +53,7 @@ describe('InMemoryEventBus', () => {
     log.child.mockReturnValue(log as any)
     const bus = new InMemoryEventBus(log as any)
     bus.subscribe('Foo', () => Promise.reject('plain string failure'))
-    await bus.publish(evt('Foo'))
+    await expect(bus.publish(evt('Foo'))).rejects.toThrow()
     expect(log.error).toHaveBeenCalledWith('event handler failed', expect.objectContaining({
       error: 'plain string failure',
     }))

--- a/src/shared/events/InMemoryEventBus.ts
+++ b/src/shared/events/InMemoryEventBus.ts
@@ -14,7 +14,11 @@ export class InMemoryEventBus implements IEventBus {
 
   async publish(event: DomainEvent): Promise<void> {
     const handlers = this.handlers.get(event.eventType) ?? []
+    // allSettled so one failing handler never starves the others, but the
+    // failures are then re-thrown — callers (queue workers) must see them and
+    // fail the job loudly instead of silently dropping the side-effect.
     const results = await Promise.allSettled(handlers.map((h) => h(event)))
+    const failures: unknown[] = []
     for (const r of results) {
       if (r.status === 'rejected') {
         this.logger?.error('event handler failed', {
@@ -22,7 +26,14 @@ export class InMemoryEventBus implements IEventBus {
           aggregateId: event.aggregateId,
           error: r.reason instanceof Error ? r.reason.message : String(r.reason),
         })
+        failures.push(r.reason)
       }
+    }
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures,
+        `${failures.length} handler(s) failed for event ${event.eventType}`,
+      )
     }
   }
 

--- a/src/shared/infrastructure/db/migrations/043_conciliated_unique_bank_tx.sql
+++ b/src/shared/infrastructure/db/migrations/043_conciliated_unique_bank_tx.sql
@@ -1,0 +1,9 @@
+-- Backstop for the conciliation double-match race: a single bank transaction
+-- must be the primary match of at most one request. The existing constraints
+-- only cover (request_id, bank_transaction_id) and (request_id, is_primary),
+-- which still allowed the same transaction to be conciliated to two different
+-- requests under concurrency. Application-level FOR UPDATE locking now closes
+-- the window; this index makes the invariant enforceable by the database too.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_conciliated_bank_tx_primary
+  ON conciliated_transactions (bank_transaction_id)
+  WHERE is_primary = true;

--- a/src/shared/infrastructure/db/migrations/044_users_totp_last_step.sql
+++ b/src/shared/infrastructure/db/migrations/044_users_totp_last_step.sql
@@ -1,0 +1,5 @@
+-- TOTP replay protection: records the time step of the last successful 2FA
+-- verification. verifyTwoFactorCode passes it to the provider as afterTimeStep
+-- so a code cannot be reused within its validity window.
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS totp_last_step BIGINT NULL;

--- a/src/shared/infrastructure/queues/Scheduler.test.ts
+++ b/src/shared/infrastructure/queues/Scheduler.test.ts
@@ -87,6 +87,9 @@ describe('Scheduler', () => {
     expect(orderIngestionAdd).toHaveBeenCalledTimes(2)
     expect(orderIngestionAdd.mock.calls[0][0]).toBe('poll')
     expect(orderIngestionAdd.mock.calls[0][1]).toEqual({ accountId: 'a1' })
+    // Idempotent jobId (no timestamp) so a slow/failed poll does not spawn a
+    // second concurrent poll for the same account.
+    expect(orderIngestionAdd.mock.calls[0][2]).toMatchObject({ jobId: 'poll:a1' })
 
     // scraping called for 2 one-shot accounts
     // persistent session: a5 is running, a6 not -> only a6 enqueued
@@ -122,6 +125,22 @@ describe('Scheduler', () => {
     orderIngestionAdd.mockClear()
     await vi.advanceTimersByTimeAsync(5000)
     expect(orderIngestionAdd).not.toHaveBeenCalled()
+  })
+
+  it('absorbs and logs errors thrown by recurring interval callbacks', async () => {
+    vi.stubEnv('POLLING_INTERVAL_SECONDS', '1')
+    dbQuery.mockResolvedValue({ rows: [] })
+    const { container, log } = makeContainer()
+    const scheduler = new Scheduler(container)
+    await scheduler.start()
+
+    // The recurring polling query now fails; the interval must not leak an
+    // unhandled rejection — it should be caught and logged.
+    dbQuery.mockRejectedValue(new Error('db down'))
+    await vi.advanceTimersByTimeAsync(1100)
+    scheduler.stop()
+
+    expect(log.error).toHaveBeenCalled()
   })
 
   it('uses default intervals when env vars are not set', async () => {

--- a/src/shared/infrastructure/queues/Scheduler.ts
+++ b/src/shared/infrastructure/queues/Scheduler.ts
@@ -27,10 +27,10 @@ export class Scheduler {
     await this.expireStaleRequests()
 
     this.timers.push(
-      setInterval(() => this.enqueuePolling(),  pollingInterval),
-      setInterval(() => this.enqueueScraping(), scrapeInterval),
-      setInterval(() => this.ensurePersistentSessions(), sessionCheckInterval),
-      setInterval(() => this.expireStaleRequests(), expireInterval),
+      setInterval(() => this.runSafely('enqueuePolling', () => this.enqueuePolling()),  pollingInterval),
+      setInterval(() => this.runSafely('enqueueScraping', () => this.enqueueScraping()), scrapeInterval),
+      setInterval(() => this.runSafely('ensurePersistentSessions', () => this.ensurePersistentSessions()), sessionCheckInterval),
+      setInterval(() => this.runSafely('expireStaleRequests', () => this.expireStaleRequests()), expireInterval),
     )
 
     this.log.info('started', {
@@ -47,6 +47,20 @@ export class Scheduler {
     this.log.info('stopped')
   }
 
+  // setInterval callbacks are fire-and-forget: an unawaited rejection would
+  // become an unhandledRejection and (Node 18+) can terminate the process,
+  // silently stopping all scheduling. Catch and log so the next tick still runs.
+  private async runSafely(name: string, fn: () => Promise<void>): Promise<void> {
+    try {
+      await fn()
+    } catch (err) {
+      this.log.error('scheduled task failed', {
+        task: name,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
   private async enqueuePolling(): Promise<void> {
     const { rows: accounts } = await db.query(
       `SELECT id FROM accounts WHERE status = 'active'`
@@ -56,7 +70,7 @@ export class Scheduler {
       await Queues.orderIngestion.add(
         'poll',
         { accountId: account.id },
-        { jobId: `poll:${account.id}:${Date.now()}`, removeOnComplete: true, removeOnFail: 100 }
+        { jobId: `poll:${account.id}`, removeOnComplete: true, removeOnFail: 100 }
       )
     }
 

--- a/src/shared/infrastructure/webhooks/WebhookSender.test.ts
+++ b/src/shared/infrastructure/webhooks/WebhookSender.test.ts
@@ -10,6 +10,13 @@ vi.mock('../logger/index.js', () => ({
   logger: { child: vi.fn(() => childLog) },
 }))
 
+// assertSafeUrl has its own SSRF tests and does real DNS; mock it here so these
+// tests stay offline and we can drive the "blocked at send time" path.
+const { assertSafeUrlMock } = vi.hoisted(() => ({ assertSafeUrlMock: vi.fn() }))
+vi.mock('../../net/assertSafeUrl.js', () => ({ assertSafeUrl: assertSafeUrlMock }))
+
+import crypto from 'node:crypto'
+
 const { sendWebhook } = await import('./WebhookSender.js')
 
 function makeResponse(status: number, body = '', statusText = 'OK') {
@@ -29,10 +36,53 @@ describe('sendWebhook', () => {
     vi.stubGlobal('fetch', fetchMock)
     childLog.debug.mockClear()
     childLog.info.mockClear()
+    assertSafeUrlMock.mockReset()
+    assertSafeUrlMock.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+  })
+
+  it('disallows following redirects (SSRF: a 3xx to an internal IP must not be followed)', async () => {
+    fetchMock.mockResolvedValue(makeResponse(200))
+    await sendWebhook({ url: 'https://example.com/x', payload: {}, authType: null, authToken: null })
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ redirect: 'error' })
+  })
+
+  it('re-validates the URL right before sending (closes the config→send TOCTOU window)', async () => {
+    fetchMock.mockResolvedValue(makeResponse(200))
+    await sendWebhook({ url: 'https://example.com/x', payload: {}, authType: null, authToken: null })
+    expect(assertSafeUrlMock).toHaveBeenCalledWith('https://example.com/x', expect.any(String))
+  })
+
+  it('does not send when the URL now resolves to a blocked address', async () => {
+    assertSafeUrlMock.mockRejectedValueOnce(new Error('blocked: private address'))
+    await expect(
+      sendWebhook({ url: 'https://rebound.example.com/x', payload: {}, authType: null, authToken: null }),
+    ).rejects.toThrow(/blocked/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('signs the body with HMAC-SHA256 when WEBHOOK_SIGNING_SECRET is set', async () => {
+    vi.stubEnv('WEBHOOK_SIGNING_SECRET', 'top-secret')
+    fetchMock.mockResolvedValue(makeResponse(200))
+    await sendWebhook({ url: 'https://example.com/x', payload: { a: 1 }, authType: null, authToken: null })
+
+    const headers = fetchMock.mock.calls[0][1].headers
+    const body = fetchMock.mock.calls[0][1].body as string
+    const ts = headers['X-Webhook-Timestamp']
+    expect(ts).toBeTruthy()
+    const expected = 'sha256=' + crypto.createHmac('sha256', 'top-secret').update(`${ts}.${body}`).digest('hex')
+    expect(headers['X-Signature-256']).toBe(expected)
+  })
+
+  it('omits the signature header when no signing secret is configured', async () => {
+    fetchMock.mockResolvedValue(makeResponse(200))
+    await sendWebhook({ url: 'https://example.com/x', payload: {}, authType: null, authToken: null })
+    const headers = fetchMock.mock.calls[0][1].headers
+    expect(headers['X-Signature-256']).toBeUndefined()
   })
 
   it('sends without Authorization header when authToken is null', async () => {

--- a/src/shared/infrastructure/webhooks/WebhookSender.ts
+++ b/src/shared/infrastructure/webhooks/WebhookSender.ts
@@ -1,4 +1,6 @@
+import crypto from 'node:crypto'
 import { logger } from '../logger/index.js'
+import { assertSafeUrl } from '../../net/assertSafeUrl.js'
 
 const log = logger.child('[webhook]')
 
@@ -22,17 +24,35 @@ export interface WebhookError extends Error {
 }
 
 export async function sendWebhook({ url, payload, authType, authToken }: SendWebhookOptions): Promise<WebhookResult> {
+  // Re-validate at send time, not just at config write: the host may now resolve
+  // to an internal address (DNS change / TOCTOU) even though it was safe before.
+  await assertSafeUrl(url, 'webhook_url')
+
   const headers: Record<string, string> = { 'Content-Type': 'application/json', 'Accept': 'application/json' }
   if (authToken) {
     headers['Authorization'] = authType === 'api_key' ? `Api-Key ${authToken}` : `Bearer ${authToken}`
   }
 
   const body = JSON.stringify(payload)
+
+  // Recipients can verify authenticity/integrity (Stripe-style) when a signing
+  // secret is configured. Signature covers `${timestamp}.${body}` to also bind
+  // the timestamp and bound replay windows.
+  const signingSecret = process.env.WEBHOOK_SIGNING_SECRET
+  if (signingSecret) {
+    const timestamp = Math.floor(Date.now() / 1000).toString()
+    const signature = crypto.createHmac('sha256', signingSecret).update(`${timestamp}.${body}`).digest('hex')
+    headers['X-Webhook-Timestamp'] = timestamp
+    headers['X-Signature-256'] = `sha256=${signature}`
+  }
+
   log.debug(`POST ${url}`)
   log.debug(`headers`, { headers: { ...headers, Authorization: headers['Authorization'] ? '[REDACTED]' : undefined } })
   log.debug(`body`, { body })
 
-  const response = await fetch(url, { method: 'POST', headers, body, signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS) })
+  // redirect: 'error' stops a malicious endpoint from 3xx-redirecting us to an
+  // internal address (SSRF) after assertSafeUrl validated the original host.
+  const response = await fetch(url, { method: 'POST', headers, body, redirect: 'error', signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS) })
   const responseBody = await response.text().catch(() => '')
   log.info(`response`, { status: response.status, statusText: response.statusText, body: responseBody })
 

--- a/src/shared/persistence/pgErrors.test.ts
+++ b/src/shared/persistence/pgErrors.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { isUniqueViolation } from './pgErrors.js'
+
+function pgError(code: string, constraint?: string) {
+  return Object.assign(new Error('db error'), { code, constraint })
+}
+
+describe('isUniqueViolation', () => {
+  it('is false for non-object and null inputs', () => {
+    expect(isUniqueViolation(null)).toBe(false)
+    expect(isUniqueViolation(undefined)).toBe(false)
+    expect(isUniqueViolation('23505')).toBe(false)
+    expect(isUniqueViolation(23505)).toBe(false)
+  })
+
+  it('is false when the error code is not 23505', () => {
+    expect(isUniqueViolation(pgError('23503'))).toBe(false)
+    expect(isUniqueViolation(new Error('plain'))).toBe(false)
+  })
+
+  it('is true for a 23505 error when no constraint is required', () => {
+    expect(isUniqueViolation(pgError('23505'))).toBe(true)
+    expect(isUniqueViolation(pgError('23505', 'any_index'))).toBe(true)
+  })
+
+  it('matches the constraint name when one is required', () => {
+    expect(isUniqueViolation(pgError('23505', 'uq_x'), 'uq_x')).toBe(true)
+    expect(isUniqueViolation(pgError('23505', 'uq_y'), 'uq_x')).toBe(false)
+    expect(isUniqueViolation(pgError('23505'), 'uq_x')).toBe(false)
+  })
+})

--- a/src/shared/persistence/pgErrors.ts
+++ b/src/shared/persistence/pgErrors.ts
@@ -1,0 +1,12 @@
+/**
+ * Detects a Postgres unique-violation (SQLSTATE 23505), optionally scoped to a
+ * specific constraint/index name. Used to treat a lost insert race as a clean
+ * no-op rather than a crash. For a partial unique index, pg reports the index
+ * name in `constraint`.
+ */
+export function isUniqueViolation(err: unknown, constraint?: string): boolean {
+  if (typeof err !== 'object' || err === null) return false
+  const e = err as { code?: unknown; constraint?: unknown }
+  if (e.code !== '23505') return false
+  return constraint === undefined || e.constraint === constraint
+}

--- a/tests/helpers/inMemoryBackupCodeRepo.ts
+++ b/tests/helpers/inMemoryBackupCodeRepo.ts
@@ -6,6 +6,8 @@ interface Row { id: string; userId: string; codeHash: string; used: boolean }
 export class InMemoryBackupCodeRepository implements IBackupCodeRepository {
   rows: Row[] = []
 
+  withTx() { return this }
+
   async replaceForUser(userId: string, codeHashes: string[]) {
     this.rows = this.rows.filter((r) => r.userId !== userId)
     for (const codeHash of codeHashes) {

--- a/tests/helpers/inMemoryBankRepos.ts
+++ b/tests/helpers/inMemoryBankRepos.ts
@@ -19,11 +19,12 @@ export class InMemoryBankTransactionRepository implements IBankTransactionReposi
     txs.sort((a, b) => b.receivedAt.getTime() - a.receivedAt.getTime())
     return txs[0].externalId
   }
-  async save(tx: BankTransaction) {
+  async save(tx: BankTransaction): Promise<boolean> {
     const key = `${tx.accountId}::${tx.externalId}`
     const existing = [...this.store.values()].find((t) => `${t.accountId}::${t.externalId}` === key)
-    if (existing) return
+    if (existing) return false
     this.store.set(tx.id, tx)
+    return true
   }
   async markExcluded(id: string) { this.excluded.add(id) }
   async isExcluded(id: string) { return this.excluded.has(id) }

--- a/tests/helpers/inMemoryConciliationRepos.ts
+++ b/tests/helpers/inMemoryConciliationRepos.ts
@@ -43,6 +43,14 @@ export class InMemoryConciliationRequestRepository implements IConciliationReque
     )
   }
   async save(request: ConciliationRequest) { this.store.set(request.id, request) }
+  async createIfAbsent(request: ConciliationRequest): Promise<boolean> {
+    const exists = [...this.store.values()].some(
+      (r) => r.accountId === request.accountId && r.externalId === request.externalId
+    )
+    if (exists) return false
+    this.store.set(request.id, request)
+    return true
+  }
   async cancelMissing(accountId: string, presentExternalIds: string[]) {
     let count = 0
     for (const r of this.store.values()) {

--- a/tests/integration/conciliation/ConciliationDoubleMatch.integration.test.ts
+++ b/tests/integration/conciliation/ConciliationDoubleMatch.integration.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser, seedAccount } from '../helpers/seed.js'
+import { insertConciliationRequest, insertBankTransaction } from './helpers.js'
+import { executorFromPool } from '../../../src/contexts/conciliation/infrastructure/Executor.js'
+import { ConciliationRequestRepository } from '../../../src/contexts/conciliation/infrastructure/ConciliationRequestRepository.js'
+import { ConciliatedTransactionRepository } from '../../../src/contexts/conciliation/infrastructure/ConciliatedTransactionRepository.js'
+import { ConciliationAttemptRepository } from '../../../src/contexts/conciliation/infrastructure/ConciliationAttemptRepository.js'
+import { BankTransactionRepository } from '../../../src/contexts/banking/infrastructure/BankTransactionRepository.js'
+import { BankTransactionFinderAdapter } from '../../../src/contexts/conciliation/infrastructure/adapters/BankTransactionFinderAdapter.js'
+import { ConciliationEngine } from '../../../src/contexts/conciliation/domain/ConciliationEngine.js'
+import { RunConciliationUseCase } from '../../../src/contexts/conciliation/application/RunConciliationUseCase.js'
+import { PgUnitOfWork } from '../../../src/shared/persistence/PgUnitOfWork.js'
+import { InMemoryEventBus } from '../../../src/shared/events/InMemoryEventBus.js'
+
+function buildRunConciliation() {
+  const pool = getTestPool()
+  const exec = executorFromPool(pool)
+  const bankTxRepo = new BankTransactionRepository(exec)
+  return new RunConciliationUseCase({
+    unitOfWork: new PgUnitOfWork(pool),
+    eventBus: new InMemoryEventBus(),
+    requestRepo: new ConciliationRequestRepository(exec),
+    attemptRepo: new ConciliationAttemptRepository(exec),
+    matchRepo: new ConciliatedTransactionRepository(exec),
+    bankTransactionFinder: new BankTransactionFinderAdapter(exec, bankTxRepo),
+    engine: new ConciliationEngine(),
+  })
+}
+
+describe('conciliation double-match (C1)', () => {
+  beforeAll(async () => { await truncateAll() })
+  beforeEach(async () => { await truncateAll() })
+  afterAll(async () => { await closeTestPool() })
+
+  it('the unique index rejects a second primary match for the same bank transaction', async () => {
+    const user = await seedUser({})
+    const account = await seedAccount(user.id)
+    const r1 = await insertConciliationRequest({ accountId: account.id })
+    const r2 = await insertConciliationRequest({ accountId: account.id })
+    const tx = await insertBankTransaction({ accountId: account.id })
+
+    const insertMatch = (requestId: string) =>
+      getTestPool().query(
+        `INSERT INTO conciliated_transactions
+           (id, account_id, request_id, bank_transaction_id, matched_by, is_primary, matched_at, created_at, is_notified)
+         VALUES ($1,$2,$3,$4,'engine',true,now(),now(),false)`,
+        [crypto.randomUUID(), account.id, requestId, tx.id]
+      )
+
+    await insertMatch(r1.id)
+    await expect(insertMatch(r2.id)).rejects.toThrow(/uq_conciliated_bank_tx_primary|unique/i)
+  })
+
+  it('two requests racing for the same single transaction yield exactly one match', async () => {
+    const user = await seedUser({})
+    const account = await seedAccount(user.id)
+    // Both requests match the same incoming transaction (same amount + sender).
+    const r1 = await insertConciliationRequest({ accountId: account.id, expectedAmount: 100, senderName: 'Alice' })
+    const r2 = await insertConciliationRequest({ accountId: account.id, expectedAmount: 100, senderName: 'Alice' })
+    await insertBankTransaction({ accountId: account.id, amount: 100, senderName: 'Alice' })
+
+    const useCase = buildRunConciliation()
+    const results = await Promise.allSettled([
+      useCase.execute({ requestId: r1.id }),
+      useCase.execute({ requestId: r2.id }),
+    ])
+
+    // At most one transaction may be conciliated, regardless of interleaving.
+    const { rows } = await getTestPool().query<{ n: number }>(
+      'SELECT COUNT(*)::int AS n FROM conciliated_transactions'
+    )
+    expect(rows[0].n).toBe(1)
+
+    const matched = await getTestPool().query<{ status: string }>(
+      `SELECT status FROM conciliation_requests WHERE status = 'matched'`
+    )
+    expect(matched.rows).toHaveLength(1)
+    // Both executions complete WITHOUT throwing: the winner conciliates, and the
+    // loser of the unique-index race aborts cleanly instead of surfacing a DB error.
+    expect(results.every((r) => r.status === 'fulfilled')).toBe(true)
+  })
+})

--- a/tests/integration/conciliation/PollIdempotency.integration.test.ts
+++ b/tests/integration/conciliation/PollIdempotency.integration.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
+import crypto from 'crypto'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser, seedAccount } from '../helpers/seed.js'
+import { executorFromPool } from '../../../src/contexts/conciliation/infrastructure/Executor.js'
+import { ConciliationRequestRepository } from '../../../src/contexts/conciliation/infrastructure/ConciliationRequestRepository.js'
+import { ConciliationRequest } from '../../../src/contexts/conciliation/domain/ConciliationRequest.js'
+
+describe('poll idempotency — createIfAbsent (A3)', () => {
+  beforeAll(async () => { await truncateAll() })
+  beforeEach(async () => { await truncateAll() })
+  afterAll(async () => { await closeTestPool() })
+
+  it('two concurrent inserts of the same (account, external_id) yield exactly one row without crashing', async () => {
+    const user = await seedUser({})
+    const account = await seedAccount(user.id)
+    const repo = new ConciliationRequestRepository(executorFromPool(getTestPool()))
+
+    const makeReq = () =>
+      ConciliationRequest.create(crypto.randomUUID(), {
+        accountId: account.id,
+        externalId: 'order-42',
+        expectedAmount: 100,
+        currency: 'USD',
+        senderName: 'Alice',
+      })
+
+    const results = await Promise.all([repo.createIfAbsent(makeReq()), repo.createIfAbsent(makeReq())])
+
+    // Exactly one insert wins; the other is a no-op, not a unique-violation crash.
+    expect(results.filter(Boolean)).toHaveLength(1)
+    const { rows } = await getTestPool().query<{ n: number }>(
+      `SELECT COUNT(*)::int AS n FROM conciliation_requests WHERE account_id = $1 AND external_id = 'order-42'`,
+      [account.id]
+    )
+    expect(rows[0].n).toBe(1)
+  })
+})

--- a/tests/integration/user/Totp2faFlow.integration.test.ts
+++ b/tests/integration/user/Totp2faFlow.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest'
 import { generateSync } from 'otplib'
 import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
 import { seedUser } from '../helpers/seed.js'
@@ -8,6 +8,7 @@ import { BackupCodeRepository } from '../../../src/contexts/user/infrastructure/
 import { BcryptPasswordHasher } from '../../../src/contexts/user/infrastructure/adapters/BcryptPasswordHasher.js'
 import { JwtTokenIssuer } from '../../../src/contexts/user/infrastructure/adapters/JwtTokenIssuer.js'
 import { OtplibTotpProvider } from '../../../src/contexts/user/infrastructure/adapters/OtplibTotpProvider.js'
+import { PgUnitOfWork } from '../../../src/shared/persistence/PgUnitOfWork.js'
 import { StartTotpEnrollmentUseCase } from '../../../src/contexts/user/application/StartTotpEnrollmentUseCase.js'
 import { ConfirmTotpEnrollmentUseCase } from '../../../src/contexts/user/application/ConfirmTotpEnrollmentUseCase.js'
 import { DisableTotpUseCase } from '../../../src/contexts/user/application/DisableTotpUseCase.js'
@@ -26,11 +27,12 @@ function build() {
   const totp = new OtplibTotpProvider()
   const issuer = new JwtTokenIssuer(SECRET)
   const twoFactor: TwoFactorDeps = { totp, backupCodes, hasher }
+  const uow = new PgUnitOfWork(getTestPool())
   return {
     userRepo, backupCodes, totp, issuer,
     start: new StartTotpEnrollmentUseCase(userRepo, totp),
-    confirm: new ConfirmTotpEnrollmentUseCase(userRepo, totp, backupCodes, hasher),
-    disable: new DisableTotpUseCase(userRepo, hasher, backupCodes, twoFactor),
+    confirm: new ConfirmTotpEnrollmentUseCase(userRepo, totp, backupCodes, hasher, uow),
+    disable: new DisableTotpUseCase(userRepo, hasher, backupCodes, twoFactor, uow),
     login: new LoginUseCase(userRepo, hasher, issuer),
     verify: new VerifyTotpLoginUseCase(userRepo, issuer, twoFactor),
   }
@@ -44,6 +46,12 @@ describe('TOTP 2FA flow (integration)', () => {
   afterAll(async () => { await closeTestPool() })
 
   it('runs the full enroll → login → verify (TOTP & backup) → disable lifecycle', async () => {
+    // Fake only the clock (leave I/O timers real for pg) so we can step into a
+    // fresh TOTP window between enrollment and login — the enrollment code is now
+    // consumed (replay protection), so the same-window code can't log in.
+    vi.useFakeTimers({ toFake: ['Date'] })
+    try {
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
     const password = 'SuperSecret123'
     const seeded = await seedUser({ email: 'flow@test.com', password })
     const m = build()
@@ -62,7 +70,8 @@ describe('TOTP 2FA flow (integration)', () => {
     // the challenge token must NOT verify as an access token
     expect(m.issuer.verify(challenge.challengeToken)?.scope).toBe('2fa_pending')
 
-    // --- complete with a TOTP code ---
+    // --- complete with a TOTP code from a later window (enrollment step consumed) ---
+    vi.setSystemTime(new Date('2026-01-01T00:01:00Z'))
     const session = await m.verify.execute({
       challengeToken: challenge.challengeToken,
       code: generateSync({ secret }),
@@ -84,7 +93,10 @@ describe('TOTP 2FA flow (integration)', () => {
     ).rejects.toBeInstanceOf(UnauthorizedError)
 
     // --- disable requires password + a valid code ---
-    await m.disable.execute({ userId: seeded.id, password, code: generateSync({ secret }) })
+    // Use an unused backup code: the current TOTP step was already consumed by
+    // the login above, and replay protection (single-use per window) would
+    // reject the same code here.
+    await m.disable.execute({ userId: seeded.id, password, code: backupCodes[1] })
 
     const after = await m.userRepo.findById(seeded.id)
     expect(after!.isTotpEnabled()).toBe(false)
@@ -99,6 +111,9 @@ describe('TOTP 2FA flow (integration)', () => {
     // login no longer challenges
     const plainLogin = await m.login.execute({ email: 'flow@test.com', password })
     expect(isTotpChallenge(plainLogin)).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('rejects disabling 2FA with a wrong password', async () => {

--- a/tests/integration/user/TotpEnrollmentAtomicity.integration.test.ts
+++ b/tests/integration/user/TotpEnrollmentAtomicity.integration.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
+import { generateSync } from 'otplib'
+import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
+import { seedUser } from '../helpers/seed.js'
+import { executorFromPool } from '../../../src/contexts/user/infrastructure/Executor.js'
+import { UserRepository } from '../../../src/contexts/user/infrastructure/UserRepository.js'
+import { BcryptPasswordHasher } from '../../../src/contexts/user/infrastructure/adapters/BcryptPasswordHasher.js'
+import { OtplibTotpProvider } from '../../../src/contexts/user/infrastructure/adapters/OtplibTotpProvider.js'
+import { StartTotpEnrollmentUseCase } from '../../../src/contexts/user/application/StartTotpEnrollmentUseCase.js'
+import { ConfirmTotpEnrollmentUseCase } from '../../../src/contexts/user/application/ConfirmTotpEnrollmentUseCase.js'
+import { PgUnitOfWork } from '../../../src/shared/persistence/PgUnitOfWork.js'
+
+const secretFromUri = (uri: string) => new URL(uri).searchParams.get('secret')!
+
+describe('TOTP enrollment atomicity (M2)', () => {
+  beforeAll(async () => { await truncateAll() })
+  beforeEach(async () => { await truncateAll() })
+  afterAll(async () => { await closeTestPool() })
+
+  it('rolls back enabling 2FA when persisting the backup codes fails', async () => {
+    const seeded = await seedUser({ email: 'atomic@test.com' })
+    const exec = executorFromPool(getTestPool())
+    const userRepo = new UserRepository(exec)
+    const totp = new OtplibTotpProvider()
+
+    const { otpauthUri } = await new StartTotpEnrollmentUseCase(userRepo, totp).execute(seeded.id)
+    const secret = secretFromUri(otpauthUri)
+
+    // Backup-code persistence fails mid-transaction.
+    const failingBackupCodes: any = {
+      withTx: () => failingBackupCodes,
+      replaceForUser: async () => { throw new Error('backup insert failed') },
+    }
+    const confirm = new ConfirmTotpEnrollmentUseCase(
+      userRepo, totp, failingBackupCodes, new BcryptPasswordHasher(4), new PgUnitOfWork(getTestPool()),
+    )
+
+    await expect(
+      confirm.execute({ userId: seeded.id, code: generateSync({ secret }) }),
+    ).rejects.toThrow(/backup insert failed/)
+
+    // The user must NOT be left with 2FA enabled and zero backup codes.
+    const after = await userRepo.findById(seeded.id)
+    expect(after!.isTotpEnabled()).toBe(false)
+    const { rows } = await getTestPool().query<{ n: number }>(
+      'SELECT COUNT(*)::int AS n FROM user_backup_codes WHERE user_id = $1', [seeded.id]
+    )
+    expect(rows[0].n).toBe(0)
+  })
+})


### PR DESCRIPTION
This pull request implements the fixes for all security and resilience findings from the project audit, grouped into focused commits:

- Conciliation matching integrity (transactional finder, FOR UPDATE, unique-index backstop, bounded date window, no-op publish guard)
- Process resilience (unhandled rejection/exception handlers, guarded scheduler intervals, event-handler failures surfaced)
- Outbound HTTP SSRF hardening (no redirects, re-validation before each request, HMAC webhook signing)
- Idempotent order polling
- Script engine resource cleanup and path-traversal guard
- TOTP 2FA hardening (atomic enrollment, replay protection, unbiased and constant-time backup codes, rate limiting)
- Realtime WebSocket gateway hardening (payload cap, heartbeat, backpressure, Origin validation)

All changes are covered by unit and integration tests; the strict coverage gate passes.