### PR TITLE
Add Checkbox component and use it for API key scope selection

### DIFF
--- a/client/src/features/user/components/ApiKeysSection.tsx
+++ b/client/src/features/user/components/ApiKeysSection.tsx
@@ -27,12 +27,9 @@ export function ApiKeysSection() {
   const [copied, setCopied] = useState(false)
 
   const setScope = (scope: ApiScope, checked: boolean) =>
-    setScopes(prev => {
-      const has = prev.includes(scope)
-      if (checked && !has) return [...prev, scope]
-      if (!checked && has) return prev.filter(x => x !== scope)
-      return prev
-    })
+    setScopes(prev =>
+      checked ? [...new Set([...prev, scope])] : prev.filter(x => x !== scope),
+    )
 
   const handleCreate = () => {
     /* v8 ignore next 1 -- the create button is disabled while name/scopes are invalid; guard is defensive. */

--- a/client/src/features/user/components/ApiKeysSection.tsx
+++ b/client/src/features/user/components/ApiKeysSection.tsx
@@ -3,10 +3,12 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { Copy, KeyRound, Trash2, Check } from 'lucide-react'
+import { cn } from '@/shared/lib/utils'
 import { Input } from '@/shared/ui/input'
 import { Label } from '@/shared/ui/label'
 import { Button } from '@/shared/ui/button'
 import { Badge } from '@/shared/ui/badge'
+import { Checkbox } from '@/shared/ui/checkbox'
 import { useApiKeys, useCreateApiKey, useRevokeApiKey } from '../hooks/useApiKeys'
 import type { ApiScope } from '../api/apiKeys'
 
@@ -24,8 +26,13 @@ export function ApiKeysSection() {
   const [createdSecret, setCreatedSecret] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
 
-  const toggleScope = (s: ApiScope) =>
-    setScopes(prev => (prev.includes(s) ? prev.filter(x => x !== s) : [...prev, s]))
+  const setScope = (scope: ApiScope, checked: boolean) =>
+    setScopes(prev => {
+      const has = prev.includes(scope)
+      if (checked && !has) return [...prev, scope]
+      if (!checked && has) return prev.filter(x => x !== scope)
+      return prev
+    })
 
   const handleCreate = () => {
     /* v8 ignore next 1 -- the create button is disabled while name/scopes are invalid; guard is defensive. */
@@ -85,13 +92,24 @@ export function ApiKeysSection() {
         </div>
         <div className="grid gap-1.5">
           <Label>{t('settings.apiKeys.scopes')}</Label>
-          <div className="flex flex-wrap gap-3">
-            {ALL_SCOPES.map(s => (
-              <label key={s} className="flex items-center gap-2 text-sm">
-                <input type="checkbox" className="size-4" checked={scopes.includes(s)} onChange={() => toggleScope(s)} />
-                <code className="text-xs">{s}</code>
-              </label>
-            ))}
+          <div className="grid gap-2 sm:grid-cols-2">
+            {ALL_SCOPES.map(s => {
+              const selected = scopes.includes(s)
+              return (
+                <label
+                  key={s}
+                  className={cn(
+                    'flex cursor-pointer items-center gap-3 rounded-lg border px-3 py-2.5 transition-colors',
+                    selected
+                      ? 'border-primary/40 bg-primary/5 ring-1 ring-primary/15'
+                      : 'border-border bg-background hover:border-muted-foreground/25 hover:bg-muted/30',
+                  )}
+                >
+                  <Checkbox checked={selected} onCheckedChange={checked => setScope(s, checked)} />
+                  <code className="text-xs font-mono text-foreground">{s}</code>
+                </label>
+              )
+            })}
           </div>
         </div>
         <div>

--- a/client/src/shared/ui/checkbox.test.tsx
+++ b/client/src/shared/ui/checkbox.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { Checkbox } from '@/shared/ui/checkbox'
+
+describe('Checkbox', () => {
+  it('renders with checkbox data-slot', () => {
+    render(<Checkbox data-testid="cb" aria-label="toggle" />)
+    expect(screen.getByTestId('cb')).toHaveAttribute('data-slot', 'checkbox')
+  })
+
+  it('merges custom className', () => {
+    render(<Checkbox data-testid="cb" className="c-cb" aria-label="toggle" />)
+    expect(screen.getByTestId('cb').className).toContain('c-cb')
+  })
+
+  it('toggles via user click', async () => {
+    const user = userEvent.setup()
+    render(<Checkbox data-testid="cb" aria-label="toggle" />)
+    const el = screen.getByTestId('cb')
+    expect(el).toHaveAttribute('aria-checked', 'false')
+    await user.click(el)
+    expect(el).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('shows a checkmark when checked', () => {
+    render(<Checkbox checked aria-label="toggle" />)
+    expect(document.querySelector('[data-slot="checkbox-indicator"] svg polyline')).toBeTruthy()
+  })
+})

--- a/client/src/shared/ui/checkbox.tsx
+++ b/client/src/shared/ui/checkbox.tsx
@@ -1,0 +1,39 @@
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox"
+
+import { cn } from "@/shared/lib/utils"
+
+function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer inline-flex size-4 shrink-0 items-center justify-center rounded-[5px] border border-input bg-background shadow-xs outline-none transition-all",
+        "focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        "data-checked:border-primary data-checked:bg-primary",
+        "dark:data-unchecked:bg-input/30",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex size-full items-center justify-center text-primary-foreground"
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          strokeWidth="3"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="size-3 stroke-primary-foreground"
+          aria-hidden="true"
+        >
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }


### PR DESCRIPTION
This pull request implements a reusable `Checkbox` component (built on `@base-ui/react`) and adopts it in the API key scope selector.

- Adds `client/src/shared/ui/checkbox.tsx` with an accessible checkbox and indicator checkmark, plus unit tests covering rendering, className merging, click toggling, and the checked indicator.
- Replaces the raw `<input type="checkbox">` list in `ApiKeysSection` with the new component, rendering each scope as a clickable card in a responsive two-column grid with selected styling.
- Refactors scope toggling from `toggleScope` to an idempotent `setScope(scope, checked)` driven by the checkbox `onCheckedChange`.
- Fixes a dark-mode bug where the checked background and checkmark were invisible: an unconditional `dark:bg-input/30` tied in specificity with `data-checked:bg-primary` and overrode it, leaving a dark box with a near-black (invisible) check. Dropping the unconditional class lets the checked state render its primary fill.