### PR TITLE
Pin vulnerable transitive dependencies to patched versions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,14 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  fast-uri: ^3.1.2
+  ip-address: ^10.4.0
+  body-parser: ^2.3.0
+  postcss: ^8.5.23
+  undici: ^7.29.0
+  brace-expansion: ^5.0.8
+  fast-uri: ^3.1.4
+  hono: ^4.12.34
+  '@hono/node-server': ^2.0.5
 
 importers:
 
@@ -710,7 +717,7 @@ packages:
     resolution: {integrity: sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: ^4
+      hono: ^4.12.34
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -1626,8 +1633,8 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
   brace-expansion@5.0.9:
@@ -1765,6 +1772,10 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -2399,10 +2410,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
-    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.3:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
@@ -3720,6 +3727,10 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typescript-eslint@8.65.0:
     resolution: {integrity: sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3734,10 +3745,6 @@ packages:
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
-
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
-    engines: {node: '>=20.18.1'}
 
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
@@ -5272,17 +5279,17 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  body-parser@2.2.2:
+  body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
-      content-type: 1.0.5
+      content-type: 2.0.0
       debug: 4.4.3
       http-errors: 2.0.1
-      iconv-lite: 0.7.2
+      iconv-lite: 0.7.3
       on-finished: 2.4.1
       qs: 6.15.3
       raw-body: 3.0.2
-      type-is: 2.0.1
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -5410,6 +5417,8 @@ snapshots:
   content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -5796,7 +5805,7 @@ snapshots:
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.3.0
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -6058,10 +6067,6 @@ snapshots:
     optionalDependencies:
       typescript: 7.0.2
 
-  iconv-lite@0.7.2:
-    dependencies:
-      safer-buffer: 2.1.2
-
   iconv-lite@0.7.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -6203,7 +6208,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -7291,6 +7296,12 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript-eslint@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@7.0.2):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@7.0.2))(eslint@10.8.0(jiti@2.7.0))(typescript@7.0.2)
@@ -7326,8 +7337,6 @@ snapshots:
       '@typescript/typescript-win32-x64': 7.0.2
 
   undici-types@8.3.0: {}
-
-  undici@7.28.0: {}
 
   undici@7.29.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,37 @@ onlyBuiltDependencies:
 packages:
   - client
 overrides:
-  # Force the patched fast-uri (transitive via shadcn > ajv); <=3.1.1 has
-  # path-traversal / host-confusion advisories (GHSA-q3j6-qgpj-74h6, GHSA-v39h-62p7-jpjc).
-  fast-uri: '^3.1.2'
+  # ip-address: leading-zero octets decoded as decimal, CIDR suffix suppressing
+  # special-use classification, IPv4-mapped/NAT64 misclassification
+  # (GHSA-mwp4-54f8-5fhr, GHSA-4xrf-jv44-h6hh, GHSA-22jq-vg5j-6vgg). Via
+  # express-rate-limit, which parses client IPs — a stale parser here means the
+  # rate limiter can be bypassed by rotating representations of the same address.
+  ip-address: '^10.4.0'
+  # body-parser: DoS when an invalid `limit` silently disables size enforcement
+  # (GHSA-v422-hmwv-36x6). Transitive via express — the only server-side runtime advisory.
+  body-parser: '^2.3.0'
+  # postcss: path traversal via attacker-controlled sourceMappingURL, arbitrary
+  # .map file disclosure (GHSA-r28c-9q8g-f849, GHSA-fxqj-rqcc-2cmp). Via vite; build-time only.
+  postcss: '^8.5.23'
+  # undici: cross-user info disclosure via degenerate/whitespaced Cache-Control
+  # directives + cookie attribute injection (GHSA-4cwx-7wf7-3272, GHSA-jr45-8vmc-qm54,
+  # GHSA-v3r7-h72x-cjcm). Via jsdom; test-time only.
+  undici: '^7.29.0'
+  # brace-expansion: OOM crash via unbounded expansion (GHSA-mh99-v99m-4gvg).
+  # Via eslint > minimatch; lint-time only.
+  brace-expansion: '^5.0.8'
+  #
+  # The four below all arrive via `shadcn`, which client/src/index.css needs for
+  # `@import "shadcn/tailwind.css"`. Only that stylesheet is ever consumed — the CLI
+  # and its bundled MCP server never execute — so forcing these is risk-free.
+  #
+  # fast-uri: host confusion via literal backslash authority delimiter
+  # (GHSA-v2hh-gcrm-f6hx). Via shadcn > @modelcontextprotocol/sdk > ajv.
+  fast-uri: '^3.1.4'
+  # hono: JSX context not isolated per request, XSS via cx() escaping bypass,
+  # ReDoS in CORS middleware (GHSA-hvrm-45r6-mjfj, GHSA-w62v-xxxg-mg59,
+  # GHSA-8j4g-w8fx-2239). Via shadcn > @modelcontextprotocol/sdk.
+  hono: '^4.12.34'
+  # @hono/node-server: serve-static path traversal on Windows via encoded
+  # backslash (GHSA-frvp-7c67-39w9). Via shadcn > @modelcontextprotocol/sdk.
+  '@hono/node-server': '^2.0.5'


### PR DESCRIPTION
This pull request implements security remediation for the dependency advisories surfaced by `pnpm audit`, cutting the count from 24 down to 1.

## Overview
`pnpm audit` flagged 24 advisories across several transitive dependencies. Each is resolved by adding a pinning `overrides:` entry to `pnpm-workspace.yaml` (this repo keeps overrides there rather than in `package.json`). Every override carries an inline comment with its GHSA IDs.

## Changes
- `ip-address ^10.4.0` — the one that actually mattered. Reached via `express-rate-limit`, which parses client IPs; the vulnerable version decodes leading-zero octets as decimal, letting an attacker rotate representations of the same IP to bypass the rate limiter sitting in front of login and OTP. GHSA-mwp4-54f8-5fhr, GHSA-4xrf-jv44-h6hh, GHSA-22jq-vg5j-6vgg.
- `body-parser ^2.3.0` — via express, the only other server-runtime advisory, low severity. GHSA-v422-hmwv-36x6.
- `postcss ^8.5.23` — via vite, build-time only. GHSA-r28c-9q8g-f849, GHSA-fxqj-rqcc-2cmp.
- `undici ^7.29.0` — via jsdom, test-time only. GHSA-4cwx-7wf7-3272, GHSA-jr45-8vmc-qm54, GHSA-v3r7-h72x-cjcm.
- `brace-expansion ^5.0.8` — via eslint > minimatch, lint-time only. GHSA-mh99-v99m-4gvg.
- `fast-uri ^3.1.4` (raised from a stale `^3.1.2` that still resolved to a vulnerable version), plus new `hono ^4.12.34` and `@hono/node-server ^2.0.5` — all reach the tree via `shadcn`, which `client/src/index.css` needs for `@import "shadcn/tailwind.css"`. Only that stylesheet is ever consumed; the CLI and its bundled MCP server never execute, so forcing these versions is risk-free.

## Notes
One advisory is deliberately left unfixed: `react-router` 7.18.1 (GHSA-qwww-vcr4-c8h2, high). It affects RSC mode only; this client is a SPA (`client/components.json` has `"rsc": false`), so it does not apply, and the patch is a major version bump (8.3.0).

This branch was rebased onto the latest `main` (which had advanced with a TypeScript 6→7 bump), so the lockfile was regenerated fresh rather than reused from the original working tree. Verification after the rebase: server typecheck, server build, client build, and server tests (150 files / 1088 tests) all pass. Client tests show one pre-existing failure (`use-mobile.test.ts`) and client lint has one pre-existing failure (`typescript-eslint` not yet supporting TS 7.0) — both confirmed to also fail on unmodified `main`, unrelated to this change.