### PR TITLE
Use hyphen in poll job id

### DIFF
--- a/src/shared/infrastructure/queues/Scheduler.test.ts
+++ b/src/shared/infrastructure/queues/Scheduler.test.ts
@@ -89,7 +89,7 @@ describe('Scheduler', () => {
     expect(orderIngestionAdd.mock.calls[0][1]).toEqual({ accountId: 'a1' })
     // Idempotent jobId (no timestamp) so a slow/failed poll does not spawn a
     // second concurrent poll for the same account.
-    expect(orderIngestionAdd.mock.calls[0][2]).toMatchObject({ jobId: 'poll:a1' })
+    expect(orderIngestionAdd.mock.calls[0][2]).toMatchObject({ jobId: 'poll-a1' })
 
     // scraping called for 2 one-shot accounts
     // persistent session: a5 is running, a6 not -> only a6 enqueued

--- a/src/shared/infrastructure/queues/Scheduler.ts
+++ b/src/shared/infrastructure/queues/Scheduler.ts
@@ -70,7 +70,7 @@ export class Scheduler {
       await Queues.orderIngestion.add(
         'poll',
         { accountId: account.id },
-        { jobId: `poll:${account.id}`, removeOnComplete: true, removeOnFail: 100 }
+        { jobId: `poll-${account.id}`, removeOnComplete: true, removeOnFail: 100 }
       )
     }
 


### PR DESCRIPTION
This pull request implements a fix for the scheduler's polling enqueue, which crashed with an unhandled rejection: `Custom Id cannot contain :`.

BullMQ rejects colons in custom job ids. `Scheduler.enqueuePolling` built the job id as `poll:${account.id}`, so every polling cycle with an active account threw. The id now uses a hyphen (`poll-${account.id}`), matching the existing convention used elsewhere (`scrape-${id}`, `webhook_${id}`).

The id stays idempotent (no timestamp), so a slow or failed poll still won't spawn a second concurrent poll for the same account. The unit test asserting the old `poll:a1` value was updated to `poll-a1`.