### PR TITLE
Activate Pichincha OTP script v1.0.2

### DIFF
--- a/src/shared/infrastructure/db/migrations/045_activate_pichincha_script_v1_0_2.sql
+++ b/src/shared/infrastructure/db/migrations/045_activate_pichincha_script_v1_0_2.sql
@@ -1,0 +1,17 @@
+-- Activate Banco Pichincha extract_transactions v1.0.2 (programmatic SMS OTP).
+-- v1.0.2 was seeded as 'review' in 042 pending confirmation of the OTP selectors
+-- against a real Pichincha SMS prompt; this is the deliberate activation step.
+-- Deprecates v1.0.1 (b3010000-...) and promotes v1.0.2 (b3020000-...).
+-- Mirrors the v1.0.1 activation flow in 038. Code is loaded from disk by ScriptLoader:
+--   scripts/bancopichincha/extract_transactions.v1.0.2.js
+
+-- Deprecate the previous active version first to satisfy uq_bank_script_active
+UPDATE bank_scripts
+SET status = 'deprecated'
+WHERE id = 'b3010000-0000-0000-0000-000000000001'
+  AND status = 'active';
+
+UPDATE bank_scripts
+SET status = 'active'
+WHERE id = 'b3020000-0000-0000-0000-000000000001'
+  AND status = 'review';


### PR DESCRIPTION
This pull request implements the activation of the Banco Pichincha `extract_transactions` v1.0.2 script, which adds programmatic SMS OTP support via `context.requestOtp()`.

Migration `042` deliberately seeded v1.0.2 as `review` (not active) until its OTP field selectors were confirmed against a real Pichincha SMS prompt. This adds migration `045` as the deliberate activation step: it deprecates v1.0.1 and promotes v1.0.2 to `active`, mirroring the v1.0.1 activation flow in `038`.

Without this, scrapes run v1.0.1 (no OTP support), so `context.requestOtp()` is never called, no pending `assistance_requests` row is created, and `POST /v1/accounts/:id/otp` returns 404. Activating v1.0.2 completes the OTP-via-API flow end to end.

The migration is idempotent: it guards on `id` + `status`, so re-running against an already-activated database is a safe no-op, and on a clean database it deprecates v1.0.1 before activating v1.0.2 to satisfy the `uq_bank_script_active` constraint.