### PR TITLE
Restyle toast with glass surface and button variants

### DIFF
--- a/client/src/shared/ui/sonner.tsx
+++ b/client/src/shared/ui/sonner.tsx
@@ -1,5 +1,10 @@
 import { Toaster as SonnerToaster, type ToasterProps } from 'sonner'
 
+const glassToast =
+  'group border-0 p-3.5 text-[13px] text-foreground [backdrop-filter:blur(20px)_saturate(160%)] shadow-[inset_0_0_0_1px_oklch(1_0_0_/_0.08),0_16px_48px_oklch(0_0_0_/_0.5)]'
+
+const glassSurface = '!bg-[oklch(0.10_0_0_/_0.92)] !text-[oklch(0.92_0_0)]'
+
 export function Toaster(props: ToasterProps) {
   return (
     <SonnerToaster
@@ -7,19 +12,26 @@ export function Toaster(props: ToasterProps) {
       position="bottom-right"
       richColors={false}
       closeButton={false}
+      style={
+        {
+          '--border-radius': 'var(--radius-lg)',
+        } as React.CSSProperties
+      }
       toastOptions={{
         classNames: {
-          toast:
-            'group rounded-xl border-0 p-4 text-[13px] shadow-[inset_0_0_0_1px_oklch(1_0_0_/_0.1),0_24px_60px_oklch(0_0_0_/_0.5)] backdrop-blur-xl',
+          toast: `${glassToast} ${glassSurface}`,
           title: 'font-medium tracking-[0.01em]',
-          description: 'text-xs opacity-70',
-          success:
-            '!bg-[oklch(0.11_0_0_/_0.94)] !text-[oklch(0.95_0_0)] [&_[data-icon]]:!text-[oklch(0.78_0.14_150)]',
-          error:
-            '!bg-[oklch(0.11_0_0_/_0.94)] !text-[oklch(0.95_0_0)] [&_[data-icon]]:!text-[oklch(0.7_0.18_28)]',
-          info: '!bg-[oklch(0.11_0_0_/_0.94)] !text-[oklch(0.95_0_0)]',
+          description: 'text-xs text-muted-foreground',
+          success: `[&_[data-icon]]:!text-[oklch(0.78_0.14_150)]`,
+          error: `[&_[data-icon]]:!text-[oklch(0.7_0.18_28)]`,
+          info: `[&_[data-icon]]:!text-[oklch(0.75_0.12_250)]`,
+          warning: `[&_[data-icon]]:!text-[oklch(0.82_0.14_85)]`,
+          loading: `[&_[data-icon]]:!text-[oklch(0.75_0_0)]`,
+          default: '',
           actionButton:
-            '!bg-[oklch(0.95_0_0)] !text-[oklch(0.12_0_0)] !rounded-md !text-[11px] !uppercase !tracking-[0.18em]',
+            '!h-7 !rounded-lg !border-0 !px-2.5 !bg-primary !text-primary-foreground !text-[11px] !font-medium !uppercase !tracking-[0.12em] hover:!bg-primary/80',
+          cancelButton:
+            '!h-7 !rounded-lg !border !border-border !px-2.5 !bg-transparent !text-foreground !text-[11px] !font-medium hover:!bg-muted/50',
         },
       }}
       {...props}


### PR DESCRIPTION
This pull request implements a visual refresh of the Sonner toast component.

- Replaces the toast surface with a darker, more translucent glass style (stronger backdrop blur/saturation, refined inset border and shadow) extracted into reusable `glassToast` / `glassSurface` class constants.
- Drives the toast corner radius from the design token via `--border-radius: var(--radius-lg)`.
- Simplifies per-type styling: success/error/info now only tint their icon, and adds `warning`, `loading`, and `default` variants for full coverage.
- Reworks the action button to use the primary token colors and adds a matching `cancelButton` variant.
- Switches the description text to the `muted-foreground` token instead of a hardcoded opacity.

Visual-only change; no behavior or API changes.