### PR TITLE
Add bank_scripts ownership migration

### DIFF
--- a/src/shared/infrastructure/db/migrations/051_bank_scripts_ownership.sql
+++ b/src/shared/infrastructure/db/migrations/051_bank_scripts_ownership.sql
@@ -1,0 +1,23 @@
+-- Per-user/per-account script ownership. NULL user_id/account_id = official
+-- system script (unchanged behavior for all existing rows). A non-null
+-- user_id scopes a script to that user across all their accounts; a
+-- non-null account_id further narrows it to one specific account.
+ALTER TABLE bank_scripts ADD COLUMN IF NOT EXISTS user_id UUID NULL REFERENCES users(id) ON DELETE CASCADE;
+ALTER TABLE bank_scripts ADD COLUMN IF NOT EXISTS account_id UUID NULL REFERENCES accounts(id) ON DELETE CASCADE;
+
+-- Replace the single active-script index (025) with three scope-specific ones,
+-- so a system script, a user-wide override, and an account-specific override
+-- can each be active for the same (bank, flow_type) at the same time.
+DROP INDEX IF EXISTS uq_bank_script_active;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_bank_script_active_system
+  ON bank_scripts (bank, flow_type)
+  WHERE status = 'active' AND user_id IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_bank_script_active_user
+  ON bank_scripts (bank, flow_type, user_id)
+  WHERE status = 'active' AND user_id IS NOT NULL AND account_id IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_bank_script_active_account
+  ON bank_scripts (bank, flow_type, account_id)
+  WHERE status = 'active' AND account_id IS NOT NULL;


### PR DESCRIPTION
This pull request implements the database migration for per-user/per-account bank script ownership.

## Changes

- Adds nullable `user_id` and `account_id` columns to `bank_scripts`, both NULL by default so every existing row keeps identical (system-wide) behavior.
- Replaces the single `uq_bank_script_active` index with three scope-specific partial unique indexes — system, user-wide, and account-specific — so a system script, a user override, and an account override can each be active for the same `(bank, flow_type)` simultaneously without colliding.

## Notes

The cross-table invariant "`account_id` set implies `user_id` set to that account's owner" is intentionally left to application code (the future creation use case) rather than a DB constraint or trigger, since there is no writer yet.

Part of the bank script isolation work tracked in #147.
