### PR TITLE
Use sentence-case button labels

### DIFF
--- a/client/src/features/user/components/ApiKeysSection.tsx
+++ b/client/src/features/user/components/ApiKeysSection.tsx
@@ -176,7 +176,7 @@ export function ApiKeysSection() {
               <Button
                 size="sm"
                 onClick={() => setCreatedSecret(null)}
-                className="border-0 bg-white px-4 text-[11px] font-semibold uppercase tracking-[0.16em] text-black hover:bg-white/90"
+                className="border-0 bg-white px-4 text-[11px] font-semibold tracking-[0.16em] text-black hover:bg-white/90"
               >
                 {t('settings.apiKeys.dismiss')}
               </Button>
@@ -254,7 +254,7 @@ export function ApiKeysSection() {
                 variant="ghost"
                 onClick={closeRevoke}
                 disabled={revoke.isPending}
-                className="text-[11px] uppercase tracking-[0.16em] text-white/60 hover:bg-white/10 hover:text-white"
+                className="text-[11px] tracking-[0.16em] text-white/60 hover:bg-white/10 hover:text-white"
               >
                 {t('settings.apiKeys.cancel')}
               </Button>
@@ -262,7 +262,7 @@ export function ApiKeysSection() {
                 size="sm"
                 onClick={submitRevoke}
                 disabled={revoke.isPending || (requires2fa && !revokeCode.trim())}
-                className="border-0 px-4 text-[11px] font-semibold uppercase tracking-[0.16em] text-white"
+                className="border-0 px-4 text-[11px] font-semibold tracking-[0.16em] text-white"
                 style={{ background: 'oklch(0.55 0.2 28)' }}
               >
                 {t('settings.apiKeys.revokeConfirm')}
@@ -339,7 +339,7 @@ export function ApiKeysSection() {
               size="sm"
               onClick={handleCreate}
               disabled={create.isPending || !name.trim() || scopes.length === 0}
-              className="border-0 bg-white px-3 text-[11px] font-semibold uppercase tracking-[0.16em] text-black hover:bg-white/90"
+              className="border-0 bg-white px-3 text-[11px] font-semibold tracking-[0.16em] text-black hover:bg-white/90"
             >
               <KeyRound className="mr-1 size-3.5" />
               {create.isPending ? t('settings.apiKeys.creating') : t('settings.apiKeys.create')}

--- a/client/src/features/user/components/SettingsDialog.test.tsx
+++ b/client/src/features/user/components/SettingsDialog.test.tsx
@@ -135,7 +135,7 @@ describe('SettingsDialog', () => {
     await user.click(saveBtn)
     // Confirmation dialog appears
     const confirmBtn = await screen.findByRole('button', {
-      name: /Sí, cambiar y borrar datos/i,
+      name: /Confirmar/i,
     })
     await user.click(confirmBtn)
     await waitFor(() => {
@@ -202,7 +202,7 @@ describe('SettingsDialog', () => {
     )
     await user.click(screen.getByRole('button', { name: /^Guardar$/i }))
     await user.click(
-      await screen.findByRole('button', { name: /Sí, cambiar y borrar datos/i })
+      await screen.findByRole('button', { name: /Confirmar/i })
     )
     await waitFor(() => {
       expect(screen.getByText(/boom/i)).toBeInTheDocument()
@@ -224,7 +224,7 @@ describe('SettingsDialog', () => {
     )
     await user.click(screen.getByRole('button', { name: /^Guardar$/i }))
     await user.click(
-      await screen.findByRole('button', { name: /Sí, cambiar y borrar datos/i })
+      await screen.findByRole('button', { name: /Confirmar/i })
     )
     await waitFor(() => {
       expect(screen.getByText(/No se pudo actualizar el modo de operación/i)).toBeInTheDocument()
@@ -318,7 +318,7 @@ describe('SettingsDialog', () => {
     )
     await user.click(screen.getByRole('button', { name: /^Guardar$/i }))
     await user.click(
-      await screen.findByRole('button', { name: /Sí, cambiar y borrar datos/i })
+      await screen.findByRole('button', { name: /Confirmar/i })
     )
     // The confirm button text flips to "Guardando..." while the PUT is pending.
     await waitFor(() => {

--- a/client/src/features/user/components/SettingsDialog.tsx
+++ b/client/src/features/user/components/SettingsDialog.tsx
@@ -205,7 +205,7 @@ export function SettingsDialog({ open, onOpenChange }: { open: boolean; onOpenCh
                           size="sm"
                           onClick={expanded ? cancelEditing : startEditing}
                           disabled={setMode.isPending}
-                          className="shrink-0 border-0 text-[11px] uppercase tracking-[0.18em]"
+                          className="shrink-0 border-0 text-[11px] tracking-[0.18em]"
                           style={{
                             background: 'oklch(1 0 0 / 0.06)',
                             color: 'oklch(0.92 0 0)',
@@ -289,7 +289,7 @@ export function SettingsDialog({ open, onOpenChange }: { open: boolean; onOpenCh
                           <Button
                             onClick={() => setConfirmOpen(true)}
                             disabled={!canSave || setMode.isPending}
-                            className="text-[11px] uppercase tracking-[0.18em]"
+                            className="text-[11px] tracking-[0.18em]"
                             style={{
                               background: 'oklch(0.95 0 0)',
                               color: 'oklch(0.12 0 0)',
@@ -352,7 +352,7 @@ export function SettingsDialog({ open, onOpenChange }: { open: boolean; onOpenCh
               variant="ghost"
               onClick={() => setConfirmOpen(false)}
               disabled={setMode.isPending}
-              className="text-[11px] uppercase tracking-[0.18em]"
+              className="text-[11px] tracking-[0.18em]"
               style={{ color: 'oklch(0.65 0 0)' }}
             >
               {t('settings.mode.confirmCancel')}
@@ -360,7 +360,7 @@ export function SettingsDialog({ open, onOpenChange }: { open: boolean; onOpenCh
             <Button
               onClick={confirmChange}
               disabled={setMode.isPending}
-              className="text-[11px] uppercase tracking-[0.18em]"
+              className="text-[11px] tracking-[0.18em]"
               style={{ background: 'oklch(0.58 0.2 28)', color: 'oklch(0.98 0 0)' }}
             >
               {setMode.isPending ? t('settings.mode.saving') : t('settings.mode.confirmConfirm')}

--- a/client/src/features/user/components/TwoFactorSection.test.tsx
+++ b/client/src/features/user/components/TwoFactorSection.test.tsx
@@ -37,7 +37,7 @@ describe('TwoFactorSection', () => {
 
       // confirm → backup codes
       await user.type(codeInput(), '123456')
-      await user.click(screen.getByRole('button', { name: /Verificar y activar/i }))
+      await user.click(screen.getByRole('button', { name: /Verificar/i }))
       expect(await screen.findByText(/Guardá tus códigos de respaldo/i)).toBeInTheDocument()
       expect(screen.getByText('AAAAA-BBBBB')).toBeInTheDocument()
       expect(screen.getByText('CCCCC-DDDDD')).toBeInTheDocument()
@@ -57,7 +57,7 @@ describe('TwoFactorSection', () => {
       await user.click(screen.getByRole('button', { name: /Activar 2FA/i }))
       await screen.findByText(/Escaneá este código QR/i)
       await user.type(codeInput(), '123456')
-      await user.click(screen.getByRole('button', { name: /Verificar y activar/i }))
+      await user.click(screen.getByRole('button', { name: /Verificar/i }))
       await screen.findByText(/Guardá tus códigos de respaldo/i)
 
       await user.click(screen.getByRole('button', { name: /Copiar/i }))
@@ -72,7 +72,7 @@ describe('TwoFactorSection', () => {
       await user.click(screen.getByRole('button', { name: /Activar 2FA/i }))
       await screen.findByText(/Escaneá este código QR/i)
       await user.type(codeInput(), '123456')
-      await user.click(screen.getByRole('button', { name: /Verificar y activar/i }))
+      await user.click(screen.getByRole('button', { name: /Verificar/i }))
       await screen.findByText(/Guardá tus códigos de respaldo/i)
 
       await user.click(screen.getByRole('button', { name: /Copiar/i }))
@@ -103,7 +103,7 @@ describe('TwoFactorSection', () => {
       await user.click(screen.getByRole('button', { name: /Activar 2FA/i }))
       await screen.findByText(/Escaneá este código QR/i)
       await user.type(codeInput(), '000000')
-      await user.click(screen.getByRole('button', { name: /Verificar y activar/i }))
+      await user.click(screen.getByRole('button', { name: /Verificar/i }))
       await waitFor(() => expect(toast.error).toHaveBeenCalled())
     })
 
@@ -133,7 +133,7 @@ describe('TwoFactorSection', () => {
       await user.click(screen.getByRole('button', { name: /Activar 2FA/i }))
       await screen.findByText(/Escaneá este código QR/i)
       await user.type(codeInput(), '123456')
-      await user.click(screen.getByRole('button', { name: /Verificar y activar/i }))
+      await user.click(screen.getByRole('button', { name: /Verificar/i }))
       expect(await screen.findByText(/Guardando/i)).toBeInTheDocument()
       await screen.findByText(/Guardá tus códigos de respaldo/i)
     })

--- a/client/src/features/user/components/TwoFactorSection.tsx
+++ b/client/src/features/user/components/TwoFactorSection.tsx
@@ -79,7 +79,7 @@ export function TwoFactorSection({ enabled }: { enabled: boolean }) {
           <Button
             variant="ghost"
             onClick={() => setStage('disabling')}
-            className="text-[11px] uppercase tracking-[0.18em]"
+            className="text-[11px] tracking-[0.18em]"
             style={{ color: 'oklch(0.7 0.18 28)' }}
           >
             <ShieldOff className="size-3.5" />
@@ -195,7 +195,7 @@ export function TwoFactorSection({ enabled }: { enabled: boolean }) {
       <Button
         onClick={() => enroll.mutate()}
         disabled={enroll.isPending}
-        className="text-[11px] uppercase tracking-[0.18em]"
+        className="text-[11px] tracking-[0.18em]"
         style={{ background: 'oklch(0.95 0 0)', color: 'oklch(0.12 0 0)' }}
       >
         <ShieldCheck className="size-3.5" />

--- a/client/src/features/user/i18n/en.json
+++ b/client/src/features/user/i18n/en.json
@@ -57,7 +57,7 @@
       "enrollError": "Could not start enrollment",
       "scanHint": "Scan this QR code with your authenticator app, then enter the 6-digit code to confirm.",
       "code": "6-digit code",
-      "verify": "Verify and enable",
+      "verify": "Verify",
       "codeError": "Invalid code, please try again",
       "backupTitle": "Save your backup codes",
       "backupHint": "Store these one-time codes somewhere safe. Each can be used once if you lose access to your authenticator. They won't be shown again.",
@@ -81,7 +81,7 @@
       "confirmTitle": "Confirm mode change",
       "confirmBody": "Changing the mode will permanently delete all movements and conciliations recorded so far. This action is irreversible.",
       "confirmCancel": "Cancel",
-      "confirmConfirm": "Yes, change and delete data"
+      "confirmConfirm": "Confirm"
     },
     "apiKeys": {
       "name": "Name",

--- a/client/src/features/user/i18n/es.json
+++ b/client/src/features/user/i18n/es.json
@@ -57,7 +57,7 @@
       "enrollError": "No se pudo iniciar la configuración",
       "scanHint": "Escaneá este código QR con tu app de autenticación y luego ingresá el código de 6 dígitos para confirmar.",
       "code": "Código de 6 dígitos",
-      "verify": "Verificar y activar",
+      "verify": "Verificar",
       "codeError": "Código inválido, probá de nuevo",
       "backupTitle": "Guardá tus códigos de respaldo",
       "backupHint": "Guardá estos códigos de un solo uso en un lugar seguro. Cada uno sirve una vez si perdés acceso a tu app de autenticación. No se mostrarán de nuevo.",
@@ -81,7 +81,7 @@
       "confirmTitle": "Confirmá el cambio de modo",
       "confirmBody": "Al cambiar de modo se eliminarán de forma permanente todos los movimientos y conciliaciones registrados hasta ahora. Esta acción es irreversible.",
       "confirmCancel": "Cancelar",
-      "confirmConfirm": "Sí, cambiar y borrar datos"
+      "confirmConfirm": "Confirmar"
     },
     "apiKeys": {
       "name": "Nombre",


### PR DESCRIPTION
This pull request changes button labels across the app from ALL-CAPS to sentence case and shortens the longer ones.

- Renames the mode-change confirmation button from "Sí, cambiar y borrar datos" / "Yes, change and delete data" to "Confirmar" / "Confirm".
- Shortens the 2FA enrollment button from "Verificar y activar" / "Verify and enable" to "Verificar" / "Verify".
- Removes the CSS `uppercase` class from every button that used it (SettingsDialog, TwoFactorSection, ApiKeysSection) so labels render with only the first letter capitalized.
- Updates the affected component tests to match the new labels.