### PR TITLE
Require TOTP code to revoke API keys with 2FA

### DIFF
--- a/client/src/features/user/api/apiKeys.ts
+++ b/client/src/features/user/api/apiKeys.ts
@@ -37,6 +37,8 @@ export async function createApiKey(input: {
   return data
 }
 
-export async function revokeApiKey(id: string): Promise<void> {
-  await httpClient.delete(`/me/api-keys/${id}`)
+export async function revokeApiKey(id: string, code?: string): Promise<void> {
+  // Send the TOTP code in the body only when present; the backend requires it
+  // when the user has 2FA enabled and ignores it otherwise.
+  await httpClient.delete(`/me/api-keys/${id}`, code ? { data: { code } } : undefined)
 }

--- a/client/src/features/user/components/ApiKeysSection.test.tsx
+++ b/client/src/features/user/components/ApiKeysSection.test.tsx
@@ -29,7 +29,12 @@ function listHandler(keys: ApiKey[]) {
 
 describe('ApiKeysSection', () => {
   beforeEach(() => {
-    server.use(listHandler([]))
+    server.use(
+      http.get('/api/me', () =>
+        HttpResponse.json({ id: 'u-1', email: 'test@x', name: 'T', operation_mode: 'passthrough', totp_enabled: false })
+      ),
+      listHandler([]),
+    )
   })
 
   it('shows the empty state when there are no active keys', async () => {
@@ -58,7 +63,8 @@ describe('ApiKeysSection', () => {
     await screen.findByText('No hay llaves activas.')
     expect(screen.getByText('Enviar código OTP')).toBeInTheDocument()
     expect(screen.getByText('Leer estado de la cuenta')).toBeInTheDocument()
-    expect(screen.getAllByText('Endpoint')).toHaveLength(2)
+    expect(screen.getByText('POST')).toBeInTheDocument()
+    expect(screen.getByText('GET')).toBeInTheDocument()
     expect(screen.getByText(/\/v1\/accounts\/\{accountId\}\/otp/)).toBeInTheDocument()
     expect(screen.getByText(/\/v1\/accounts\/\{accountId\}\/status/)).toBeInTheDocument()
   })
@@ -157,9 +163,10 @@ describe('ApiKeysSection', () => {
     expect(await screen.findByText('No se pudo crear la llave')).toBeInTheDocument()
   })
 
-  it('revokes a key and refreshes the list', async () => {
+  it('revokes a key via the confirm dialog when 2FA is off', async () => {
     const user = userEvent.setup()
     let revokedId: string | null = null
+    let sentBody: unknown = 'unset'
     server.use(
       http.get('/api/me/api-keys', () =>
         HttpResponse.json({
@@ -167,8 +174,44 @@ describe('ApiKeysSection', () => {
           available_scopes: ['otp:write', 'status:read'],
         })
       ),
-      http.delete('/api/me/api-keys/:id', ({ params }) => {
+      http.delete('/api/me/api-keys/:id', async ({ params, request }) => {
+        sentBody = await request.json().catch(() => null)
         revokedId = params.id as string
+        return new HttpResponse(null, { status: 204 })
+      })
+    )
+    renderWithProviders(<ApiKeysSection />)
+
+    await screen.findByText('SMS server')
+    // The trash icon opens the confirm dialog; nothing is revoked yet.
+    await user.click(screen.getByRole('button', { name: 'Revocar' }))
+    expect(revokedId).toBeNull()
+    // With 2FA off there is no code field.
+    expect(screen.queryByPlaceholderText('123456')).not.toBeInTheDocument()
+    // The only visible "Revocar" text is the dialog's confirm button.
+    await user.click(screen.getByText('Revocar'))
+
+    expect(await screen.findByText('Llave revocada')).toBeInTheDocument()
+    expect(revokedId).toBe('k-1')
+    // No code sent on the 2FA-off path.
+    expect(sentBody).toBeNull()
+    expect(await screen.findByText('No hay llaves activas.')).toBeInTheDocument()
+  })
+
+  it('requires a TOTP code to revoke when 2FA is enabled', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('/api/me', () =>
+        HttpResponse.json({ id: 'u-1', email: 'test@x', name: 'T', operation_mode: 'passthrough', totp_enabled: true })
+      ),
+      http.get('/api/me/api-keys', () =>
+        HttpResponse.json({ keys: [key()], available_scopes: ['otp:write', 'status:read'] })
+      ),
+      http.delete('/api/me/api-keys/:id', async ({ request }) => {
+        const body = (await request.json().catch(() => ({}))) as { code?: string }
+        if (body.code !== '123456') {
+          return HttpResponse.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid code' } }, { status: 401 })
+        }
         return new HttpResponse(null, { status: 204 })
       })
     )
@@ -177,8 +220,17 @@ describe('ApiKeysSection', () => {
     await screen.findByText('SMS server')
     await user.click(screen.getByRole('button', { name: 'Revocar' }))
 
+    // A wrong code keeps the dialog open and shows an inline error.
+    const input = await screen.findByPlaceholderText('123456')
+    await user.type(input, '000000')
+    await user.click(screen.getByText('Revocar'))
+    expect(await screen.findByText('Código inválido, probá de nuevo')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('123456')).toBeInTheDocument()
+
+    // The correct code revokes the key.
+    await user.clear(input)
+    await user.type(input, '123456')
+    await user.click(screen.getByText('Revocar'))
     expect(await screen.findByText('Llave revocada')).toBeInTheDocument()
-    expect(revokedId).toBe('k-1')
-    expect(await screen.findByText('No hay llaves activas.')).toBeInTheDocument()
   })
 })

--- a/client/src/features/user/components/ApiKeysSection.test.tsx
+++ b/client/src/features/user/components/ApiKeysSection.test.tsx
@@ -233,4 +233,104 @@ describe('ApiKeysSection', () => {
     await user.click(screen.getByText('Revocar'))
     expect(await screen.findByText('Llave revocada')).toBeInTheDocument()
   })
+
+  it('toasts the localized backend error when a revoke fails with a known code', async () => {
+    const user = userEvent.setup()
+    server.use(
+      listHandler([key()]),
+      http.delete('/api/me/api-keys/:id', () =>
+        HttpResponse.json({ error: { code: 'CONFLICT', message: 'nope' } }, { status: 400 })
+      )
+    )
+    renderWithProviders(<ApiKeysSection />)
+
+    await screen.findByText('SMS server')
+    await user.click(screen.getByRole('button', { name: 'Revocar' }))
+    await user.click(screen.getByText('Revocar'))
+
+    expect(await screen.findByText('Ya existe un registro con esos datos')).toBeInTheDocument()
+  })
+
+  it('falls back to the generic revoke error when a 2FA revoke fails without a message', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('/api/me', () =>
+        HttpResponse.json({ id: 'u-1', email: 'test@x', name: 'T', operation_mode: 'passthrough', totp_enabled: true })
+      ),
+      listHandler([key()]),
+      http.delete('/api/me/api-keys/:id', () => new HttpResponse(null, { status: 500 }))
+    )
+    renderWithProviders(<ApiKeysSection />)
+
+    await screen.findByText('SMS server')
+    await user.click(screen.getByRole('button', { name: 'Revocar' }))
+    const input = await screen.findByPlaceholderText('123456')
+    await user.type(input, '123456')
+    await user.click(screen.getByText('Revocar'))
+
+    expect(await screen.findByText('No se pudo revocar la llave')).toBeInTheDocument()
+  })
+
+  it('dismisses the one-time secret dialog when closed via escape', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.post('/api/me/api-keys', () =>
+        HttpResponse.json({ ...key(), key: 'rbk_abcd1234_secret' }, { status: 201 })
+      )
+    )
+    renderWithProviders(<ApiKeysSection />)
+
+    await screen.findByText('No hay llaves activas.')
+    await user.type(screen.getByLabelText('Nombre'), 'My key')
+    await user.click(screen.getByRole('button', { name: /Crear llave/ }))
+    expect(await screen.findByText('rbk_abcd1234_secret')).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+    await waitFor(() => expect(screen.queryByText('rbk_abcd1234_secret')).not.toBeInTheDocument())
+  })
+
+  it('ignores Enter in the code field until a 2FA code is entered', async () => {
+    const user = userEvent.setup()
+    let deleteCalled = false
+    server.use(
+      http.get('/api/me', () =>
+        HttpResponse.json({ id: 'u-1', email: 'test@x', name: 'T', operation_mode: 'passthrough', totp_enabled: true })
+      ),
+      listHandler([key()]),
+      http.delete('/api/me/api-keys/:id', () => {
+        deleteCalled = true
+        return new HttpResponse(null, { status: 204 })
+      })
+    )
+    renderWithProviders(<ApiKeysSection />)
+
+    await screen.findByText('SMS server')
+    await user.click(screen.getByRole('button', { name: 'Revocar' }))
+    const input = await screen.findByPlaceholderText('123456')
+
+    // Enter with an empty code is a no-op: nothing is sent and the dialog stays open.
+    await user.click(input)
+    await user.keyboard('{Enter}')
+    expect(deleteCalled).toBe(false)
+    expect(screen.getByPlaceholderText('123456')).toBeInTheDocument()
+
+    // Enter once a code is present submits the revoke.
+    await user.type(input, '123456')
+    await user.keyboard('{Enter}')
+    expect(await screen.findByText('Llave revocada')).toBeInTheDocument()
+    expect(deleteCalled).toBe(true)
+  })
+
+  it('closes the revoke dialog when dismissed via escape', async () => {
+    const user = userEvent.setup()
+    server.use(listHandler([key()]))
+    renderWithProviders(<ApiKeysSection />)
+
+    await screen.findByText('SMS server')
+    await user.click(screen.getByRole('button', { name: 'Revocar' }))
+    expect(await screen.findByText('Revocar llave')).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+    await waitFor(() => expect(screen.queryByText('Revocar llave')).not.toBeInTheDocument())
+  })
 })

--- a/client/src/features/user/components/ApiKeysSection.tsx
+++ b/client/src/features/user/components/ApiKeysSection.tsx
@@ -116,6 +116,7 @@ export function ApiKeysSection() {
       <Dialog
         open={createdSecret !== null}
         onOpenChange={o => {
+          /* v8 ignore next 4 -- dialog has no internal trigger so the truthy branch is defensive */
           if (!o) {
             setCreatedSecret(null)
             setCopied(false)
@@ -185,7 +186,13 @@ export function ApiKeysSection() {
       </Dialog>
 
       {/* Revoke confirmation — requires a current TOTP code when 2FA is enabled */}
-      <Dialog open={revokeTarget !== null} onOpenChange={o => { if (!o) closeRevoke() }}>
+      <Dialog
+        open={revokeTarget !== null}
+        onOpenChange={o => {
+          /* v8 ignore next -- dialog has no internal trigger so the truthy branch is defensive */
+          if (!o) closeRevoke()
+        }}
+      >
         <DialogContent
           forceOverlay
           overlayClassName="bg-black/75 supports-backdrop-filter:backdrop-blur-sm"

--- a/client/src/features/user/components/ApiKeysSection.tsx
+++ b/client/src/features/user/components/ApiKeysSection.tsx
@@ -1,16 +1,18 @@
 import { localizedApiError } from '@/shared/http/client'
-import { useState } from 'react'
+import { Fragment, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
-import { Copy, KeyRound, Trash2, Check } from 'lucide-react'
+import { Copy, KeyRound, Trash2, Check, AlertTriangle } from 'lucide-react'
 import { cn } from '@/shared/lib/utils'
 import { Input } from '@/shared/ui/input'
 import { Label } from '@/shared/ui/label'
 import { Button } from '@/shared/ui/button'
 import { Badge } from '@/shared/ui/badge'
 import { Checkbox } from '@/shared/ui/checkbox'
+import { Dialog, DialogContent, DialogTitle, DialogDescription } from '@/shared/ui/dialog'
 import { useApiKeys, useCreateApiKey, useRevokeApiKey } from '../hooks/useApiKeys'
-import type { ApiScope } from '../api/apiKeys'
+import { useUser } from '../hooks/useUser'
+import type { ApiKey, ApiScope } from '../api/apiKeys'
 
 // Each scope maps to exactly one /v1 endpoint; the method+path are language-neutral so they live here, not in i18n
 const SCOPES: { scope: ApiScope; key: string; method: string; path: string }[] = [
@@ -28,6 +30,7 @@ const METHOD_STYLES: Record<string, string> = {
 export function ApiKeysSection() {
   const { t } = useTranslation('user')
   const { data } = useApiKeys()
+  const { data: me } = useUser()
   const create = useCreateApiKey()
   const revoke = useRevokeApiKey()
 
@@ -35,6 +38,45 @@ export function ApiKeysSection() {
   const [scopes, setScopes] = useState<ApiScope[]>(['otp:write'])
   const [createdSecret, setCreatedSecret] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
+
+  // Key pending revocation; opening the dialog. 2FA users must enter a code.
+  const [revokeTarget, setRevokeTarget] = useState<ApiKey | null>(null)
+  const [revokeCode, setRevokeCode] = useState('')
+  const [revokeCodeError, setRevokeCodeError] = useState(false)
+
+  const requires2fa = me?.totpEnabled ?? false
+
+  const closeRevoke = () => {
+    setRevokeTarget(null)
+    setRevokeCode('')
+    setRevokeCodeError(false)
+  }
+
+  const submitRevoke = () => {
+    /* v8 ignore next 1 -- the submit button only renders while a target is set; guard is defensive. */
+    if (!revokeTarget) return
+    if (requires2fa && !revokeCode.trim()) return
+    setRevokeCodeError(false)
+    revoke.mutate(
+      { id: revokeTarget.id, code: requires2fa ? revokeCode.trim() : undefined },
+      {
+        onSuccess: () => {
+          toast.success(t('settings.apiKeys.revoked'))
+          closeRevoke()
+        },
+        onError: (err) => {
+          const status = (err as { response?: { status?: number } })?.response?.status
+          // A 401 on the 2FA path means the code was wrong — keep the dialog open
+          // and surface an inline error instead of a toast.
+          if (requires2fa && status === 401) {
+            setRevokeCodeError(true)
+            return
+          }
+          toast.error(localizedApiError(err) ?? t('settings.apiKeys.revokeError'))
+        },
+      },
+    )
+  }
 
   const setScope = (scope: ApiScope, checked: boolean) =>
     setScopes(prev =>
@@ -61,7 +103,7 @@ export function ApiKeysSection() {
   const copySecret = async () => {
     /* v8 ignore next 1 -- the copy button only renders when a secret exists; guard is defensive. */
     if (!createdSecret) return
-    await navigator.clipboard.writeText(createdSecret).catch(() => {})
+    await navigator.clipboard.writeText(createdSecret).catch(() => { })
     setCopied(true)
     setTimeout(() => setCopied(false), 1500)
   }
@@ -69,43 +111,163 @@ export function ApiKeysSection() {
   const keys = data?.keys.filter(k => !k.revoked_at) ?? []
 
   return (
-    <div className="mt-6 space-y-5">
-      {/* One-time secret reveal */}
-      {createdSecret && (
-        <div className="space-y-3 rounded-2xl border border-amber-300/25 bg-amber-300/[0.08] p-4 shadow-[inset_0_1px_0_oklch(1_0_0_/_0.08)]">
-          <div className="space-y-0.5">
-            <p className="text-[13px] font-semibold text-amber-50">{t('settings.apiKeys.secretTitle')}</p>
-            <p className="text-xs leading-relaxed text-amber-50/65">{t('settings.apiKeys.secretHelp')}</p>
-          </div>
-          <div className="flex items-center gap-2">
-            <code className="flex-1 truncate rounded-xl border border-white/10 bg-black/25 px-3 py-2 text-xs font-mono text-amber-50">{createdSecret}</code>
-            <Button size="icon-sm" variant="outline" onClick={copySecret} className="border-amber-50/15 bg-amber-50/10 text-amber-50 hover:bg-amber-50/15">
-              {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
-            </Button>
-          </div>
-          <Button size="sm" variant="ghost" onClick={() => setCreatedSecret(null)} className="text-amber-50/80 hover:bg-amber-50/10 hover:text-amber-50">
-            {t('settings.apiKeys.dismiss')}
-          </Button>
-        </div>
-      )}
+    <>
+      {/* One-time secret reveal — modal over the settings dialog */}
+      <Dialog
+        open={createdSecret !== null}
+        onOpenChange={o => {
+          if (!o) {
+            setCreatedSecret(null)
+            setCopied(false)
+          }
+        }}
+      >
+        <DialogContent
+          forceOverlay
+          overlayClassName="bg-black/75 supports-backdrop-filter:backdrop-blur-sm"
+          className="overflow-hidden border-0 p-0 ring-0 sm:!max-w-[540px]"
+          style={{
+            background: 'oklch(0.12 0.008 85 / 0.97)',
+            backdropFilter: 'blur(28px) saturate(160%)',
+            WebkitBackdropFilter: 'blur(28px) saturate(160%)',
+            boxShadow:
+              'inset 0 0 0 1px oklch(0.83 0.13 85 / 0.26), 0 32px 90px oklch(0 0 0 / 0.7)',
+            color: 'oklch(0.92 0 0)',
+          }}
+        >
+          {/* amber accent hairline along the top edge */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 top-0 h-px"
+            style={{ background: 'linear-gradient(90deg, transparent, oklch(0.83 0.14 85 / 0.7), transparent)' }}
+          />
+          <div className="grid min-w-0 gap-5 p-6">
+            <div className="flex items-start gap-3 pr-6">
+              <div className="grid size-9 shrink-0 place-items-center rounded-xl border border-amber-300/25 bg-amber-300/[0.12]">
+                <KeyRound className="size-4 text-amber-300" />
+              </div>
+              <div className="min-w-0 space-y-1.5">
+                <DialogTitle className="text-[15px] font-semibold leading-tight tracking-[-0.01em] text-amber-50">
+                  {t('settings.apiKeys.secretTitle')}
+                </DialogTitle>
+                <DialogDescription className="text-xs leading-relaxed text-amber-50/60">
+                  {t('settings.apiKeys.secretHelp')}
+                </DialogDescription>
+              </div>
+            </div>
 
-      {/* Create */}
-      <div className="relative overflow-hidden rounded-2xl border border-white/[0.09] bg-white/[0.035] p-4 shadow-[inset_0_1px_0_oklch(1_0_0_/_0.07)]">
-        <div
-          aria-hidden
-          className="pointer-events-none absolute -right-20 -top-28 size-56 rounded-full opacity-40 blur-3xl"
-          style={{ background: 'radial-gradient(circle, oklch(0.72 0 0 / 0.22), transparent 68%)' }}
-        />
-        <div className="relative grid gap-5">
-          <div className="space-y-1">
-            <p className="text-[10px] uppercase tracking-[0.22em]" style={{ color: 'oklch(0.55 0 0)' }}>
-              {t('settings.apiKeys.scopes')}
-            </p>
-            <h3 className="text-[18px] font-semibold leading-tight tracking-[-0.03em]" style={{ color: 'oklch(0.96 0 0)' }}>
-              {t('settings.apiKeys.subtitle')}
-            </h3>
-          </div>
+            <div className="min-w-0 space-y-2.5 rounded-xl border border-white/10 bg-black/35 p-3.5 shadow-[inset_0_1px_0_oklch(1_0_0_/_0.04)]">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-[10px] uppercase tracking-[0.2em] text-white/35">API key</span>
+                <Button
+                  size="icon-sm"
+                  variant="outline"
+                  onClick={copySecret}
+                  className="border-amber-50/15 bg-amber-50/10 text-amber-50 hover:bg-amber-50/15"
+                >
+                  {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+                </Button>
+              </div>
+              <code className="block select-all truncate font-mono text-[12.5px] text-amber-50">{createdSecret}</code>
+            </div>
 
+            <div className="flex justify-end">
+              <Button
+                size="sm"
+                onClick={() => setCreatedSecret(null)}
+                className="border-0 bg-white px-4 text-[11px] font-semibold uppercase tracking-[0.16em] text-black hover:bg-white/90"
+              >
+                {t('settings.apiKeys.dismiss')}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Revoke confirmation — requires a current TOTP code when 2FA is enabled */}
+      <Dialog open={revokeTarget !== null} onOpenChange={o => { if (!o) closeRevoke() }}>
+        <DialogContent
+          forceOverlay
+          overlayClassName="bg-black/75 supports-backdrop-filter:backdrop-blur-sm"
+          className="overflow-hidden border-0 p-0 ring-0 sm:!max-w-[460px]"
+          style={{
+            background: 'oklch(0.12 0.01 28 / 0.97)',
+            backdropFilter: 'blur(28px) saturate(160%)',
+            WebkitBackdropFilter: 'blur(28px) saturate(160%)',
+            boxShadow: 'inset 0 0 0 1px oklch(0.55 0.18 28 / 0.30), 0 32px 90px oklch(0 0 0 / 0.7)',
+            color: 'oklch(0.92 0 0)',
+          }}
+        >
+          <div className="grid min-w-0 gap-5 p-6">
+            <div className="flex items-start gap-3 pr-6">
+              <div className="grid size-9 shrink-0 place-items-center rounded-xl border border-rose-400/25 bg-rose-400/[0.12]">
+                <AlertTriangle className="size-4 text-rose-300" />
+              </div>
+              <div className="min-w-0 space-y-1.5">
+                <DialogTitle className="text-[15px] font-semibold leading-tight tracking-[-0.01em] text-rose-50">
+                  {t('settings.apiKeys.revokeTitle')}
+                </DialogTitle>
+                <DialogDescription className="text-xs leading-relaxed text-rose-50/65">
+                  {t('settings.apiKeys.revokeBody')}
+                </DialogDescription>
+                {revokeTarget && (
+                  <p className="truncate text-xs">
+                    <span className="font-semibold text-white/80">{revokeTarget.name}</span>
+                    <span className="ml-1.5 font-mono text-white/40">rbk_{revokeTarget.prefix}_…</span>
+                  </p>
+                )}
+              </div>
+            </div>
+
+            {requires2fa && (
+              <div className="grid gap-1.5">
+                <Label htmlFor="revoke-2fa-code" className="text-[10px] uppercase tracking-[0.2em]" style={{ color: 'oklch(0.5 0 0)' }}>
+                  {t('settings.apiKeys.revoke2faHint')}
+                </Label>
+                <Input
+                  id="revoke-2fa-code"
+                  value={revokeCode}
+                  onChange={e => { setRevokeCode(e.target.value); setRevokeCodeError(false) }}
+                  autoComplete="one-time-code"
+                  inputMode="numeric"
+                  autoFocus
+                  placeholder="123456"
+                  onKeyDown={e => { if (e.key === 'Enter') submitRevoke() }}
+                  className="settings-input border-white/10 bg-black/20 text-[13px] text-white placeholder:text-white/30 focus-visible:border-white/25 focus-visible:ring-white/10"
+                />
+                {revokeCodeError && (
+                  <p className="text-xs text-rose-300">{t('settings.security.codeError')}</p>
+                )}
+              </div>
+            )}
+
+            <div className="flex justify-end gap-2">
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={closeRevoke}
+                disabled={revoke.isPending}
+                className="text-[11px] uppercase tracking-[0.16em] text-white/60 hover:bg-white/10 hover:text-white"
+              >
+                {t('settings.apiKeys.cancel')}
+              </Button>
+              <Button
+                size="sm"
+                onClick={submitRevoke}
+                disabled={revoke.isPending || (requires2fa && !revokeCode.trim())}
+                className="border-0 px-4 text-[11px] font-semibold uppercase tracking-[0.16em] text-white"
+                style={{ background: 'oklch(0.55 0.2 28)' }}
+              >
+                {t('settings.apiKeys.revokeConfirm')}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <div className="mt-6 space-y-5">
+        {/* Create */}
+        <div className="grid gap-5">
           <div className="grid gap-1.5">
             <Label
               htmlFor="apikey-name"
@@ -132,52 +294,40 @@ export function ApiKeysSection() {
                 v1 API
               </span>
             </div>
-            <div className="grid gap-2.5 sm:grid-cols-2">
+            <div>
+              <hr className="border-white/[0.08]" />
               {SCOPES.map(({ scope, key, method, path }) => {
                 const selected = scopes.includes(scope)
                 return (
-                  <label
-                    key={scope}
-                    className={cn(
-                      'group flex min-h-[154px] cursor-pointer flex-col justify-between gap-4 rounded-2xl border p-3 transition-all',
-                      selected
-                        ? 'border-white/20 bg-white/[0.07] shadow-[inset_0_1px_0_oklch(1_0_0_/_0.08),0_18px_45px_oklch(0_0_0_/_0.18)]'
-                        : 'border-white/[0.08] bg-black/10 hover:border-white/15 hover:bg-white/[0.045]',
-                    )}
-                  >
-                    <div className="flex items-start gap-3">
+                  <Fragment key={scope}>
+                    <label className="group flex cursor-pointer items-start gap-3 py-4">
                       <Checkbox
                         className="mt-0.5 border-white/20 bg-black/30 data-checked:border-white data-checked:bg-white data-checked:[&_svg]:stroke-black"
                         checked={selected}
                         onCheckedChange={checked => setScope(scope, checked)}
                       />
-                      <div className="min-w-0 flex-1 space-y-1.5">
-                        <span className="block text-sm font-semibold leading-snug text-white">{t(`settings.apiKeys.scopeInfo.${key}.title`)}</span>
-                        <p className="text-xs leading-relaxed" style={{ color: 'oklch(0.68 0 0)' }}>{t(`settings.apiKeys.scopeInfo.${key}.desc`)}</p>
+                      <div className="min-w-0 flex-1 space-y-2">
+                        <div className="space-y-1">
+                          <span className="block text-sm font-semibold leading-snug text-white">{t(`settings.apiKeys.scopeInfo.${key}.title`)}</span>
+                          <p className="text-xs leading-relaxed" style={{ color: 'oklch(0.68 0 0)' }}>{t(`settings.apiKeys.scopeInfo.${key}.desc`)}</p>
+                        </div>
+                        <div className="flex min-w-0 flex-wrap items-center gap-2">
+                          <span className={cn('shrink-0 rounded-md border px-1.5 py-0.5 text-[10px] font-mono font-semibold', METHOD_STYLES[method])}>
+                            {method}
+                          </span>
+                          <code className="min-w-0 break-all font-mono text-[11px] leading-relaxed text-white/75">{path}</code>
+                          <code className="font-mono text-[10px] text-white/35">{scope}</code>
+                        </div>
                       </div>
-                    </div>
-                    <div className="space-y-2 rounded-xl border border-white/[0.08] bg-black/20 p-2.5">
-                      <div className="flex items-center justify-between gap-3">
-                        <span className="text-[9px] uppercase tracking-[0.22em] text-white/35">Endpoint</span>
-                        <code className="font-mono text-[10px] text-white/40">{scope}</code>
-                      </div>
-                      <div className="flex min-w-0 items-center gap-2">
-                        <span className={cn('shrink-0 rounded-md border px-1.5 py-0.5 text-[10px] font-mono font-semibold', METHOD_STYLES[method])}>
-                          {method}
-                        </span>
-                        <code className="min-w-0 break-words font-mono text-[11px] leading-relaxed text-white/78">{path}</code>
-                      </div>
-                    </div>
-                  </label>
+                    </label>
+                    <hr className="border-white/[0.08]" />
+                  </Fragment>
                 )
               })}
             </div>
           </div>
 
-          <div className="flex items-center justify-between gap-3 border-t border-white/[0.08] pt-4">
-            <p className="text-[11px] leading-relaxed text-white/40">
-              {scopes.length} / {SCOPES.length} scopes
-            </p>
+          <div className="flex items-center justify-end gap-3">
             <Button
               size="sm"
               onClick={handleCreate}
@@ -189,36 +339,41 @@ export function ApiKeysSection() {
             </Button>
           </div>
         </div>
-      </div>
 
-      {/* List */}
-      <div className="space-y-2">
-        {keys.length === 0 && (
-          <div className="rounded-2xl border border-dashed border-white/[0.10] bg-white/[0.02] px-4 py-5 text-sm text-white/45">
-            {t('settings.apiKeys.empty')}
-          </div>
-        )}
-        {keys.map(k => (
-          <div key={k.id} className="flex items-center justify-between gap-3 rounded-2xl border border-white/[0.09] bg-white/[0.035] p-3 shadow-[inset_0_1px_0_oklch(1_0_0_/_0.05)]">
-            <div className="min-w-0">
-              <p className="truncate text-sm font-semibold text-white">{k.name}</p>
-              <p className="font-mono text-xs text-white/45">rbk_{k.prefix}_…</p>
-              <div className="mt-1 flex flex-wrap gap-1">
-                {k.scopes.map(s => <Badge key={s} variant="secondary" className="border border-white/10 bg-white/[0.06] text-[10px] text-white/70">{s}</Badge>)}
-              </div>
-            </div>
-            <Button
-              size="icon-sm"
-              variant="ghost"
-              className="text-white/45 hover:bg-white/10 hover:text-white"
-              onClick={() => revoke.mutate(k.id, { onSuccess: () => toast.success(t('settings.apiKeys.revoked')) })}
-              aria-label={t('settings.apiKeys.revoke')}
-            >
-              <Trash2 className="size-3.5" />
-            </Button>
-          </div>
-        ))}
+        {/* List */}
+        <div>
+          {keys.length === 0 ? (
+            <p className="text-sm text-white/45">{t('settings.apiKeys.empty')}</p>
+          ) : (
+            <>
+              <hr className="border-white/[0.08]" />
+              {keys.map(k => (
+                <Fragment key={k.id}>
+                  <div className="flex items-center justify-between gap-3 py-3">
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-semibold text-white">{k.name}</p>
+                      <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+                        <p className="font-mono text-xs text-white/45">rbk_{k.prefix}_…</p>
+                        {k.scopes.map(s => <Badge key={s} variant="secondary" className="border border-white/10 bg-white/[0.06] text-[10px] text-white/70">{s}</Badge>)}
+                      </div>
+                    </div>
+                    <Button
+                      size="icon-sm"
+                      variant="ghost"
+                      className="text-white/45 hover:bg-white/10 hover:text-white"
+                      onClick={() => setRevokeTarget(k)}
+                      aria-label={t('settings.apiKeys.revoke')}
+                    >
+                      <Trash2 className="size-3.5" />
+                    </Button>
+                  </div>
+                  <hr className="border-white/[0.08]" />
+                </Fragment>
+              ))}
+            </>
+          )}
+        </div>
       </div>
-    </div>
+    </>
   )
 }

--- a/client/src/features/user/components/SettingsDialog.test.tsx
+++ b/client/src/features/user/components/SettingsDialog.test.tsx
@@ -74,31 +74,11 @@ describe('SettingsDialog', () => {
     expect(await screen.findByText(/Cargando.../i)).toBeInTheDocument()
   })
 
-  it('renders user details and the first-letter avatar', async () => {
-    server.use(meHandler({}))
-    renderWithProviders(<Host />)
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('Alice Smith')).toBeInTheDocument()
-    })
-    expect(screen.getByDisplayValue('user@x')).toBeInTheDocument()
-    // First initial of name shown in sidebar avatar
-    expect(screen.getByText('A')).toBeInTheDocument()
-  })
-
-  it('uses email initial when name is null', async () => {
-    server.use(meHandler({ name: null, email: 'zoe@x' }))
-    renderWithProviders(<Host />)
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('zoe@x')).toBeInTheDocument()
-    })
-    expect(screen.getByText('Z')).toBeInTheDocument()
-  })
-
   it('shows the 2FA enable action on the Security tab when 2FA is off', async () => {
     server.use(meHandler({ totpEnabled: false }))
     const user = userEvent.setup()
     renderWithProviders(<Host />)
-    await waitFor(() => expect(screen.getByDisplayValue('user@x')).toBeInTheDocument())
+    await screen.findByRole('heading', { name: /Seguridad/i })
     await user.click(screen.getByRole('tab', { name: /Seguridad/i }))
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /Activar 2FA/i })).toBeInTheDocument()
@@ -109,7 +89,7 @@ describe('SettingsDialog', () => {
     server.use(meHandler({ totpEnabled: true }))
     const user = userEvent.setup()
     renderWithProviders(<Host />)
-    await waitFor(() => expect(screen.getByDisplayValue('user@x')).toBeInTheDocument())
+    await screen.findByRole('heading', { name: /Seguridad/i })
     await user.click(screen.getByRole('tab', { name: /Seguridad/i }))
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /Desactivar 2FA/i })).toBeInTheDocument()
@@ -120,9 +100,7 @@ describe('SettingsDialog', () => {
     server.use(meHandler({ operationMode: 'passthrough' }))
     const user = userEvent.setup()
     renderWithProviders(<Host />)
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('user@x')).toBeInTheDocument()
-    })
+    await screen.findByRole('heading', { name: /Seguridad/i })
     await user.click(screen.getByRole('tab', { name: /Operación/i }))
     await waitFor(() => {
       expect(screen.getByText(/Actual/i)).toBeInTheDocument()
@@ -143,9 +121,7 @@ describe('SettingsDialog', () => {
     )
     const user = userEvent.setup()
     renderWithProviders(<Host />)
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('user@x')).toBeInTheDocument()
-    })
+    await screen.findByRole('heading', { name: /Seguridad/i })
     await user.click(screen.getByRole('tab', { name: /Operación/i }))
     await user.click(screen.getByRole('button', { name: /Cambiar modo/i }))
     // Now back card (reconcile) is interactive; click it
@@ -171,9 +147,7 @@ describe('SettingsDialog', () => {
     server.use(meHandler({ operationMode: 'passthrough' }))
     const user = userEvent.setup()
     renderWithProviders(<Host />)
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('user@x')).toBeInTheDocument()
-    })
+    await screen.findByRole('heading', { name: /Seguridad/i })
     await user.click(screen.getByRole('tab', { name: /Operación/i }))
     await user.click(screen.getByRole('button', { name: /Cambiar modo/i }))
     expect(
@@ -191,9 +165,7 @@ describe('SettingsDialog', () => {
     server.use(meHandler({ operationMode: 'passthrough' }))
     const user = userEvent.setup()
     renderWithProviders(<Host />)
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('user@x')).toBeInTheDocument()
-    })
+    await screen.findByRole('heading', { name: /Seguridad/i })
     await user.click(screen.getByRole('tab', { name: /Operación/i }))
     await user.click(screen.getByRole('button', { name: /Cambiar modo/i }))
     await user.click(
@@ -222,9 +194,7 @@ describe('SettingsDialog', () => {
     )
     const user = userEvent.setup()
     renderWithProviders(<Host />)
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('user@x')).toBeInTheDocument()
-    })
+    await screen.findByRole('heading', { name: /Seguridad/i })
     await user.click(screen.getByRole('tab', { name: /Operación/i }))
     await user.click(screen.getByRole('button', { name: /Cambiar modo/i }))
     await user.click(
@@ -246,9 +216,7 @@ describe('SettingsDialog', () => {
     )
     const user = userEvent.setup()
     renderWithProviders(<Host />)
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('user@x')).toBeInTheDocument()
-    })
+    await screen.findByRole('heading', { name: /Seguridad/i })
     await user.click(screen.getByRole('tab', { name: /Operación/i }))
     await user.click(screen.getByRole('button', { name: /Cambiar modo/i }))
     await user.click(
@@ -268,26 +236,12 @@ describe('SettingsDialog', () => {
     const onOpenChange = vi.fn()
     const user = userEvent.setup()
     renderWithProviders(<Host onOpenChange={onOpenChange} />)
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('user@x')).toBeInTheDocument()
-    })
+    await screen.findByRole('heading', { name: /Seguridad/i })
     // Press Escape to dismiss the dialog
     await user.keyboard('{Escape}')
     await waitFor(() => {
       expect(onOpenChange).toHaveBeenCalledWith(false)
     })
-  })
-
-  it('falls back to the "Profile" heading when name is missing', async () => {
-    server.use(meHandler({ name: null, email: 'zoe@x' }))
-    renderWithProviders(<Host />)
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('zoe@x')).toBeInTheDocument()
-    })
-    // Sidebar heading falls back to "settings.profile.name" → "Nombre"
-    const sidebar = screen
-      .getByRole('heading', { name: /Nombre/i, level: 2 })
-    expect(sidebar).toBeInTheDocument()
   })
 
   it('confirmChange is a no-op when no mode is selected', async () => {
@@ -305,9 +259,7 @@ describe('SettingsDialog', () => {
     )
     const user = userEvent.setup()
     renderWithProviders(<Host />)
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('user@x')).toBeInTheDocument()
-    })
+    await screen.findByRole('heading', { name: /Seguridad/i })
     await user.click(screen.getByRole('tab', { name: /Operación/i }))
     await user.click(screen.getByRole('button', { name: /Cambiar modo/i }))
     // Save remains disabled because nothing changed
@@ -320,9 +272,7 @@ describe('SettingsDialog', () => {
     server.use(meHandler({ operationMode: 'passthrough' }))
     const user = userEvent.setup()
     renderWithProviders(<Host />)
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('user@x')).toBeInTheDocument()
-    })
+    await screen.findByRole('heading', { name: /Seguridad/i })
     await user.click(screen.getByRole('tab', { name: /Operación/i }))
     await user.click(screen.getByRole('button', { name: /Cambiar modo/i }))
     const reconcileCard = await screen.findByRole('button', {
@@ -335,9 +285,7 @@ describe('SettingsDialog', () => {
     server.use(meHandler({ operationMode: 'passthrough' }))
     const user = userEvent.setup()
     renderWithProviders(<Host />)
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('user@x')).toBeInTheDocument()
-    })
+    await screen.findByRole('heading', { name: /Seguridad/i })
     await user.click(screen.getByRole('tab', { name: /Operación/i }))
     await user.click(screen.getByRole('button', { name: /Cambiar modo/i }))
     // Switch to reconcile first to enable save
@@ -362,9 +310,7 @@ describe('SettingsDialog', () => {
     )
     const user = userEvent.setup()
     renderWithProviders(<Host />)
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('user@x')).toBeInTheDocument()
-    })
+    await screen.findByRole('heading', { name: /Seguridad/i })
     await user.click(screen.getByRole('tab', { name: /Operación/i }))
     await user.click(screen.getByRole('button', { name: /Cambiar modo/i }))
     await user.click(
@@ -384,9 +330,7 @@ describe('SettingsDialog', () => {
     server.use(meHandler({ operationMode: 'passthrough' }))
     const user = userEvent.setup()
     renderWithProviders(<Host />)
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('user@x')).toBeInTheDocument()
-    })
+    await screen.findByRole('heading', { name: /Seguridad/i })
     await user.click(screen.getByRole('tab', { name: /Operación/i }))
     await user.click(screen.getByRole('button', { name: /Cambiar modo/i }))
     await user.click(

--- a/client/src/features/user/components/SettingsDialog.tsx
+++ b/client/src/features/user/components/SettingsDialog.tsx
@@ -2,9 +2,7 @@ import { localizedApiError } from '@/shared/http/client'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
-import { GitMerge, ArrowDownUp, AlertTriangle, UserRound, Settings2, ShieldCheck, KeyRound } from 'lucide-react'
-import { Input } from '@/shared/ui/input'
-import { Label } from '@/shared/ui/label'
+import { GitMerge, ArrowDownUp, AlertTriangle, Settings2, ShieldCheck, KeyRound } from 'lucide-react'
 import { Button } from '@/shared/ui/button'
 import { Badge } from '@/shared/ui/badge'
 import { Dialog, DialogContent, DialogTitle, DialogDescription } from '@/shared/ui/dialog'
@@ -22,7 +20,6 @@ const MODE_OPTIONS = [
 ]
 
 const SECTIONS = [
-  { key: 'general', icon: UserRound },
   { key: 'security', icon: ShieldCheck },
   { key: 'operation', icon: Settings2 },
   { key: 'apiKeys', icon: KeyRound },
@@ -48,7 +45,6 @@ export function SettingsDialog({ open, onOpenChange }: { open: boolean; onOpenCh
   }
 
   const currentMode = me?.operationMode ?? null
-  const initial = me?.name?.[0]?.toUpperCase() ?? me?.email?.[0]?.toUpperCase() ?? '?'
 
   function startEditing() {
     setSelected(currentMode)
@@ -134,7 +130,7 @@ export function SettingsDialog({ open, onOpenChange }: { open: boolean; onOpenCh
           />
 
           <Tabs
-            defaultValue="general"
+            defaultValue="security"
             orientation="vertical"
             className="relative grid h-full min-h-0 grid-cols-[220px_1fr] gap-0"
           >
@@ -146,21 +142,6 @@ export function SettingsDialog({ open, onOpenChange }: { open: boolean; onOpenCh
                 borderRight: '1px solid oklch(1 0 0 / 0.07)',
               }}
             >
-              <div className="mb-7">
-                <p
-                  className="text-[10px] uppercase tracking-[0.28em]"
-                  style={{ color: 'oklch(0.5 0 0)' }}
-                >
-                  {t('settings.title')}
-                </p>
-                <h2
-                  className="mt-1 text-[20px] font-semibold leading-[1.1]"
-                  style={{ color: 'oklch(0.98 0 0)', letterSpacing: '-0.01em' }}
-                >
-                  {me?.name?.split(' ')[0] ?? t('settings.profile.name')}
-                </h2>
-              </div>
-
               <TabsList
                 variant="line"
                 className="h-auto w-full flex-col items-stretch gap-1 border-0 bg-transparent p-0 shadow-none"
@@ -187,29 +168,6 @@ export function SettingsDialog({ open, onOpenChange }: { open: boolean; onOpenCh
                 ))}
               </TabsList>
 
-              {me && (
-                <div
-                  className="mt-auto flex items-center gap-3 rounded-lg p-2"
-                  style={{
-                    background: 'oklch(1 0 0 / 0.04)',
-                    boxShadow: 'inset 0 0 0 1px oklch(1 0 0 / 0.07)',
-                  }}
-                >
-                  <div
-                    className="flex size-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold"
-                    style={{
-                      color: 'oklch(0.96 0 0)',
-                      background: 'oklch(1 0 0 / 0.07)',
-                      boxShadow: 'inset 0 0 0 1px oklch(1 0 0 / 0.1)',
-                    }}
-                  >
-                    {initial}
-                  </div>
-                  <p className="min-w-0 truncate text-[11px]" style={{ color: 'oklch(0.6 0 0)' }}>
-                    {me.email}
-                  </p>
-                </div>
-              )}
             </aside>
 
             {/* Content */}
@@ -221,26 +179,10 @@ export function SettingsDialog({ open, onOpenChange }: { open: boolean; onOpenCh
               ) : (
                 <div className="flex h-full min-h-0 flex-col">
                   <TabsContent
-                    value="general"
-                    className="min-h-0 flex-1 overflow-y-auto px-8 py-7 outline-none data-[active]:flex data-[active]:flex-col"
-                  >
-                    <PaneHeader title={t('settings.tabs.general')} subtitle={t('settings.subtitle')} />
-
-                    <div className="mt-6 grid gap-5 sm:grid-cols-2">
-                      <Field label={t('settings.profile.name')}>
-                        <Input value={me.name ?? ''} disabled className="settings-input" />
-                      </Field>
-                      <Field label={t('settings.profile.email')}>
-                        <Input value={me.email} disabled className="settings-input" />
-                      </Field>
-                    </div>
-                  </TabsContent>
-
-                  <TabsContent
                     value="security"
                     className="min-h-0 flex-1 overflow-y-auto px-8 py-7 outline-none data-[active]:flex data-[active]:flex-col"
                   >
-                    <PaneHeader title={t('settings.tabs.security')} subtitle={t('settings.security.subtitle')} />
+                    <PaneHeader title={t('settings.tabs.security')} />
                     <TwoFactorSection enabled={me.totpEnabled} />
                   </TabsContent>
 
@@ -248,10 +190,7 @@ export function SettingsDialog({ open, onOpenChange }: { open: boolean; onOpenCh
                     value="operation"
                     className="min-h-0 flex-1 overflow-y-auto px-8 py-7 outline-none data-[active]:flex data-[active]:flex-col"
                   >
-                    <PaneHeader
-                      title={t('settings.tabs.operation')}
-                      subtitle={t('settings.mode.title')}
-                    />
+                    <PaneHeader title={t('settings.tabs.operation')} />
 
                     <div className="mt-6 space-y-4">
                       {/* Header row */}
@@ -368,7 +307,7 @@ export function SettingsDialog({ open, onOpenChange }: { open: boolean; onOpenCh
                     value="apiKeys"
                     className="min-h-0 flex-1 overflow-y-auto px-8 py-7 outline-none data-[active]:flex data-[active]:flex-col"
                   >
-                    <PaneHeader title={t('settings.tabs.apiKeys')} subtitle={t('settings.apiKeys.subtitle')} />
+                    <PaneHeader title={t('settings.tabs.apiKeys')} />
                     <div className="mt-6">
                       <ApiKeysSection />
                     </div>
@@ -433,22 +372,17 @@ export function SettingsDialog({ open, onOpenChange }: { open: boolean; onOpenCh
   )
 }
 
-function PaneHeader({ title, subtitle }: { title: string; subtitle: string }) {
+function PaneHeader({ title }: { title: string }) {
   return (
-    <div className="space-y-1">
-      <p
-        className="text-[10px] uppercase tracking-[0.28em]"
-        style={{ color: 'oklch(0.5 0 0)' }}
-      >
-        {subtitle}
-      </p>
+    <>
       <h3
         className="text-[22px] font-semibold leading-[1.1]"
         style={{ color: 'oklch(0.98 0 0)', letterSpacing: '-0.01em' }}
       >
         {title}
       </h3>
-    </div>
+      <hr className="mt-4 border-white/[0.08]" />
+    </>
   )
 }
 
@@ -536,19 +470,5 @@ function ModeCard({
         {t(`modeSelect.${mode}.desc`)}
       </p>
     </button>
-  )
-}
-
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div className="space-y-1.5">
-      <Label
-        className="text-[10px] uppercase tracking-[0.2em]"
-        style={{ color: 'oklch(0.5 0 0)' }}
-      >
-        {label}
-      </Label>
-      {children}
-    </div>
   )
 }

--- a/client/src/features/user/hooks/useApiKeys.ts
+++ b/client/src/features/user/hooks/useApiKeys.ts
@@ -19,7 +19,8 @@ export function useCreateApiKey() {
 export function useRevokeApiKey() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: revokeApiKey,
+    mutationFn: ({ id, code }: { id: string; code?: string }) => revokeApiKey(id, code),
+    meta: { errorHandled: true },
     onSuccess: () => qc.invalidateQueries({ queryKey: apiKeysQueryKey }),
   })
 }

--- a/client/src/features/user/i18n/en.json
+++ b/client/src/features/user/i18n/en.json
@@ -44,18 +44,11 @@
     "subtitle": "Manage your profile and operation mode",
     "loading": "Loading...",
     "tabs": {
-      "general": "General",
       "security": "Security",
       "operation": "Operation",
       "apiKeys": "API Keys"
     },
-    "profile": {
-      "title": "Profile",
-      "name": "Name",
-      "email": "Email"
-    },
     "security": {
-      "subtitle": "Two-factor authentication",
       "intro": "Add a second step at sign-in using an authenticator app (Google Authenticator, Authy, 1Password).",
       "disabledLabel": "Two-factor authentication is off",
       "enabledLabel": "Two-factor authentication is on",
@@ -86,16 +79,14 @@
       "saveError": "Failed to update operation mode",
       "changeWarning": "Changing the mode will permanently delete all movements and conciliations.",
       "confirmTitle": "Confirm mode change",
-      "confirmBody": "Changing the mode will permanently delete all movements and conciliations recorded so far. For security and compliance reasons, data processed under one mode cannot be carried over to the other. This action is irreversible.",
+      "confirmBody": "Changing the mode will permanently delete all movements and conciliations recorded so far. This action is irreversible.",
       "confirmCancel": "Cancel",
       "confirmConfirm": "Yes, change and delete data"
     },
     "apiKeys": {
-      "subtitle": "Keys for external integrations (SMS server, etc.)",
       "name": "Name",
       "namePlaceholder": "SMS server",
-      "scopes": "Scopes",
-      "scopesHint": "Each scope enables one API endpoint. Turn on only the ones your integration needs.",
+      "scopesHint": "Each permission enables one API endpoint.",
       "scopeInfo": {
         "otpWrite": { "title": "Submit OTP code", "desc": "Sends a bank account the (OTP/SMS) code the bank requested." },
         "statusRead": { "title": "Read account status", "desc": "Checks whether a session is active and whether the bank is requesting a code." }
@@ -109,7 +100,13 @@
       "dismiss": "Done",
       "empty": "No active keys.",
       "revoke": "Revoke",
-      "revoked": "Key revoked"
+      "revoked": "Key revoked",
+      "revokeTitle": "Revoke key",
+      "revokeBody": "This can't be undone. Any integration using this key will stop working.",
+      "revoke2faHint": "Enter your 6-digit authenticator code to confirm.",
+      "revokeConfirm": "Revoke",
+      "cancel": "Cancel",
+      "revokeError": "Could not revoke the key"
     }
   },
   "modeSelect": {

--- a/client/src/features/user/i18n/es.json
+++ b/client/src/features/user/i18n/es.json
@@ -44,18 +44,11 @@
     "subtitle": "Gestioná tu perfil y el modo de operación",
     "loading": "Cargando...",
     "tabs": {
-      "general": "General",
       "security": "Seguridad",
       "operation": "Operación",
       "apiKeys": "API Keys"
     },
-    "profile": {
-      "title": "Perfil",
-      "name": "Nombre",
-      "email": "Email"
-    },
     "security": {
-      "subtitle": "Autenticación en dos pasos",
       "intro": "Agregá un segundo paso al iniciar sesión usando una app de autenticación (Google Authenticator, Authy, 1Password).",
       "disabledLabel": "La autenticación en dos pasos está desactivada",
       "enabledLabel": "La autenticación en dos pasos está activada",
@@ -86,16 +79,14 @@
       "saveError": "No se pudo actualizar el modo de operación",
       "changeWarning": "Cambiar de modo eliminará permanentemente todos los movimientos y conciliaciones.",
       "confirmTitle": "Confirmá el cambio de modo",
-      "confirmBody": "Al cambiar de modo se eliminarán de forma permanente todos los movimientos y conciliaciones registrados hasta ahora. Por motivos de seguridad y cumplimiento, los datos procesados bajo un modo no pueden conservarse al pasar al otro. Esta acción es irreversible.",
+      "confirmBody": "Al cambiar de modo se eliminarán de forma permanente todos los movimientos y conciliaciones registrados hasta ahora. Esta acción es irreversible.",
       "confirmCancel": "Cancelar",
       "confirmConfirm": "Sí, cambiar y borrar datos"
     },
     "apiKeys": {
-      "subtitle": "Llaves para integraciones externas (servidor SMS, etc.)",
       "name": "Nombre",
       "namePlaceholder": "Servidor SMS",
-      "scopes": "Permisos",
-      "scopesHint": "Cada permiso habilita un endpoint de la API. Activá solo los que tu integración necesita.",
+      "scopesHint": "Cada permiso habilita un endpoint de la API.",
       "scopeInfo": {
         "otpWrite": { "title": "Enviar código OTP", "desc": "Envía a una cuenta el código (OTP/SMS) que pide el banco." },
         "statusRead": { "title": "Leer estado de la cuenta", "desc": "Consulta si hay una sesión activa y si el banco está pidiendo un código." }
@@ -109,7 +100,13 @@
       "dismiss": "Listo",
       "empty": "No hay llaves activas.",
       "revoke": "Revocar",
-      "revoked": "Llave revocada"
+      "revoked": "Llave revocada",
+      "revokeTitle": "Revocar llave",
+      "revokeBody": "Esta acción no se puede deshacer. Cualquier integración que use esta llave dejará de funcionar.",
+      "revoke2faHint": "Ingresá el código de 6 dígitos de tu authenticator para confirmar.",
+      "revokeConfirm": "Revocar",
+      "cancel": "Cancelar",
+      "revokeError": "No se pudo revocar la llave"
     }
   },
   "modeSelect": {

--- a/client/src/shared/ui/dialog.tsx
+++ b/client/src/shared/ui/dialog.tsx
@@ -41,15 +41,21 @@ function DialogOverlay({
 
 function DialogContent({
   className,
+  overlayClassName,
+  forceOverlay,
   children,
   showCloseButton = true,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
+  overlayClassName?: string
+  // Base UI suppresses a nested dialog's backdrop by default; set this to render
+  // a visible scrim that dims the parent dialog behind a stacked modal.
+  forceOverlay?: boolean
 }) {
   return (
     <DialogPortal>
-      <DialogOverlay />
+      <DialogOverlay className={overlayClassName} forceRender={forceOverlay} />
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(

--- a/src/api/routes/apiKeys.routes.test.ts
+++ b/src/api/routes/apiKeys.routes.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import request from 'supertest'
 import { buildApiKeysRouter } from './apiKeys.routes.js'
 import { buildTestApp, AUTH_HEADER } from '../../../tests/helpers/buildTestApp.js'
+import { UnauthorizedError } from '../../shared/errors/index.js'
 import type { UserModule } from '../../composition/userModule.js'
 
 type MockedUserModule = {
@@ -160,7 +161,30 @@ describe('apiKeys.routes', () => {
         .set('Authorization', AUTH_HEADER)
 
       expect(res.status).toBe(204)
-      expect(user.revokeApiKey.execute).toHaveBeenCalledWith(id, 'user-1')
+      expect(user.revokeApiKey.execute).toHaveBeenCalledWith(id, 'user-1', undefined)
+    })
+
+    it('forwards a 2FA code from the body to the use case', async () => {
+      user.revokeApiKey.execute.mockResolvedValue(true)
+
+      const res = await request(makeApp(user))
+        .delete(`/me/api-keys/${id}`)
+        .set('Authorization', AUTH_HEADER)
+        .send({ code: '123456' })
+
+      expect(res.status).toBe(204)
+      expect(user.revokeApiKey.execute).toHaveBeenCalledWith(id, 'user-1', '123456')
+    })
+
+    it('propagates a 401 when the use case rejects the code', async () => {
+      user.revokeApiKey.execute.mockRejectedValue(new UnauthorizedError('Invalid code'))
+
+      const res = await request(makeApp(user))
+        .delete(`/me/api-keys/${id}`)
+        .set('Authorization', AUTH_HEADER)
+        .send({ code: '000000' })
+
+      expect(res.status).toBe(401)
     })
 
     it('returns 404 when the key does not exist for the user', async () => {

--- a/src/api/routes/apiKeys.routes.ts
+++ b/src/api/routes/apiKeys.routes.ts
@@ -13,6 +13,8 @@ const createSchema = z.object({
   account_ids: z.array(z.string().uuid()).nullable().optional(),
 })
 const idParams = z.object({ id: z.string().uuid() })
+// `.default({})` so a bodyless DELETE (no JSON body at all) is treated as "no code"
+const revokeSchema = z.object({ code: z.string().optional() }).default({})
 
 function requireUserId(req: AuthRequest): string {
   if (!req.userId) throw new UnauthorizedError('Unauthorized')
@@ -59,7 +61,8 @@ export function buildApiKeysRouter(user: UserModule): Router {
   router.delete('/:id', controller(async (req: AuthRequest, res) => {
     const userId = requireUserId(req)
     const { id } = validateParams(req, idParams)
-    const revoked = await user.revokeApiKey.execute(id, userId)
+    const { code } = validateBody(req, revokeSchema)
+    const revoked = await user.revokeApiKey.execute(id, userId, code)
     if (!revoked) throw new NotFoundError('API key not found')
     res.status(204).end()
   }))

--- a/src/composition/userModule.ts
+++ b/src/composition/userModule.ts
@@ -88,7 +88,7 @@ export function buildUserModule(container: ContainerBase): UserModule {
     ),
     createApiKey: new CreateApiKeyUseCase(apiKeyRepository),
     listApiKeys: new ListApiKeysUseCase(apiKeyRepository),
-    revokeApiKey: new RevokeApiKeyUseCase(apiKeyRepository),
+    revokeApiKey: new RevokeApiKeyUseCase(apiKeyRepository, userRepository, totp),
     authenticateApiKey: new AuthenticateApiKeyUseCase(apiKeyRepository),
   }
 }

--- a/src/contexts/user/application/ManageApiKeysUseCase.test.ts
+++ b/src/contexts/user/application/ManageApiKeysUseCase.test.ts
@@ -5,6 +5,10 @@ import {
   AuthenticateApiKeyUseCase,
 } from './ManageApiKeysUseCase.js'
 import type { IApiKeyRepository } from '../domain/IApiKeyRepository.js'
+import type { IUserRepository } from '../domain/IUserRepository.js'
+import type { ITotpProvider } from '../domain/ports/ITotpProvider.js'
+import type { User } from '../domain/User.js'
+import { NotFoundError, UnauthorizedError } from '../../../shared/errors/index.js'
 import { generateApiKey } from '../infrastructure/apiKeyCrypto.js'
 
 function makeRepo() {
@@ -15,6 +19,39 @@ function makeRepo() {
     revoke: vi.fn(),
     touchLastUsed: vi.fn(),
   } satisfies IApiKeyRepository
+}
+
+function makeUser(opts: { totpEnabled: boolean; totpLastStep?: number | null }) {
+  return {
+    isTotpEnabled: () => opts.totpEnabled,
+    totpSecret: opts.totpEnabled ? 'SECRET32' : null,
+    totpLastStep: opts.totpLastStep ?? null,
+    recordTotpStep: vi.fn(),
+  }
+}
+
+function makeUserRepo(user: ReturnType<typeof makeUser> | null) {
+  return {
+    findById: vi.fn().mockResolvedValue(user),
+    save: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function makeTotp() {
+  return { generateSecret: vi.fn(), keyUri: vi.fn(), verify: vi.fn() }
+}
+
+// The repo/userRepo/totp partials carry only the methods the use case touches.
+function newRevoke(
+  repo: ReturnType<typeof makeRepo>,
+  userRepo: ReturnType<typeof makeUserRepo>,
+  totp: ReturnType<typeof makeTotp>,
+) {
+  return new RevokeApiKeyUseCase(
+    repo,
+    userRepo as unknown as IUserRepository,
+    totp as unknown as ITotpProvider,
+  )
 }
 
 describe('ListApiKeysUseCase', () => {
@@ -30,14 +67,85 @@ describe('ListApiKeysUseCase', () => {
 })
 
 describe('RevokeApiKeyUseCase', () => {
-  it('delegates to the repository scoped by user', async () => {
+  it('revokes without a code when 2FA is disabled', async () => {
     const repo = makeRepo()
     repo.revoke.mockResolvedValue(true)
+    const user = makeUser({ totpEnabled: false })
+    const userRepo = makeUserRepo(user)
+    const totp = makeTotp()
 
-    const result = await new RevokeApiKeyUseCase(repo).execute('key-1', 'user-1')
+    const result = await newRevoke(repo, userRepo, totp).execute('key-1', 'user-1')
 
-    expect(repo.revoke).toHaveBeenCalledWith('key-1', 'user-1')
     expect(result).toBe(true)
+    expect(repo.revoke).toHaveBeenCalledWith('key-1', 'user-1')
+    expect(totp.verify).not.toHaveBeenCalled()
+    expect(userRepo.save).not.toHaveBeenCalled()
+  })
+
+  it('throws when the user no longer exists', async () => {
+    const repo = makeRepo()
+    const userRepo = makeUserRepo(null)
+
+    await expect(
+      newRevoke(repo, userRepo, makeTotp()).execute('key-1', 'user-1'),
+    ).rejects.toBeInstanceOf(NotFoundError)
+    expect(repo.revoke).not.toHaveBeenCalled()
+  })
+
+  it('rejects with no revoke when 2FA is on and no code is provided', async () => {
+    const repo = makeRepo()
+    const userRepo = makeUserRepo(makeUser({ totpEnabled: true }))
+    const totp = makeTotp()
+
+    await expect(
+      newRevoke(repo, userRepo, totp).execute('key-1', 'user-1'),
+    ).rejects.toBeInstanceOf(UnauthorizedError)
+    expect(totp.verify).not.toHaveBeenCalled()
+    expect(repo.revoke).not.toHaveBeenCalled()
+  })
+
+  it('rejects with no revoke when the TOTP code is invalid', async () => {
+    const repo = makeRepo()
+    const userRepo = makeUserRepo(makeUser({ totpEnabled: true, totpLastStep: 10 }))
+    const totp = makeTotp()
+    totp.verify.mockResolvedValue({ valid: false })
+
+    await expect(
+      newRevoke(repo, userRepo, totp).execute('key-1', 'user-1', '000000'),
+    ).rejects.toBeInstanceOf(UnauthorizedError)
+    expect(totp.verify).toHaveBeenCalledWith('SECRET32', '000000', { afterTimeStep: 10 })
+    expect(repo.revoke).not.toHaveBeenCalled()
+  })
+
+  it('revokes and records the consumed step on a valid code', async () => {
+    const repo = makeRepo()
+    repo.revoke.mockResolvedValue(true)
+    const user = makeUser({ totpEnabled: true, totpLastStep: 10 })
+    const userRepo = makeUserRepo(user)
+    const totp = makeTotp()
+    totp.verify.mockResolvedValue({ valid: true, timeStep: 42 })
+
+    const result = await newRevoke(repo, userRepo, totp).execute('key-1', 'user-1', '123456')
+
+    expect(result).toBe(true)
+    expect(repo.revoke).toHaveBeenCalledWith('key-1', 'user-1')
+    expect(user.recordTotpStep).toHaveBeenCalledWith(42)
+    expect(userRepo.save).toHaveBeenCalledWith(user)
+  })
+
+  it('does not record the step when the key was not found', async () => {
+    const repo = makeRepo()
+    repo.revoke.mockResolvedValue(false)
+    const user = makeUser({ totpEnabled: true })
+    const userRepo = makeUserRepo(user)
+    const totp = makeTotp()
+    totp.verify.mockResolvedValue({ valid: true, timeStep: 42 })
+
+    const result = await newRevoke(repo, userRepo, totp).execute('key-1', 'user-1', '123456')
+
+    expect(result).toBe(false)
+    expect(user.recordTotpStep).not.toHaveBeenCalled()
+    expect(userRepo.save).not.toHaveBeenCalled()
   })
 })
 

--- a/src/contexts/user/application/ManageApiKeysUseCase.ts
+++ b/src/contexts/user/application/ManageApiKeysUseCase.ts
@@ -1,5 +1,8 @@
 import { ApiKey, ApiKeyPrincipal } from '../domain/ApiKey.js'
 import { IApiKeyRepository } from '../domain/IApiKeyRepository.js'
+import { IUserRepository } from '../domain/IUserRepository.js'
+import { ITotpProvider } from '../domain/ports/ITotpProvider.js'
+import { NotFoundError, UnauthorizedError } from '../../../shared/errors/index.js'
 import { parseApiKey, secretMatches } from '../infrastructure/apiKeyCrypto.js'
 
 export class ListApiKeysUseCase {
@@ -9,10 +12,41 @@ export class ListApiKeysUseCase {
   }
 }
 
+/**
+ * Revokes a key. When the owner has 2FA enabled, a valid current TOTP code is
+ * required (backup codes are intentionally NOT accepted for this action, so we
+ * verify against the TOTP provider directly rather than via verifyTwoFactorCode).
+ */
 export class RevokeApiKeyUseCase {
-  constructor(private readonly repo: IApiKeyRepository) {}
-  execute(id: string, userId: string): Promise<boolean> {
-    return this.repo.revoke(id, userId)
+  constructor(
+    private readonly repo: IApiKeyRepository,
+    private readonly userRepo: IUserRepository,
+    private readonly totp: ITotpProvider,
+  ) {}
+
+  async execute(id: string, userId: string, code?: string): Promise<boolean> {
+    const user = await this.userRepo.findById(userId)
+    if (!user) throw new NotFoundError('User not found')
+
+    let stepToRecord: number | undefined
+    if (user.isTotpEnabled()) {
+      const trimmed = (code ?? '').trim()
+      if (!trimmed) throw new UnauthorizedError('Invalid code')
+      // afterTimeStep rejects an already-consumed step, mirroring the replay
+      // guard in verifyTwoFactorCode's TOTP path.
+      const res = await this.totp.verify(user.totpSecret!, trimmed, { afterTimeStep: user.totpLastStep })
+      if (!res.valid) throw new UnauthorizedError('Invalid code')
+      stepToRecord = res.timeStep
+    }
+
+    const revoked = await this.repo.revoke(id, userId)
+    // Persist the consumed step only after a successful revoke, so revoking a
+    // non-existent key (404) doesn't burn the user's current code.
+    if (revoked && stepToRecord !== undefined) {
+      user.recordTotpStep(stepToRecord)
+      await this.userRepo.save(user)
+    }
+    return revoked
   }
 }
 


### PR DESCRIPTION
This pull request implements two-factor-protected API key revocation and the supporting UI.

**Backend**
- `RevokeApiKeyUseCase` now takes an optional TOTP `code`. When the owner has 2FA enabled, a valid current code is required; it verifies against the TOTP provider directly (backup codes are intentionally not accepted for this action) and records the consumed time step only after a successful revoke, so revoking a missing key (404) doesn't burn the user's code.
- `DELETE /me/api-keys/:id` reads the code from the body via `revokeSchema = z.object({ code: z.string().optional() }).default({})`, so a bodyless DELETE (no 2FA) is treated as "no code" instead of failing validation.
- Wires `userRepo` and the TOTP provider into the use case in the composition module.

**Frontend**
- Adds a revoke confirmation dialog in the API keys settings. When 2FA is on, it requires a 6-digit code; a wrong code surfaces an inline error and keeps the dialog open, other failures toast.
- `revokeApiKey` sends the code in the body only when present; the mutation now passes `{ id, code }`.

**Shared UI**
- `DialogContent` gains `forceOverlay` / `overlayClassName` so a nested modal can render a visible scrim dimming the parent dialog (Base UI suppresses a nested dialog's backdrop by default).

**Settings cleanup**
- Removes the unused "general" profile tab from the settings dialog and tightens some copy.

Tests for the use case and routes (including the bodyless-DELETE and wrong-code paths) and the API keys section are updated.