### PR TITLE
Improve login/register field errors and spacing

### DIFF
--- a/client/src/features/user/pages/Login.test.tsx
+++ b/client/src/features/user/pages/Login.test.tsx
@@ -56,8 +56,8 @@ describe('Login page', () => {
     const user = userEvent.setup()
     renderLogin()
     await user.click(screen.getByRole('button', { name: /Ingresar/i }))
-    const messages = await screen.findAllByText(/Completá este campo/i)
-    expect(messages).toHaveLength(2)
+    expect(await screen.findByText(/El campo correo electrónico es obligatorio\./i)).toBeInTheDocument()
+    expect(screen.getByText(/El campo contraseña es obligatorio\./i)).toBeInTheDocument()
     expect(screen.getByLabelText(/Email/i)).toHaveAttribute('aria-invalid', 'true')
     expect(screen.getByLabelText(/Contraseña/i)).toHaveAttribute('aria-invalid', 'true')
   })
@@ -147,7 +147,7 @@ describe('Login page', () => {
     await user.type(screen.getByLabelText(/Email/i), 'ok@x.com')
     await user.type(screen.getByLabelText(/Contraseña/i), 'good')
     await user.click(screen.getByRole('button', { name: /Ingresar/i }))
-    expect(await screen.findByText(/Completá este campo/i)).toBeInTheDocument()
+    expect(await screen.findByText(/El campo contraseña es obligatorio\./i)).toBeInTheDocument()
   })
 
   it('shows the server-provided message for unexpected non-auth failures', async () => {

--- a/client/src/features/user/pages/Login.tsx
+++ b/client/src/features/user/pages/Login.tsx
@@ -34,9 +34,9 @@ export function Login() {
 
   function validate(values: { email: string; password: string }): LoginErrors {
     const next: LoginErrors = {}
-    if (!values.email.trim()) next.email = t('common:validation.required')
+    if (!values.email.trim()) next.email = t('common:validation.emailRequired')
     else if (!emailPattern.test(values.email)) next.email = t('errors.emailInvalid')
-    if (!values.password) next.password = t('common:validation.required')
+    if (!values.password) next.password = t('common:validation.passwordRequired')
     return next
   }
 
@@ -73,7 +73,7 @@ export function Login() {
       if (fieldErrors.email || fieldErrors.password) {
         setErrors({
           email: fieldErrors.email && t('errors.emailInvalid'),
-          password: fieldErrors.password && t('common:validation.required'),
+          password: fieldErrors.password && t('common:validation.passwordRequired'),
         })
         return
       }

--- a/client/src/features/user/pages/Register.test.tsx
+++ b/client/src/features/user/pages/Register.test.tsx
@@ -109,8 +109,8 @@ describe('Register page', () => {
     const user = userEvent.setup()
     renderRegister()
     await user.click(screen.getByRole('button', { name: /^Registrar$/i }))
-    const messages = await screen.findAllByText(/Completá este campo/i)
-    expect(messages).toHaveLength(2)
+    expect(await screen.findByText(/El campo correo electrónico es obligatorio\./i)).toBeInTheDocument()
+    expect(screen.getByText(/El campo contraseña es obligatorio\./i)).toBeInTheDocument()
   })
 
   it('shows the server-provided error message on conflict', async () => {

--- a/client/src/features/user/pages/Register.tsx
+++ b/client/src/features/user/pages/Register.tsx
@@ -27,10 +27,10 @@ export function Register() {
 
   function validate(values: { email: string; password: string }): RegisterErrors {
     const next: RegisterErrors = {}
-    if (!values.email.trim()) next.email = t('common:validation.required')
+    if (!values.email.trim()) next.email = t('common:validation.emailRequired')
     else if (!emailPattern.test(values.email)) next.email = t('errors.emailInvalid')
     if (!values.password) {
-      next.password = t('common:validation.required')
+      next.password = t('common:validation.passwordRequired')
     } else {
       // One rule at a time: only the first failing rule is shown; fixing it reveals the next
       const rule = firstFailingPasswordRule(values.password)

--- a/client/src/shared/i18n/common.ts
+++ b/client/src/shared/i18n/common.ts
@@ -70,6 +70,8 @@ export const commonEs = {
   },
   validation: {
     required: 'Completá este campo',
+    emailRequired: 'El campo correo electrónico es obligatorio.',
+    passwordRequired: 'El campo contraseña es obligatorio.',
   },
   errors: {
     generic: 'Algo salió mal',
@@ -164,6 +166,8 @@ export const commonEn = {
   },
   validation: {
     required: 'Please fill out this field',
+    emailRequired: 'The email field is required.',
+    passwordRequired: 'The password field is required.',
   },
   errors: {
     generic: 'Something went wrong',

--- a/client/src/shared/ui/FormField.tsx
+++ b/client/src/shared/ui/FormField.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from 'react'
 import { Label } from '@/shared/ui/label'
 import { cn } from '@/shared/lib/utils'
-import { AlertCircle, Info } from 'lucide-react'
+import { Info } from 'lucide-react'
 
 interface FormFieldProps {
   label: ReactNode
@@ -28,7 +28,7 @@ export function FormField({ label, htmlFor, helpId, required, hint, error, child
         )}
       </Label>
       {children}
-      {(hasError || hint || helpId) && (
+      {(hasError || hint) && (
         <p
           id={helpId}
           aria-live="polite"
@@ -37,9 +37,7 @@ export function FormField({ label, htmlFor, helpId, required, hint, error, child
             hasError ? 'text-destructive' : 'text-muted-foreground',
           )}
         >
-          {hasError ? (
-            <AlertCircle className="size-3 shrink-0" aria-hidden />
-          ) : hint ? (
+          {!hasError && hint ? (
             <Info className="size-3 shrink-0 opacity-60" aria-hidden />
           ) : null}
           <span>{hasError ? error : hint}</span>


### PR DESCRIPTION
This pull request implements clearer field-level validation feedback on the auth forms and removes the empty space that was always reserved below each input.

**Specific required messages**
- Empty email/password now show per-field copy instead of the generic "required" message, in both ES and EN.
- Added reusable `validation.emailRequired` / `validation.passwordRequired` keys to the shared `common` namespace; applied in both Login and Register.

**FormField (shared) cleanup**
- Removed the `AlertCircle` error icon so the error line is text-only (the `Info` hint icon stays).
- The error/hint line now renders only when there is actual content (dropped the `helpId`-only trigger), so the empty reserved line under inputs is gone and the layout shifts only when an error appears. Affects all forms using FormField (Login, Register, Accounts, AccountConfig).

**Tests**
- Updated Login/Register tests to assert the new per-field messages. Full suites pass; typecheck and lint are clean.