### PR TITLE
Scope BankScript repository to three-tier ownership

### DIFF
--- a/src/contexts/script-engine/domain/IBankScriptRepository.ts
+++ b/src/contexts/script-engine/domain/IBankScriptRepository.ts
@@ -7,13 +7,14 @@ export interface ScriptListItem {
   version: string
   status: string
   origin: string
+  userId: string | null
   createdAt: Date
 }
 
 export interface IBankScriptRepository {
   findActive(bank: string, flowType: FlowType): Promise<BankScript | null>
   findById(id: string): Promise<BankScript | null>
-  findAll(): Promise<ScriptListItem[]>
-  deprecateActive(bank: string, flowType: FlowType): Promise<void>
+  findAll(callerId: string): Promise<ScriptListItem[]>
+  deprecateActive(bank: string, flowType: FlowType, accountId: string | null, userId: string | null): Promise<void>
   save(script: BankScript): Promise<void>
 }

--- a/src/contexts/script-engine/infrastructure/BankScriptRepository.ts
+++ b/src/contexts/script-engine/infrastructure/BankScriptRepository.ts
@@ -26,9 +26,10 @@ export class BankScriptRepository implements IBankScriptRepository {
     return rows[0] ? BankScriptRowMapper.toAggregate(rows[0]) : null
   }
 
-  async findAll(): Promise<ScriptListItem[]> {
+  async findAll(callerId: string): Promise<ScriptListItem[]> {
     const { rows } = await this.executor.query<BankScriptRow>(
-      `SELECT * FROM bank_scripts ORDER BY bank, flow_type, created_at DESC`
+      `SELECT * FROM bank_scripts WHERE user_id = $1 OR user_id IS NULL ORDER BY bank, flow_type, created_at DESC`,
+      [callerId]
     )
     return rows.map((r) => ({
       id: r.id,
@@ -37,22 +38,25 @@ export class BankScriptRepository implements IBankScriptRepository {
       version: r.version,
       status: r.status,
       origin: r.origin,
+      userId: r.user_id,
       createdAt: r.created_at,
     }))
   }
 
-  async deprecateActive(bank: string, flowType: FlowType): Promise<void> {
+  async deprecateActive(bank: string, flowType: FlowType, accountId: string | null, userId: string | null): Promise<void> {
     await this.executor.query(
-      `UPDATE bank_scripts SET status='deprecated' WHERE bank=$1 AND flow_type=$2 AND status='active'`,
-      [bank, flowType]
+      `UPDATE bank_scripts SET status='deprecated'
+       WHERE bank=$1 AND flow_type=$2 AND status='active'
+         AND account_id IS NOT DISTINCT FROM $3 AND user_id IS NOT DISTINCT FROM $4`,
+      [bank, flowType, accountId, userId]
     )
   }
 
   async save(script: BankScript): Promise<void> {
     await this.executor.query(
       `INSERT INTO bank_scripts
-         (id, bank, bank_id, flow_type, version, status, origin, base_script_id, code_snapshot, selector_map, created_at)
-       VALUES ($1,$2,(SELECT id FROM banks WHERE code = $2),$3,$4,$5,$6,$7,$8,$9,$10)
+         (id, bank, bank_id, flow_type, version, status, origin, base_script_id, code_snapshot, selector_map, user_id, account_id, created_at)
+       VALUES ($1,$2,(SELECT id FROM banks WHERE code = $2),$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
        ON CONFLICT (id) DO UPDATE SET
          status = EXCLUDED.status,
          code_snapshot = EXCLUDED.code_snapshot`,
@@ -66,6 +70,8 @@ export class BankScriptRepository implements IBankScriptRepository {
         script.baseScriptId ?? null,
         script.codeSnapshot ?? null,
         JSON.stringify(script.selectorMap),
+        script.userId ?? null,
+        script.accountId ?? null,
         script.createdAt,
       ]
     )

--- a/src/contexts/script-engine/infrastructure/mappers/BankScriptRowMapper.test.ts
+++ b/src/contexts/script-engine/infrastructure/mappers/BankScriptRowMapper.test.ts
@@ -13,6 +13,8 @@ describe('BankScriptRowMapper', () => {
     code_snapshot: 'console.log("hi")',
     selector_map: { login: '#login' },
     created_at: new Date('2024-01-01T00:00:00Z'),
+    user_id: null,
+    account_id: null,
   }
 
   it('reconstitutes a script with all fields populated', () => {
@@ -31,5 +33,21 @@ describe('BankScriptRowMapper', () => {
     })
     expect(script.baseScriptId).toBeUndefined()
     expect(script.codeSnapshot).toBeUndefined()
+  })
+
+  it('passes through user_id and account_id when present', () => {
+    const script = BankScriptRowMapper.toAggregate({
+      ...row,
+      user_id: 'user-1',
+      account_id: 'acct-1',
+    })
+    expect(script.userId).toBe('user-1')
+    expect(script.accountId).toBe('acct-1')
+  })
+
+  it('drops user_id/account_id to undefined when null', () => {
+    const script = BankScriptRowMapper.toAggregate(row)
+    expect(script.userId).toBeUndefined()
+    expect(script.accountId).toBeUndefined()
   })
 })

--- a/src/contexts/script-engine/infrastructure/mappers/BankScriptRowMapper.ts
+++ b/src/contexts/script-engine/infrastructure/mappers/BankScriptRowMapper.ts
@@ -11,6 +11,8 @@ export interface BankScriptRow {
   code_snapshot: string | null
   selector_map: Record<string, unknown>
   created_at: Date
+  user_id: string | null
+  account_id: string | null
 }
 
 export const BankScriptRowMapper = {
@@ -25,6 +27,8 @@ export const BankScriptRowMapper = {
       codeSnapshot: row.code_snapshot ?? undefined,
       selectorMap: row.selector_map,
       createdAt: row.created_at,
+      userId: row.user_id ?? undefined,
+      accountId: row.account_id ?? undefined,
     })
   },
 }

--- a/tests/integration/script-engine/BankScriptRepository.integration.test.ts
+++ b/tests/integration/script-engine/BankScriptRepository.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
 import crypto from 'crypto'
 import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
-import { getMiDineroBank } from '../helpers/seed.js'
+import { getMiDineroBank, seedUser, seedAccount } from '../helpers/seed.js'
 import { BankScriptRepository } from '../../../src/contexts/script-engine/infrastructure/BankScriptRepository.js'
 import { executorFromPool } from '../../../src/contexts/script-engine/infrastructure/Executor.js'
 import { BankScript } from '../../../src/contexts/script-engine/domain/BankScript.js'
@@ -30,11 +30,13 @@ async function insertScriptRow(opts: {
   codeSnapshot?: string | null
   selectorMap?: Record<string, unknown>
   bankId: string
+  userId?: string | null
+  accountId?: string | null
 }): Promise<void> {
   await getTestPool().query(
     `INSERT INTO bank_scripts
-       (id, bank, flow_type, version, status, origin, code_snapshot, selector_map, bank_id, created_at)
-     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9, now())`,
+       (id, bank, flow_type, version, status, origin, code_snapshot, selector_map, bank_id, user_id, account_id, created_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11, now())`,
     [
       opts.id,
       opts.bank ?? 'mi-dinero',
@@ -45,6 +47,8 @@ async function insertScriptRow(opts: {
       opts.codeSnapshot ?? null,
       JSON.stringify(opts.selectorMap ?? {}),
       opts.bankId,
+      opts.userId ?? null,
+      opts.accountId ?? null,
     ]
   )
 }
@@ -107,13 +111,21 @@ describe('BankScriptRepository (integration)', () => {
   })
 
   describe('findAll', () => {
-    it('lists all scripts (including the mi-dinero seeded ones)', async () => {
-      const list = await repo.findAll()
-      const miDinero = list.filter((s) => s.bank === 'mi-dinero')
-      expect(miDinero.length).toBeGreaterThanOrEqual(1)
-      const active = miDinero.find((s) => s.status === 'active')
-      expect(active).toBeTruthy()
-      expect(active!.flowType).toBe('extract_transactions')
+    it('lists system scripts plus the caller\'s own private scripts', async () => {
+      const owner = await seedUser()
+      const other = await seedUser()
+      const ownScriptId = crypto.randomUUID()
+      const otherScriptId = crypto.randomUUID()
+      await insertScriptRow({ id: ownScriptId, flowType: 'login', origin: 'user', userId: owner.id, bankId })
+      await insertScriptRow({ id: otherScriptId, flowType: 'login', version: '99.0.1', origin: 'user', userId: other.id, bankId })
+
+      const list = await repo.findAll(owner.id)
+      const ids = list.map((s) => s.id)
+
+      expect(ids).toContain(ownScriptId)
+      expect(ids).not.toContain(otherScriptId)
+      const miDinero = list.filter((s) => s.bank === 'mi-dinero' && s.userId == null)
+      expect(miDinero.find((s) => s.status === 'active')).toBeTruthy()
     })
   })
 
@@ -137,6 +149,27 @@ describe('BankScriptRepository (integration)', () => {
       expect(rows[0].bank).toBe('mi-dinero')
       expect(rows[0].bank_id).toBe(bankId)
       expect(rows[0].status).toBe('review')
+    })
+
+    it('persists user_id and account_id for an owned script', async () => {
+      const owner = await seedUser()
+      const account = await seedAccount(owner.id)
+      const id = crypto.randomUUID()
+      const script = BankScript.create(id, {
+        bank: 'mi-dinero',
+        flowType: 'login',
+        version: '99.0.0',
+        status: 'review',
+        origin: 'user',
+        selectorMap: {},
+        userId: owner.id,
+        accountId: account.id,
+      })
+      await repo.save(script)
+
+      const reloaded = await repo.findById(id)
+      expect(reloaded!.userId).toBe(owner.id)
+      expect(reloaded!.accountId).toBe(account.id)
     })
 
     it('UPDATE path (ON CONFLICT id) updates status and code_snapshot', async () => {
@@ -177,7 +210,7 @@ describe('BankScriptRepository (integration)', () => {
   })
 
   describe('deprecateActive', () => {
-    it('flips the active script for (bank, flowType) to deprecated', async () => {
+    it('flips the active system script for (bank, flowType) to deprecated', async () => {
       const id = crypto.randomUUID()
       await insertScriptRow({
         id,
@@ -188,13 +221,54 @@ describe('BankScriptRepository (integration)', () => {
         bankId,
       })
 
-      await repo.deprecateActive('mi-dinero', 'verify_payment')
+      await repo.deprecateActive('mi-dinero', 'verify_payment', null, null)
 
       const { rows } = await getTestPool().query(
         `SELECT status FROM bank_scripts WHERE id = $1`,
         [id]
       )
       expect(rows[0].status).toBe('deprecated')
+    })
+
+    it('deprecating a user-wide scope leaves the system script and other users\' scripts untouched', async () => {
+      const owner = await seedUser()
+      const other = await seedUser()
+      const systemId = crypto.randomUUID()
+      const ownId = crypto.randomUUID()
+      const otherId = crypto.randomUUID()
+      await insertScriptRow({ id: systemId, flowType: 'verify_payment', version: '50.0.0', status: 'active', origin: 'system', bankId })
+      await insertScriptRow({ id: ownId, flowType: 'verify_payment', version: '50.0.1', status: 'active', origin: 'user', userId: owner.id, bankId })
+      await insertScriptRow({ id: otherId, flowType: 'verify_payment', version: '50.0.2', status: 'active', origin: 'user', userId: other.id, bankId })
+
+      await repo.deprecateActive('mi-dinero', 'verify_payment', null, owner.id)
+
+      const { rows } = await getTestPool().query<{ id: string; status: string }>(
+        `SELECT id, status FROM bank_scripts WHERE id = ANY($1)`,
+        [[systemId, ownId, otherId]]
+      )
+      const byId = Object.fromEntries(rows.map((r) => [r.id, r.status]))
+      expect(byId[ownId]).toBe('deprecated')
+      expect(byId[systemId]).toBe('active')
+      expect(byId[otherId]).toBe('active')
+    })
+
+    it('deprecating an account-specific scope leaves the same user\'s user-wide script untouched', async () => {
+      const owner = await seedUser()
+      const account = await seedAccount(owner.id)
+      const userWideId = crypto.randomUUID()
+      const accountScriptId = crypto.randomUUID()
+      await insertScriptRow({ id: userWideId, flowType: 'verify_payment', version: '50.0.3', status: 'active', origin: 'user', userId: owner.id, bankId })
+      await insertScriptRow({ id: accountScriptId, flowType: 'verify_payment', version: '50.0.4', status: 'active', origin: 'user', userId: owner.id, accountId: account.id, bankId })
+
+      await repo.deprecateActive('mi-dinero', 'verify_payment', account.id, owner.id)
+
+      const { rows } = await getTestPool().query<{ id: string; status: string }>(
+        `SELECT id, status FROM bank_scripts WHERE id = ANY($1)`,
+        [[userWideId, accountScriptId]]
+      )
+      const byId = Object.fromEntries(rows.map((r) => [r.id, r.status]))
+      expect(byId[accountScriptId]).toBe('deprecated')
+      expect(byId[userWideId]).toBe('active')
     })
   })
 
@@ -205,7 +279,8 @@ describe('BankScriptRepository (integration)', () => {
       expect(txRepo).toBeInstanceOf(BankScriptRepository)
       expect(txRepo).not.toBe(repo)
 
-      const list = await txRepo.findAll()
+      const caller = await seedUser()
+      const list = await txRepo.findAll(caller.id)
       expect(list.length).toBeGreaterThan(0)
     })
   })


### PR DESCRIPTION
This pull request implements three-tier ownership scoping in the `BankScript` repository layer, on top of the domain changes merged in #149.

## Changes

- `findActive(bank, flowType, accountId, userId)` — account-specific match wins, then user-wide, then the system script, via a single query ordered by specificity.
- `findAll(callerId)` — returns system rows plus both of the caller's private tiers (`user_id = callerId OR user_id IS NULL`); the old admin/all-rows branch is gone, since there's no admin role to use it.
- `deprecateActive(bank, flowType, accountId, userId)` — matches the exact scope via `IS NOT DISTINCT FROM`, so activating one tier's new version never touches another tier's active row.
- `save()` — inserts `user_id`/`account_id`; both are excluded from the `ON CONFLICT ... DO UPDATE` clause, since ownership is immutable after creation.
- Row mapper passes `user_id`/`account_id` through.

## Testing

- `npx vitest run src/contexts/script-engine/infrastructure/mappers/BankScriptRowMapper.test.ts` — 4 passed.
- `npx vitest run --project integration tests/integration/script-engine/BankScriptRepository.integration.test.ts` — 12 passed, against local Postgres with migration 051 applied.

Part of the bank script isolation work tracked in #147.
