### PR TITLE
Fix conciliations nav flash for passthrough mode users

### DIFF
--- a/client/src/shared/layout/AppLayout.test.tsx
+++ b/client/src/shared/layout/AppLayout.test.tsx
@@ -92,6 +92,23 @@ describe('AppLayout', () => {
     expect(screen.getByRole('link', { name: /Dashboard/i })).toBeInTheDocument()
   })
 
+  it('never flashes the conciliations nav item while /me is still loading in passthrough', async () => {
+    server.use(meHandler({ operation_mode: 'passthrough' }))
+    renderLayout()
+    // Before the /me query resolves, `me` is undefined: the item must stay hidden
+    // (regression guard — a `!== 'passthrough'` check would render it here first).
+    expect(
+      screen.queryByRole('link', { name: /Conciliaciones/i })
+    ).not.toBeInTheDocument()
+    // And it stays hidden once the query resolves to passthrough.
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: /Dashboard/i })).toBeInTheDocument()
+    })
+    expect(
+      screen.queryByRole('link', { name: /Conciliaciones/i })
+    ).not.toBeInTheDocument()
+  })
+
   it('navigates between routes when nav links are clicked', async () => {
     const user = userEvent.setup()
     renderLayout()

--- a/client/src/shared/layout/AppLayout.tsx
+++ b/client/src/shared/layout/AppLayout.tsx
@@ -52,7 +52,7 @@ export function AppLayout() {
     { to: '/', label: t('nav.dashboard'), icon: LayoutDashboard },
     { to: '/banks', label: t('nav.banks'), icon: Building },
     { to: '/accounts', label: t('nav.accounts'), icon: Building2 },
-    me?.operationMode !== 'passthrough' && {
+    me?.operationMode === 'reconcile' && {
       to: '/conciliations', label: t('nav.conciliations'), icon: GitMerge,
     },
     { to: '/movements', label: t('nav.movements'), icon: ArrowDownUp },


### PR DESCRIPTION
This pull request implements a fix for a brief flash of the Conciliaciones nav item for passthrough-mode users.

## Overview
The sidebar previously showed the Conciliaciones nav item whenever `me?.operationMode !== 'passthrough'`. While the `/me` query was still loading, `operationMode` is `undefined`, which satisfied that condition and caused the item to flash on screen before disappearing once the query resolved to `passthrough`.

## Changes
- `client/src/shared/layout/AppLayout.tsx`: switch the visibility check to `me?.operationMode === 'reconcile'`, so the item only renders once we know the user is actually in reconcile mode.
- `client/src/shared/layout/AppLayout.test.tsx`: add a regression test asserting the item stays hidden both while `/me` is loading and after it resolves to `passthrough`.