### PR TITLE
Add ownership fields and guards to BankScript domain

### DIFF
--- a/src/contexts/script-engine/domain/BankScript.test.ts
+++ b/src/contexts/script-engine/domain/BankScript.test.ts
@@ -54,6 +54,37 @@ describe('BankScript.deprecate', () => {
   })
 })
 
+describe('BankScript ownership', () => {
+  it('is a system script when no userId is set', () => {
+    const s = BankScript.create('id-1', base)
+    expect(s.userId).toBeUndefined()
+    expect(s.accountId).toBeUndefined()
+    expect(s.isSystem()).toBe(true)
+  })
+
+  it('is not a system script when userId is set', () => {
+    const s = BankScript.create('id-1', { ...base, userId: 'user-1' })
+    expect(s.userId).toBe('user-1')
+    expect(s.isSystem()).toBe(false)
+  })
+
+  it('exposes accountId when set', () => {
+    const s = BankScript.create('id-1', { ...base, userId: 'user-1', accountId: 'acct-1' })
+    expect(s.accountId).toBe('acct-1')
+  })
+
+  it('belongsTo returns true only for the owning user', () => {
+    const s = BankScript.create('id-1', { ...base, userId: 'user-1' })
+    expect(s.belongsTo('user-1')).toBe(true)
+    expect(s.belongsTo('user-2')).toBe(false)
+  })
+
+  it('belongsTo returns false for a system script regardless of caller', () => {
+    const s = BankScript.create('id-1', base)
+    expect(s.belongsTo('user-1')).toBe(false)
+  })
+})
+
 describe('BankScript getters and validation', () => {
   it('rejects missing flowType', () => {
     expect(() => BankScript.create('id', { ...base, flowType: '' as 'login' })).toThrow(ValidationError)

--- a/src/contexts/script-engine/domain/BankScript.ts
+++ b/src/contexts/script-engine/domain/BankScript.ts
@@ -21,6 +21,8 @@ interface Props {
   codeSnapshot?: string
   selectorMap: Record<string, unknown>
   createdAt: Date
+  userId?: string
+  accountId?: string
 }
 
 export class BankScript extends AggregateRoot<string> {
@@ -56,8 +58,12 @@ export class BankScript extends AggregateRoot<string> {
   get codeSnapshot() { return this.props.codeSnapshot }
   get selectorMap()  { return this.props.selectorMap }
   get createdAt()    { return this.props.createdAt }
+  get userId()        { return this.props.userId }
+  get accountId()     { return this.props.accountId }
 
   isActive(): boolean { return this.props.status === 'active' }
+  isSystem(): boolean { return this.props.userId == null }
+  belongsTo(userId: string): boolean { return this.props.userId === userId }
 
   promote(): void {
     if (this.props.status !== 'review') {


### PR DESCRIPTION
This pull request implements ownership on the `BankScript` domain entity, the foundation the repository and runtime loader layers build on.

## Changes

- Adds `userId`/`accountId` to `Props` and their getters.
- Adds `belongsTo(userId)` and `isSystem()` guards, mirroring `Account.belongsTo` in `src/contexts/account/domain/Account.ts`.
- `promote()`/`deprecate()` are unchanged — only who is authorized to call them changes, at the use-case layer (a later task).

## Testing

`npx vitest run src/contexts/script-engine/domain/BankScript.test.ts` — 22 passed.

Part of the bank script isolation work tracked in #147. Task 3 (repository layer) and task 4 (runtime loader) both branch off this once merged.
