### PR TITLE
Add ownership-aware use cases, routes, and runtime chain wiring

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc && cp -r src/contexts/script-engine/infrastructure/scripts dist/contexts/script-engine/infrastructure/scripts && pnpm --dir client build",
     "start": "node dist/index.js",
-    "migrate": "tsx --tsconfig tsconfig.json src/shared/infrastructure/db/migrate.ts"
+    "migrate": "tsx --tsconfig tsconfig.json src/shared/infrastructure/db/migrate.ts",
+    "publish-script": "tsx --tsconfig tsconfig.json src/shared/infrastructure/cli/publishScript.ts"
   },
   "keywords": [],
   "author": "",

--- a/src/api/routes/scripts.routes.test.ts
+++ b/src/api/routes/scripts.routes.test.ts
@@ -1,18 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import request from 'supertest'
-import type { RequestHandler } from 'express'
 import { buildScriptsRouter } from './scripts.routes.js'
 import { buildTestApp, AUTH_HEADER } from '../../../tests/helpers/buildTestApp.js'
-import { NotFoundError } from '../../shared/errors/index.js'
+import { NotFoundError, ForbiddenError } from '../../shared/errors/index.js'
 import type { ScriptEngineModule } from '../../composition/scriptEngineModule.js'
 
-const allowAdmin: RequestHandler = (_req, _res, next) => next()
-const denyAdmin: RequestHandler = (_req, res) => { res.status(403).json({ error: 'Forbidden' }) }
+const CALLER_ID = 'user-1'
 
 type MockedScriptEngineModule = {
   listScripts: { execute: ReturnType<typeof vi.fn> }
   getScriptDetail: { execute: ReturnType<typeof vi.fn> }
   promoteScript: { execute: ReturnType<typeof vi.fn> }
+  deprecateScript: { execute: ReturnType<typeof vi.fn> }
 }
 
 function makeModule(): MockedScriptEngineModule {
@@ -20,13 +19,14 @@ function makeModule(): MockedScriptEngineModule {
     listScripts: { execute: vi.fn() },
     getScriptDetail: { execute: vi.fn() },
     promoteScript: { execute: vi.fn() },
+    deprecateScript: { execute: vi.fn() },
   }
 }
 
-function makeApp(mod: MockedScriptEngineModule, requireAdmin: RequestHandler = allowAdmin) {
+function makeApp(mod: MockedScriptEngineModule) {
   return buildTestApp({
     basePath: '/scripts',
-    router: buildScriptsRouter(mod as unknown as ScriptEngineModule, requireAdmin),
+    router: buildScriptsRouter(mod as unknown as ScriptEngineModule),
     protected: true,
   })
 }
@@ -50,7 +50,7 @@ describe('scripts.routes', () => {
 
       expect(res.status).toBe(200)
       expect(res.body).toEqual([{ id: 's1', name: 'one' }])
-      expect(mod.listScripts.execute).toHaveBeenCalledTimes(1)
+      expect(mod.listScripts.execute).toHaveBeenCalledWith({ callerId: CALLER_ID })
     })
 
     it('returns 401 when auth header is missing', async () => {
@@ -81,7 +81,7 @@ describe('scripts.routes', () => {
 
       expect(res.status).toBe(200)
       expect(res.body).toEqual({ id: SCRIPT_ID, name: 'one' })
-      expect(mod.getScriptDetail.execute).toHaveBeenCalledWith(SCRIPT_ID)
+      expect(mod.getScriptDetail.execute).toHaveBeenCalledWith({ scriptId: SCRIPT_ID, callerId: CALLER_ID })
     })
 
     it('returns 400 when scriptId is not a uuid', async () => {
@@ -117,7 +117,7 @@ describe('scripts.routes', () => {
 
       expect(res.status).toBe(200)
       expect(res.body).toEqual({ promoted: true })
-      expect(mod.promoteScript.execute).toHaveBeenCalledWith({ scriptId: SCRIPT_ID })
+      expect(mod.promoteScript.execute).toHaveBeenCalledWith({ scriptId: SCRIPT_ID, callerId: CALLER_ID })
     })
 
     it('returns 400 when scriptId is not a uuid', async () => {
@@ -135,13 +135,14 @@ describe('scripts.routes', () => {
       expect(res.status).toBe(401)
     })
 
-    it('returns 403 when the user is not an admin', async () => {
-      const res = await request(makeApp(mod, denyAdmin))
+    it('returns 403 when the use case rejects promoting a system script', async () => {
+      mod.promoteScript.execute.mockRejectedValue(new ForbiddenError('Only the script owner can promote it'))
+
+      const res = await request(makeApp(mod))
         .post(`/scripts/${SCRIPT_ID}/promote`)
         .set('Authorization', AUTH_HEADER)
 
       expect(res.status).toBe(403)
-      expect(mod.promoteScript.execute).not.toHaveBeenCalled()
     })
 
     it('returns 500 on unexpected errors', async () => {
@@ -152,6 +153,44 @@ describe('scripts.routes', () => {
         .set('Authorization', AUTH_HEADER)
 
       expect(res.status).toBe(500)
+    })
+  })
+
+  describe('POST /scripts/:scriptId/deprecate', () => {
+    it('returns 200 with deprecated true on a valid uuid', async () => {
+      mod.deprecateScript.execute.mockResolvedValue(undefined)
+
+      const res = await request(makeApp(mod))
+        .post(`/scripts/${SCRIPT_ID}/deprecate`)
+        .set('Authorization', AUTH_HEADER)
+
+      expect(res.status).toBe(200)
+      expect(res.body).toEqual({ deprecated: true })
+      expect(mod.deprecateScript.execute).toHaveBeenCalledWith({ scriptId: SCRIPT_ID, callerId: CALLER_ID })
+    })
+
+    it('returns 400 when scriptId is not a uuid', async () => {
+      const res = await request(makeApp(mod))
+        .post('/scripts/bad/deprecate')
+        .set('Authorization', AUTH_HEADER)
+
+      expect(res.status).toBe(400)
+      expect(mod.deprecateScript.execute).not.toHaveBeenCalled()
+    })
+
+    it('returns 401 when auth header is missing', async () => {
+      const res = await request(makeApp(mod)).post(`/scripts/${SCRIPT_ID}/deprecate`)
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 404 when the use case throws NotFoundError', async () => {
+      mod.deprecateScript.execute.mockRejectedValue(new NotFoundError('Script not found'))
+
+      const res = await request(makeApp(mod))
+        .post(`/scripts/${SCRIPT_ID}/deprecate`)
+        .set('Authorization', AUTH_HEADER)
+
+      expect(res.status).toBe(404)
     })
   })
 })

--- a/src/api/routes/scripts.routes.ts
+++ b/src/api/routes/scripts.routes.ts
@@ -1,30 +1,42 @@
 import { Router } from 'express'
-import type { RequestHandler } from 'express'
 import { z } from 'zod'
 import { controller } from '../http/controller.js'
 import { validateParams } from '../http/validate.js'
 import type { ScriptEngineModule } from '../../composition/scriptEngineModule.js'
+import type { AuthRequest } from '../middlewares/auth.middleware.js'
+import { UnauthorizedError } from '../../shared/errors/index.js'
 
 const scriptIdParams = z.object({ scriptId: z.string().uuid() })
 
-export function buildScriptsRouter(scriptEngine: ScriptEngineModule, requireAdmin: RequestHandler): Router {
+function requireUserId(req: AuthRequest): string {
+  if (!req.userId) throw new UnauthorizedError('Unauthorized')
+  return req.userId
+}
+
+export function buildScriptsRouter(scriptEngine: ScriptEngineModule): Router {
   const router = Router()
 
-  router.get('/', controller(async (_req, res) => {
-    const scripts = await scriptEngine.listScripts.execute()
+  router.get('/', controller(async (req: AuthRequest, res) => {
+    const scripts = await scriptEngine.listScripts.execute({ callerId: requireUserId(req) })
     res.json(scripts)
   }))
 
-  router.get('/:scriptId', controller(async (req, res) => {
+  router.get('/:scriptId', controller(async (req: AuthRequest, res) => {
     const { scriptId } = validateParams(req, scriptIdParams)
-    const detail = await scriptEngine.getScriptDetail.execute(scriptId)
+    const detail = await scriptEngine.getScriptDetail.execute({ scriptId, callerId: requireUserId(req) })
     res.json(detail)
   }))
 
-  router.post('/:scriptId/promote', requireAdmin, controller(async (req, res) => {
+  router.post('/:scriptId/promote', controller(async (req: AuthRequest, res) => {
     const { scriptId } = validateParams(req, scriptIdParams)
-    await scriptEngine.promoteScript.execute({ scriptId })
+    await scriptEngine.promoteScript.execute({ scriptId, callerId: requireUserId(req) })
     res.json({ promoted: true })
+  }))
+
+  router.post('/:scriptId/deprecate', controller(async (req: AuthRequest, res) => {
+    const { scriptId } = validateParams(req, scriptIdParams)
+    await scriptEngine.deprecateScript.execute({ scriptId, callerId: requireUserId(req) })
+    res.json({ deprecated: true })
   }))
 
   return router

--- a/src/composition/bankingModule.test.ts
+++ b/src/composition/bankingModule.test.ts
@@ -167,6 +167,25 @@ describe('buildBankingModule', () => {
       await expect(mod.sessionManager.ensureRunning('acc-1')).rejects.toThrow('No active script for TEST')
     })
 
+    it('resolves the active script scoped to the account and its owning user', async () => {
+      const c = makeContainer()
+      c.account.accountRepository.findById.mockResolvedValue({
+        id: 'acc-1', userId: 'owner-1', bank: 'TEST',
+      })
+      c.account.accountConfigRepository.findByAccountId.mockResolvedValue({
+        sessionType: 'persistent', loginMode: 'simple',
+      })
+      dbMock.query.mockResolvedValueOnce({ rows: [{ username: 'u', encrypted_password: 'p' }] })
+      scriptLoaderMock.loadActive.mockResolvedValue({ id: 'script-1', codeSnapshot: 'code()' })
+      ;(c.pool as any).query.mockResolvedValue({ rows: [] })
+      runnerStartMock.mockResolvedValue({ stop: vi.fn(), done: new Promise(() => {}) })
+
+      const mod = buildBankingModule(c)
+      await mod.sessionManager.ensureRunning('acc-1')
+
+      expect(scriptLoaderMock.loadActive).toHaveBeenCalledWith('TEST', 'extract_transactions', 'acc-1', 'owner-1')
+    })
+
     it('starts the persistent runner with context, ingest hook, and bank-day getter', async () => {
       const c = makeContainer()
       c.account.accountRepository.findById.mockResolvedValue({

--- a/src/composition/bankingModule.ts
+++ b/src/composition/bankingModule.ts
@@ -109,7 +109,7 @@ export function buildBankingModule(container: ContainerBase): BankingModule {
     )
     if (!creds) throw new Error(`No valid credentials for account ${accountId}`)
 
-    const script = await ScriptLoader.loadActive(account.bank, 'extract_transactions')
+    const script = await ScriptLoader.loadActive(account.bank, 'extract_transactions', accountId, account.userId)
     if (!script || !script.codeSnapshot) throw new Error(`No active script for ${account.bank}`)
 
     const lastExternalId = await bankTxRepo.findLatestExternalId(accountId)

--- a/src/composition/bindRoutes.ts
+++ b/src/composition/bindRoutes.ts
@@ -68,5 +68,5 @@ export function bindRoutes(app: Express, container: Container): void {
   app.use('/api/accounts', protectedApi, buildAccountsRouter(container.account))
   app.use('/api/banks', protectedApi, buildBanksRouter(container.account, requireAdmin))
   app.use('/api/conciliation', protectedApi, buildConciliationRouter(container.conciliation))
-  app.use('/api/scripts', protectedApi, buildScriptsRouter(container.scriptEngine, requireAdmin))
+  app.use('/api/scripts', protectedApi, buildScriptsRouter(container.scriptEngine))
 }

--- a/src/composition/scriptEngineModule.test.ts
+++ b/src/composition/scriptEngineModule.test.ts
@@ -3,6 +3,8 @@ import { buildScriptEngineModule } from './scriptEngineModule.js'
 import { PromoteScriptUseCase } from '../contexts/script-engine/application/PromoteScriptUseCase.js'
 import { ListScriptsUseCase } from '../contexts/script-engine/application/ListScriptsUseCase.js'
 import { GetScriptDetailUseCase } from '../contexts/script-engine/application/GetScriptDetailUseCase.js'
+import { DeprecateScriptUseCase } from '../contexts/script-engine/application/DeprecateScriptUseCase.js'
+import { PublishOfficialScriptUseCase } from '../contexts/script-engine/application/PublishOfficialScriptUseCase.js'
 
 describe('buildScriptEngineModule', () => {
   it('wires every script-engine use case', () => {
@@ -15,6 +17,8 @@ describe('buildScriptEngineModule', () => {
     expect(mod.promoteScript).toBeInstanceOf(PromoteScriptUseCase)
     expect(mod.listScripts).toBeInstanceOf(ListScriptsUseCase)
     expect(mod.getScriptDetail).toBeInstanceOf(GetScriptDetailUseCase)
+    expect(mod.deprecateScript).toBeInstanceOf(DeprecateScriptUseCase)
+    expect(mod.publishOfficialScript).toBeInstanceOf(PublishOfficialScriptUseCase)
     expect(mod.bankScriptRepository).toBeDefined()
   })
 })

--- a/src/composition/scriptEngineModule.ts
+++ b/src/composition/scriptEngineModule.ts
@@ -6,6 +6,8 @@ import { BankScriptRepository } from '../contexts/script-engine/infrastructure/B
 import { PromoteScriptUseCase } from '../contexts/script-engine/application/PromoteScriptUseCase.js'
 import { ListScriptsUseCase } from '../contexts/script-engine/application/ListScriptsUseCase.js'
 import { GetScriptDetailUseCase } from '../contexts/script-engine/application/GetScriptDetailUseCase.js'
+import { DeprecateScriptUseCase } from '../contexts/script-engine/application/DeprecateScriptUseCase.js'
+import { PublishOfficialScriptUseCase } from '../contexts/script-engine/application/PublishOfficialScriptUseCase.js'
 
 interface ContainerBase {
   pool: pg.Pool
@@ -17,6 +19,8 @@ export interface ScriptEngineModule {
   promoteScript: PromoteScriptUseCase
   listScripts: ListScriptsUseCase
   getScriptDetail: GetScriptDetailUseCase
+  deprecateScript: DeprecateScriptUseCase
+  publishOfficialScript: PublishOfficialScriptUseCase
   bankScriptRepository: BankScriptRepository
 }
 
@@ -28,5 +32,7 @@ export function buildScriptEngineModule(container: ContainerBase): ScriptEngineM
     promoteScript: new PromoteScriptUseCase(bankScriptRepository, container.unitOfWork, container.eventBus),
     listScripts: new ListScriptsUseCase(bankScriptRepository),
     getScriptDetail: new GetScriptDetailUseCase(bankScriptRepository),
+    deprecateScript: new DeprecateScriptUseCase(bankScriptRepository),
+    publishOfficialScript: new PublishOfficialScriptUseCase(bankScriptRepository, container.unitOfWork, container.eventBus),
   }
 }

--- a/src/contexts/banking/application/RunBankScrapeUseCase.test.ts
+++ b/src/contexts/banking/application/RunBankScrapeUseCase.test.ts
@@ -54,6 +54,24 @@ describe('RunBankScrapeUseCase', () => {
     expect(handler).toHaveBeenCalledTimes(2)
   })
 
+  it('resolves the script scoped to the account and its owning user', async () => {
+    const loadActiveScript = vi.fn().mockResolvedValue({ id: 'script-1', codeSnapshot: '' })
+    const txRepo = new InMemoryBankTransactionRepository()
+    const scrapeRunRepo = new InMemoryScrapeRunRepository()
+    const eventBus = new InMemoryEventBus()
+    const ingest = new IngestTransactionsUseCase({ txRepo, eventBus })
+    const useCase = new RunBankScrapeUseCase({
+      accountReader: { findById: async (accountId: string) => ({ id: accountId, userId: 'owner-1', bank: 'bancopichincha', sessionType: 'one-shot' as const, loginMode: 'simple' as const }) },
+      txRepo, scrapeRunRepo,
+      scriptEngine: { loadActiveScript, runScript: async () => [] },
+      ingest,
+    })
+
+    await useCase.execute({ accountId: 'acc-1' })
+
+    expect(loadActiveScript).toHaveBeenCalledWith('bancopichincha', 'extract_transactions', 'acc-1', 'owner-1')
+  })
+
   it('skips already-known transactions by externalId', async () => {
     const { useCase, txRepo } = buildSut([sample('ext-1'), sample('ext-1')])
     await useCase.execute({ accountId: 'acc-1' })

--- a/src/contexts/banking/application/RunBankScrapeUseCase.ts
+++ b/src/contexts/banking/application/RunBankScrapeUseCase.ts
@@ -43,7 +43,7 @@ export class RunBankScrapeUseCase {
 
     const lastExternalId = await txRepo.findLatestExternalId(accountId)
 
-    const script = await scriptEngine.loadActiveScript(account.bank, 'extract_transactions')
+    const script = await scriptEngine.loadActiveScript(account.bank, 'extract_transactions', account.id, account.userId)
     if (!script) throw new NotFoundError(`No active script for ${account.bank}:extract_transactions`)
 
     const runId = crypto.randomUUID()

--- a/src/contexts/banking/domain/IScriptEnginePort.ts
+++ b/src/contexts/banking/domain/IScriptEnginePort.ts
@@ -14,6 +14,6 @@ export interface ActiveScript {
 }
 
 export interface IScriptEnginePort {
-  loadActiveScript(bank: string, flowType: string): Promise<ActiveScript | null>
+  loadActiveScript(bank: string, flowType: string, accountId: string, userId: string): Promise<ActiveScript | null>
   runScript(script: ActiveScript, context: { accountId: string; lastExternalId: string | null }): Promise<ScrapedTransaction[]>
 }

--- a/src/contexts/banking/infrastructure/ScriptEngineAdapter.test.ts
+++ b/src/contexts/banking/infrastructure/ScriptEngineAdapter.test.ts
@@ -28,22 +28,22 @@ describe('ScriptEngineAdapter', () => {
     it('returns null when ScriptLoader returns null', async () => {
       loadActiveMock.mockResolvedValue(null)
       const adapter = new ScriptEngineAdapter()
-      const result = await adapter.loadActiveScript('bancopichincha', 'extract_transactions')
+      const result = await adapter.loadActiveScript('bancopichincha', 'extract_transactions', 'acc-1', 'user-1')
       expect(result).toBeNull()
-      expect(loadActiveMock).toHaveBeenCalledWith('bancopichincha', 'extract_transactions')
+      expect(loadActiveMock).toHaveBeenCalledWith('bancopichincha', 'extract_transactions', 'acc-1', 'user-1')
     })
 
     it('returns null when the loaded script has no codeSnapshot', async () => {
       loadActiveMock.mockResolvedValue({ id: 'script-1', codeSnapshot: undefined })
       const adapter = new ScriptEngineAdapter()
-      const result = await adapter.loadActiveScript('bancopichincha', 'extract_transactions')
+      const result = await adapter.loadActiveScript('bancopichincha', 'extract_transactions', 'acc-1', 'user-1')
       expect(result).toBeNull()
     })
 
     it('returns id and codeSnapshot when the script is active', async () => {
       loadActiveMock.mockResolvedValue({ id: 'script-1', codeSnapshot: 'return []' })
       const adapter = new ScriptEngineAdapter()
-      const result = await adapter.loadActiveScript('bancopichincha', 'extract_transactions')
+      const result = await adapter.loadActiveScript('bancopichincha', 'extract_transactions', 'acc-1', 'user-1')
       expect(result).toEqual({ id: 'script-1', codeSnapshot: 'return []' })
     })
   })

--- a/src/contexts/banking/infrastructure/ScriptEngineAdapter.ts
+++ b/src/contexts/banking/infrastructure/ScriptEngineAdapter.ts
@@ -6,8 +6,8 @@ import type { ILogger } from '../../../shared/logger/ILogger.js'
 export class ScriptEngineAdapter implements IScriptEnginePort {
   constructor(private readonly logger?: ILogger) {}
 
-  async loadActiveScript(bank: string, flowType: string): Promise<ActiveScript | null> {
-    const script = await ScriptLoader.loadActive(bank, flowType as any)
+  async loadActiveScript(bank: string, flowType: string, accountId: string, userId: string): Promise<ActiveScript | null> {
+    const script = await ScriptLoader.loadActive(bank, flowType as any, accountId, userId)
     if (!script || !script.codeSnapshot) return null
     return { id: script.id, codeSnapshot: script.codeSnapshot }
   }

--- a/src/contexts/script-engine/application/DeprecateScriptUseCase.test.ts
+++ b/src/contexts/script-engine/application/DeprecateScriptUseCase.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { DeprecateScriptUseCase } from './DeprecateScriptUseCase.js'
+import { BankScript } from '../domain/BankScript.js'
+import { InMemoryBankScriptRepository } from '../../../../tests/helpers/inMemoryScriptRepo.js'
+import { ForbiddenError, NotFoundError } from '../../../shared/errors/index.js'
+
+const OWNER = 'user-1'
+const OTHER = 'user-2'
+
+const baseProps = {
+  bank: 'TEST',
+  flowType: 'extract_transactions' as const,
+  version: '1.0.0',
+  origin: 'user' as const,
+  status: 'active' as const,
+  selectorMap: {},
+}
+
+describe('DeprecateScriptUseCase', () => {
+  it('deprecates the caller\'s own active script', async () => {
+    const repo = new InMemoryBankScriptRepository()
+    const script = BankScript.create('s-1', { ...baseProps, userId: OWNER })
+    repo.store.set(script.id, script)
+
+    const useCase = new DeprecateScriptUseCase(repo)
+    await useCase.execute({ scriptId: 's-1', callerId: OWNER })
+
+    expect(repo.store.get('s-1')!.status).toBe('deprecated')
+  })
+
+  it('throws NotFoundError when the script does not exist', async () => {
+    const repo = new InMemoryBankScriptRepository()
+    const useCase = new DeprecateScriptUseCase(repo)
+    await expect(useCase.execute({ scriptId: 'missing', callerId: OWNER })).rejects.toBeInstanceOf(NotFoundError)
+  })
+
+  it('throws NotFoundError (masking existence) when the script is privately owned by someone else', async () => {
+    const repo = new InMemoryBankScriptRepository()
+    const script = BankScript.create('s-1', { ...baseProps, userId: OWNER })
+    repo.store.set(script.id, script)
+
+    const useCase = new DeprecateScriptUseCase(repo)
+    await expect(useCase.execute({ scriptId: 's-1', callerId: OTHER })).rejects.toBeInstanceOf(NotFoundError)
+  })
+
+  it('throws ForbiddenError when a regular caller tries to deprecate the official system script', async () => {
+    const repo = new InMemoryBankScriptRepository()
+    const script = BankScript.create('s-1', { ...baseProps, origin: 'system' })
+    repo.store.set(script.id, script)
+
+    const useCase = new DeprecateScriptUseCase(repo)
+    await expect(useCase.execute({ scriptId: 's-1', callerId: OWNER })).rejects.toBeInstanceOf(ForbiddenError)
+  })
+})

--- a/src/contexts/script-engine/application/DeprecateScriptUseCase.ts
+++ b/src/contexts/script-engine/application/DeprecateScriptUseCase.ts
@@ -1,0 +1,22 @@
+import { IBankScriptRepository } from '../domain/IBankScriptRepository.js'
+import { ForbiddenError, NotFoundError } from '../../../shared/errors/index.js'
+
+interface Input { scriptId: string; callerId: string }
+
+export class DeprecateScriptUseCase {
+  constructor(private readonly scriptRepo: IBankScriptRepository) {}
+
+  async execute({ scriptId, callerId }: Input): Promise<void> {
+    const script = await this.scriptRepo.findById(scriptId)
+    if (!script) throw new NotFoundError(`Script ${scriptId} not found`)
+    if (script.userId != null && script.userId !== callerId) {
+      throw new NotFoundError(`Script ${scriptId} not found`)
+    }
+    if (script.userId == null) {
+      throw new ForbiddenError('Only the script owner can deprecate it')
+    }
+
+    script.deprecate()
+    await this.scriptRepo.save(script)
+  }
+}

--- a/src/contexts/script-engine/application/GetScriptDetailUseCase.ts
+++ b/src/contexts/script-engine/application/GetScriptDetailUseCase.ts
@@ -2,12 +2,14 @@ import { IBankScriptRepository } from '../domain/IBankScriptRepository.js'
 import { NotFoundError } from '../../../shared/errors/index.js'
 import { ScriptDetailDto } from './dto/ScriptDto.js'
 
+interface Input { scriptId: string; callerId: string }
+
 export class GetScriptDetailUseCase {
   constructor(private readonly scriptRepo: IBankScriptRepository) {}
 
-  async execute(scriptId: string): Promise<ScriptDetailDto> {
+  async execute({ scriptId, callerId }: Input): Promise<ScriptDetailDto> {
     const s = await this.scriptRepo.findById(scriptId)
-    if (!s) throw new NotFoundError('Script not found')
+    if (!s || (s.userId != null && s.userId !== callerId)) throw new NotFoundError('Script not found')
     return {
       id: s.id,
       bank: s.bank,

--- a/src/contexts/script-engine/application/ListScriptsUseCase.ts
+++ b/src/contexts/script-engine/application/ListScriptsUseCase.ts
@@ -1,11 +1,13 @@
 import { IBankScriptRepository } from '../domain/IBankScriptRepository.js'
 import { ScriptListItemDto } from './dto/ScriptDto.js'
 
+interface Input { callerId: string }
+
 export class ListScriptsUseCase {
   constructor(private readonly scriptRepo: IBankScriptRepository) {}
 
-  async execute(): Promise<ScriptListItemDto[]> {
-    const items = await this.scriptRepo.findAll()
+  async execute({ callerId }: Input): Promise<ScriptListItemDto[]> {
+    const items = await this.scriptRepo.findAll(callerId)
     return items.map((s) => ({
       id: s.id,
       bank: s.bank,

--- a/src/contexts/script-engine/application/PromoteScriptUseCase.test.ts
+++ b/src/contexts/script-engine/application/PromoteScriptUseCase.test.ts
@@ -4,26 +4,29 @@ import { BankScript } from '../domain/BankScript.js'
 import { InMemoryBankScriptRepository } from '../../../../tests/helpers/inMemoryScriptRepo.js'
 import { InMemoryUnitOfWork } from '../../../../tests/helpers/inMemoryUnitOfWork.js'
 import { InMemoryEventBus } from '../../../shared/events/InMemoryEventBus.js'
-import { NotFoundError } from '../../../shared/errors/index.js'
+import { ForbiddenError, NotFoundError } from '../../../shared/errors/index.js'
+
+const OWNER = 'user-1'
+const OTHER = 'user-2'
 
 const baseProps = {
   bank: 'TEST',
   flowType: 'extract_transactions' as const,
   version: '1.0.0',
-  origin: 'system' as const,
+  origin: 'user' as const,
   selectorMap: {},
 }
 
 describe('PromoteScriptUseCase', () => {
-  it('promotes the script and deprecates the previously active one', async () => {
+  it("promotes the caller's own script and deprecates their previously active one, without any role check", async () => {
     const repo = new InMemoryBankScriptRepository()
-    const previous = BankScript.create('prev', { ...baseProps, version: '0.9.0', status: 'active' })
-    const candidate = BankScript.create('next', { ...baseProps, version: '1.0.0', status: 'review' })
+    const previous = BankScript.create('prev', { ...baseProps, version: '0.9.0', status: 'active', userId: OWNER })
+    const candidate = BankScript.create('next', { ...baseProps, version: '1.0.0', status: 'review', userId: OWNER })
     repo.store.set(previous.id, previous)
     repo.store.set(candidate.id, candidate)
 
     const useCase = new PromoteScriptUseCase(repo as any, new InMemoryUnitOfWork(), new InMemoryEventBus())
-    await useCase.execute({ scriptId: 'next' })
+    await useCase.execute({ scriptId: 'next', callerId: OWNER })
 
     expect(repo.store.get('next')!.status).toBe('active')
     expect(repo.store.get('prev')!.status).toBe('deprecated')
@@ -31,14 +34,14 @@ describe('PromoteScriptUseCase', () => {
 
   it('publishes a ScriptPromoted event after the transaction commits', async () => {
     const repo = new InMemoryBankScriptRepository()
-    const candidate = BankScript.create('next', { ...baseProps, status: 'review' })
+    const candidate = BankScript.create('next', { ...baseProps, status: 'review', userId: OWNER })
     repo.store.set(candidate.id, candidate)
     const bus = new InMemoryEventBus()
     const handler = vi.fn().mockResolvedValue(undefined)
     bus.subscribe('ScriptPromoted', handler)
 
     const useCase = new PromoteScriptUseCase(repo as any, new InMemoryUnitOfWork(), bus)
-    await useCase.execute({ scriptId: 'next' })
+    await useCase.execute({ scriptId: 'next', callerId: OWNER })
 
     expect(handler).toHaveBeenCalledTimes(1)
   })
@@ -46,6 +49,24 @@ describe('PromoteScriptUseCase', () => {
   it('throws NotFoundError when the script does not exist', async () => {
     const repo = new InMemoryBankScriptRepository()
     const useCase = new PromoteScriptUseCase(repo as any, new InMemoryUnitOfWork(), new InMemoryEventBus())
-    await expect(useCase.execute({ scriptId: 'missing' })).rejects.toBeInstanceOf(NotFoundError)
+    await expect(useCase.execute({ scriptId: 'missing', callerId: OWNER })).rejects.toBeInstanceOf(NotFoundError)
+  })
+
+  it("throws NotFoundError (masking existence) when the script is privately owned by someone else", async () => {
+    const repo = new InMemoryBankScriptRepository()
+    const candidate = BankScript.create('next', { ...baseProps, status: 'review', userId: OWNER })
+    repo.store.set(candidate.id, candidate)
+
+    const useCase = new PromoteScriptUseCase(repo as any, new InMemoryUnitOfWork(), new InMemoryEventBus())
+    await expect(useCase.execute({ scriptId: 'next', callerId: OTHER })).rejects.toBeInstanceOf(NotFoundError)
+  })
+
+  it('throws ForbiddenError when a regular caller tries to promote a system script', async () => {
+    const repo = new InMemoryBankScriptRepository()
+    const candidate = BankScript.create('next', { ...baseProps, origin: 'system', status: 'review' })
+    repo.store.set(candidate.id, candidate)
+
+    const useCase = new PromoteScriptUseCase(repo as any, new InMemoryUnitOfWork(), new InMemoryEventBus())
+    await expect(useCase.execute({ scriptId: 'next', callerId: OWNER })).rejects.toBeInstanceOf(ForbiddenError)
   })
 })

--- a/src/contexts/script-engine/application/PromoteScriptUseCase.ts
+++ b/src/contexts/script-engine/application/PromoteScriptUseCase.ts
@@ -1,9 +1,9 @@
 import { BankScriptRepository } from '../infrastructure/BankScriptRepository.js'
 import { IUnitOfWork } from '../../../shared/persistence/IUnitOfWork.js'
 import { IEventBus } from '../../../shared/events/IEventBus.js'
-import { NotFoundError } from '../../../shared/errors/index.js'
+import { ForbiddenError, NotFoundError } from '../../../shared/errors/index.js'
 
-interface Input { scriptId: string }
+interface Input { scriptId: string; callerId: string }
 
 export class PromoteScriptUseCase {
   constructor(
@@ -12,15 +12,21 @@ export class PromoteScriptUseCase {
     private readonly eventBus: IEventBus,
   ) {}
 
-  async execute({ scriptId }: Input): Promise<void> {
+  async execute({ scriptId, callerId }: Input): Promise<void> {
     const script = await this.scriptRepo.findById(scriptId)
     if (!script) throw new NotFoundError(`Script ${scriptId} not found`)
+    if (script.userId != null && script.userId !== callerId) {
+      throw new NotFoundError(`Script ${scriptId} not found`)
+    }
+    if (script.userId == null) {
+      throw new ForbiddenError('Only the script owner can promote it')
+    }
 
     script.promote()
 
     await this.unitOfWork.run(async (tx) => {
       const txRepo = this.scriptRepo.withTx(tx)
-      await txRepo.deprecateActive(script.bank, script.flowType)
+      await txRepo.deprecateActive(script.bank, script.flowType, script.accountId ?? null, script.userId ?? null)
       await txRepo.save(script)
     })
 

--- a/src/contexts/script-engine/application/PublishOfficialScriptUseCase.test.ts
+++ b/src/contexts/script-engine/application/PublishOfficialScriptUseCase.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const scriptFileExistsMock = vi.fn()
+vi.mock('../infrastructure/ScriptLoader.js', () => ({
+  ScriptLoader: { scriptFileExists: (...args: unknown[]) => scriptFileExistsMock(...args) },
+}))
+
+import { PublishOfficialScriptUseCase } from './PublishOfficialScriptUseCase.js'
+import { InMemoryBankScriptRepository } from '../../../../tests/helpers/inMemoryScriptRepo.js'
+import { InMemoryUnitOfWork } from '../../../../tests/helpers/inMemoryUnitOfWork.js'
+import { InMemoryEventBus } from '../../../shared/events/InMemoryEventBus.js'
+import { BankScript } from '../domain/BankScript.js'
+
+describe('PublishOfficialScriptUseCase', () => {
+  beforeEach(() => {
+    scriptFileExistsMock.mockReset()
+  })
+
+  it('creates and activates a new official script, deprecating the previous official one', async () => {
+    scriptFileExistsMock.mockReturnValue(true)
+    const repo = new InMemoryBankScriptRepository()
+    const previous = BankScript.create('prev', {
+      bank: 'mi-dinero', flowType: 'extract_transactions', version: '1.0.0',
+      origin: 'system', status: 'active', selectorMap: {},
+    })
+    repo.store.set(previous.id, previous)
+
+    const useCase = new PublishOfficialScriptUseCase(repo as any, new InMemoryUnitOfWork(), new InMemoryEventBus())
+    await useCase.execute({ bank: 'mi-dinero', flowType: 'extract_transactions', version: '1.1.0' })
+
+    const scripts = [...repo.store.values()]
+    const activated = scripts.find((s) => s.version === '1.1.0')
+    expect(activated).toBeDefined()
+    expect(activated!.status).toBe('active')
+    expect(activated!.origin).toBe('system')
+    expect(activated!.userId).toBeUndefined()
+    expect(repo.store.get('prev')!.status).toBe('deprecated')
+  })
+
+  it('never touches private (user/account-owned) scripts for the same bank/flow', async () => {
+    scriptFileExistsMock.mockReturnValue(true)
+    const repo = new InMemoryBankScriptRepository()
+    const privateScript = BankScript.create('priv', {
+      bank: 'mi-dinero', flowType: 'extract_transactions', version: '1.0.0',
+      origin: 'user', status: 'active', selectorMap: {}, userId: 'user-1',
+    })
+    repo.store.set(privateScript.id, privateScript)
+
+    const useCase = new PublishOfficialScriptUseCase(repo as any, new InMemoryUnitOfWork(), new InMemoryEventBus())
+    await useCase.execute({ bank: 'mi-dinero', flowType: 'extract_transactions', version: '1.1.0' })
+
+    expect(repo.store.get('priv')!.status).toBe('active')
+  })
+
+  it('throws when the on-disk script file does not exist', async () => {
+    scriptFileExistsMock.mockReturnValue(false)
+    const repo = new InMemoryBankScriptRepository()
+    const useCase = new PublishOfficialScriptUseCase(repo as any, new InMemoryUnitOfWork(), new InMemoryEventBus())
+
+    await expect(
+      useCase.execute({ bank: 'ghost-bank', flowType: 'extract_transactions', version: '1.0.0' }),
+    ).rejects.toThrow(/not found/i)
+    expect(repo.store.size).toBe(0)
+  })
+
+  it('publishes a ScriptPromoted event', async () => {
+    scriptFileExistsMock.mockReturnValue(true)
+    const repo = new InMemoryBankScriptRepository()
+    const bus = new InMemoryEventBus()
+    const handler = vi.fn().mockResolvedValue(undefined)
+    bus.subscribe('ScriptPromoted', handler)
+
+    const useCase = new PublishOfficialScriptUseCase(repo as any, new InMemoryUnitOfWork(), bus)
+    await useCase.execute({ bank: 'mi-dinero', flowType: 'extract_transactions', version: '1.1.0' })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/contexts/script-engine/application/PublishOfficialScriptUseCase.ts
+++ b/src/contexts/script-engine/application/PublishOfficialScriptUseCase.ts
@@ -1,0 +1,42 @@
+import crypto from 'crypto'
+import { BankScript, FlowType } from '../domain/BankScript.js'
+import { BankScriptRepository } from '../infrastructure/BankScriptRepository.js'
+import { ScriptLoader } from '../infrastructure/ScriptLoader.js'
+import { IUnitOfWork } from '../../../shared/persistence/IUnitOfWork.js'
+import { IEventBus } from '../../../shared/events/IEventBus.js'
+import { NotFoundError } from '../../../shared/errors/index.js'
+
+interface Input { bank: string; flowType: FlowType; version: string }
+
+/**
+ * CLI-only: registers a new git-committed script version as the official one
+ * for a bank/flow. No callerId/role check — trust comes from having shell/DB
+ * access to run this at all, the same trust level as hand-writing a migration.
+ */
+export class PublishOfficialScriptUseCase {
+  constructor(
+    private readonly scriptRepo: BankScriptRepository,
+    private readonly unitOfWork: IUnitOfWork,
+    private readonly eventBus: IEventBus,
+  ) {}
+
+  async execute({ bank, flowType, version }: Input): Promise<void> {
+    if (!ScriptLoader.scriptFileExists(bank, flowType, version)) {
+      throw new NotFoundError(`Script file not found for ${bank}:${flowType}:v${version}`)
+    }
+
+    const script = BankScript.create(crypto.randomUUID(), {
+      bank, flowType, version, status: 'review', origin: 'system', selectorMap: {},
+    })
+    script.promote()
+
+    await this.unitOfWork.run(async (tx) => {
+      const txRepo = this.scriptRepo.withTx(tx)
+      await txRepo.deprecateActive(bank, flowType, null, null)
+      await txRepo.save(script)
+    })
+
+    await this.eventBus.publishAll(script.domainEvents)
+    script.clearDomainEvents()
+  }
+}

--- a/src/contexts/script-engine/application/scriptEngineUseCases.test.ts
+++ b/src/contexts/script-engine/application/scriptEngineUseCases.test.ts
@@ -18,9 +18,9 @@ const baseScript = (overrides: Record<string, unknown> = {}) => ({
 })
 
 describe('GetScriptDetailUseCase', () => {
-  it('returns the full detail', async () => {
+  it('returns the full detail for a system script regardless of caller', async () => {
     const repo = { findById: vi.fn().mockResolvedValue(baseScript()) } as any
-    const out = await new GetScriptDetailUseCase(repo).execute('s-1')
+    const out = await new GetScriptDetailUseCase(repo).execute({ scriptId: 's-1', callerId: 'user-1' })
 
     expect(out).toMatchObject({
       id: 's-1',
@@ -34,7 +34,7 @@ describe('GetScriptDetailUseCase', () => {
     const repo = {
       findById: vi.fn().mockResolvedValue(baseScript({ baseScriptId: undefined, codeSnapshot: undefined })),
     } as any
-    const out = await new GetScriptDetailUseCase(repo).execute('s-1')
+    const out = await new GetScriptDetailUseCase(repo).execute({ scriptId: 's-1', callerId: 'user-1' })
 
     expect(out.baseScriptId).toBeNull()
     expect(out.codeSnapshot).toBeNull()
@@ -42,22 +42,35 @@ describe('GetScriptDetailUseCase', () => {
 
   it('throws NotFoundError when the script is missing', async () => {
     const repo = { findById: vi.fn().mockResolvedValue(null) } as any
-    await expect(new GetScriptDetailUseCase(repo).execute('missing')).rejects.toBeInstanceOf(
-      NotFoundError,
-    )
+    await expect(
+      new GetScriptDetailUseCase(repo).execute({ scriptId: 'missing', callerId: 'user-1' }),
+    ).rejects.toBeInstanceOf(NotFoundError)
+  })
+
+  it('returns the detail when the caller owns the private script', async () => {
+    const repo = { findById: vi.fn().mockResolvedValue(baseScript({ userId: 'user-1' })) } as any
+    const out = await new GetScriptDetailUseCase(repo).execute({ scriptId: 's-1', callerId: 'user-1' })
+    expect(out.id).toBe('s-1')
+  })
+
+  it('throws NotFoundError (masking existence) when the script is privately owned by someone else', async () => {
+    const repo = { findById: vi.fn().mockResolvedValue(baseScript({ userId: 'user-1' })) } as any
+    await expect(
+      new GetScriptDetailUseCase(repo).execute({ scriptId: 's-1', callerId: 'user-2' }),
+    ).rejects.toBeInstanceOf(NotFoundError)
   })
 })
 
 describe('ListScriptsUseCase', () => {
-  it('maps repository items to list DTOs', async () => {
-    const repo = {
-      findAll: vi.fn().mockResolvedValue([
-        baseScript(),
-        baseScript({ id: 's-2', version: '2.0.2', status: 'deprecated' }),
-      ]),
-    } as any
-    const out = await new ListScriptsUseCase(repo).execute()
+  it('maps repository items to list DTOs, scoped to the caller', async () => {
+    const findAll = vi.fn().mockResolvedValue([
+      baseScript(),
+      baseScript({ id: 's-2', version: '2.0.2', status: 'deprecated' }),
+    ])
+    const repo = { findAll } as any
+    const out = await new ListScriptsUseCase(repo).execute({ callerId: 'user-1' })
 
+    expect(findAll).toHaveBeenCalledWith('user-1')
     expect(out).toHaveLength(2)
     expect(out[0].status).toBe('active')
     expect(out[1].status).toBe('deprecated')
@@ -67,6 +80,6 @@ describe('ListScriptsUseCase', () => {
 
   it('returns empty array when there are no scripts', async () => {
     const repo = { findAll: vi.fn().mockResolvedValue([]) } as any
-    expect(await new ListScriptsUseCase(repo).execute()).toEqual([])
+    expect(await new ListScriptsUseCase(repo).execute({ callerId: 'user-1' })).toEqual([])
   })
 })

--- a/src/contexts/script-engine/infrastructure/ScriptLoader.test.ts
+++ b/src/contexts/script-engine/infrastructure/ScriptLoader.test.ts
@@ -165,6 +165,25 @@ describe('ScriptLoader', () => {
     expect(existsSyncMock).not.toHaveBeenCalled()
   })
 
+  it('scriptFileExists reports true when the on-disk file is present', () => {
+    existsSyncMock.mockReturnValueOnce(true)
+    const result = ScriptLoader.scriptFileExists('BancoPichincha', 'extract_transactions', '1.0.0')
+    expect(result).toBe(true)
+    const filePath = existsSyncMock.mock.calls[0][0] as string
+    expect(filePath).toMatch(/bancopichincha\/extract_transactions\.v1\.0\.0\.js$/)
+  })
+
+  it('scriptFileExists reports false when the on-disk file is missing', () => {
+    existsSyncMock.mockReturnValueOnce(false)
+    expect(ScriptLoader.scriptFileExists('GhostBank', 'extract_transactions', '9.9.9')).toBe(false)
+  })
+
+  it('scriptFileExists rejects a bank slug containing path-traversal characters', () => {
+    expect(() => ScriptLoader.scriptFileExists('../../../etc/passwd', 'extract_transactions', '1.0.0'))
+      .toThrow(/invalid bank/i)
+    expect(existsSyncMock).not.toHaveBeenCalled()
+  })
+
   it('slugifies bank names with internal whitespace before resolving the file path', async () => {
     dbQueryMock
       .mockResolvedValueOnce({ rows: [{ id: 'bank-id' }] })

--- a/src/contexts/script-engine/infrastructure/ScriptLoader.ts
+++ b/src/contexts/script-engine/infrastructure/ScriptLoader.ts
@@ -10,14 +10,18 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
 const BANK_SLUG_RE = /^[a-z0-9-]+$/
 
-function loadScriptCode(bank: string, flowType: string, version: string): string {
+function resolveScriptFilePath(bank: string, flowType: string, version: string): string {
   const bankSlug = bank.toLowerCase().replace(/\s+/g, '')
   // The slug is interpolated into a filesystem path; reject anything that could
   // traverse out of scriptsDir (e.g. "../") before touching disk.
   if (!BANK_SLUG_RE.test(bankSlug)) {
     throw new Error(`invalid bank slug: ${bank}`)
   }
-  const filePath = path.join(scriptsDir, bankSlug, `${flowType}.v${version}.js`)
+  return path.join(scriptsDir, bankSlug, `${flowType}.v${version}.js`)
+}
+
+function loadScriptCode(bank: string, flowType: string, version: string): string {
+  const filePath = resolveScriptFilePath(bank, flowType, version)
   if (!existsSync(filePath)) {
     throw new Error(`Script file not found: ${filePath}`)
   }
@@ -31,6 +35,10 @@ async function resolveBankId(bankIdOrCode: string): Promise<string | null> {
 }
 
 export const ScriptLoader = {
+  scriptFileExists(bank: string, flowType: string, version: string): boolean {
+    return existsSync(resolveScriptFilePath(bank, flowType, version))
+  },
+
   async loadActive(bankIdOrCode: string, flowType: FlowType, accountId: string, userId: string): Promise<BankScript | null> {
     const bankId = await resolveBankId(bankIdOrCode)
     if (!bankId) return null

--- a/src/shared/infrastructure/cli/publishScript.test.ts
+++ b/src/shared/infrastructure/cli/publishScript.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('dotenv/config', () => ({}))
+vi.mock('../db/client.js', () => ({ db: { query: vi.fn(), end: vi.fn() } }))
+
+import { parseArgs } from './publishScript.js'
+
+describe('publishScript parseArgs', () => {
+  it('parses bank, flowType, and version from --key=value args', () => {
+    const result = parseArgs(['--bank=mi-dinero', '--flowType=extract_transactions', '--version=1.1.0'])
+    expect(result).toEqual({ bank: 'mi-dinero', flowType: 'extract_transactions', version: '1.1.0' })
+  })
+
+  it('throws when a required arg is missing', () => {
+    expect(() => parseArgs(['--bank=mi-dinero', '--version=1.1.0'])).toThrow(/Usage:/)
+  })
+
+  it('throws when flowType is not a recognized value', () => {
+    expect(() => parseArgs(['--bank=mi-dinero', '--flowType=bogus', '--version=1.1.0'])).toThrow(/Invalid flowType/)
+  })
+})

--- a/src/shared/infrastructure/cli/publishScript.ts
+++ b/src/shared/infrastructure/cli/publishScript.ts
@@ -1,0 +1,47 @@
+import 'dotenv/config'
+import { db } from '../db/client.js'
+import { executorFromPool } from '../../../contexts/script-engine/infrastructure/Executor.js'
+import { BankScriptRepository } from '../../../contexts/script-engine/infrastructure/BankScriptRepository.js'
+import { PublishOfficialScriptUseCase } from '../../../contexts/script-engine/application/PublishOfficialScriptUseCase.js'
+import { PgUnitOfWork } from '../../persistence/PgUnitOfWork.js'
+import { InMemoryEventBus } from '../../events/InMemoryEventBus.js'
+import { logger } from '../../logger/index.js'
+import type { FlowType } from '../../../contexts/script-engine/domain/BankScript.js'
+
+const log = logger.child('[publish-script]')
+
+const FLOW_TYPES = ['login', 'extract_transactions', 'verify_payment']
+
+export function parseArgs(argv: string[]): { bank: string; flowType: FlowType; version: string } {
+  const opts: Record<string, string> = {}
+  for (const arg of argv) {
+    const match = /^--([a-zA-Z]+)=(.+)$/.exec(arg)
+    if (match) opts[match[1]] = match[2]
+  }
+  if (!opts.bank || !opts.flowType || !opts.version) {
+    throw new Error('Usage: publish-script --bank=<code> --flowType=<login|extract_transactions|verify_payment> --version=<x.y.z>')
+  }
+  if (!FLOW_TYPES.includes(opts.flowType)) {
+    throw new Error(`Invalid flowType: ${opts.flowType} (expected one of ${FLOW_TYPES.join(', ')})`)
+  }
+  return { bank: opts.bank, flowType: opts.flowType as FlowType, version: opts.version }
+}
+
+async function main() {
+  const { bank, flowType, version } = parseArgs(process.argv.slice(2))
+
+  const repo = new BankScriptRepository(executorFromPool(db))
+  const useCase = new PublishOfficialScriptUseCase(repo, new PgUnitOfWork(db), new InMemoryEventBus(logger))
+
+  await useCase.execute({ bank, flowType, version })
+  log.info(`published ${bank}:${flowType} v${version} as the new official active script`)
+  await db.end()
+}
+
+const isMain = process.argv[1] && import.meta.url === `file://${process.argv[1]}`
+if (isMain) {
+  main().catch(err => {
+    log.error('publish-script failed', { error: err instanceof Error ? err.message : String(err) })
+    process.exit(1)
+  })
+}

--- a/tests/helpers/inMemoryScriptRepo.ts
+++ b/tests/helpers/inMemoryScriptRepo.ts
@@ -18,15 +18,20 @@ export class InMemoryBankScriptRepository implements IBankScriptRepository {
     return this.store.get(id) ?? null
   }
 
-  async findAll(): Promise<ScriptListItem[]> {
-    return [...this.store.values()].map((s) => ({
-      id: s.id, bank: s.bank, flowType: s.flowType, version: s.version,
-      status: s.status, origin: s.origin, createdAt: s.createdAt,
-    }))
+  async findAll(callerId: string): Promise<ScriptListItem[]> {
+    return [...this.store.values()]
+      .filter((s) => s.userId == null || s.userId === callerId)
+      .map((s) => ({
+        id: s.id, bank: s.bank, flowType: s.flowType, version: s.version,
+        status: s.status, origin: s.origin, userId: s.userId ?? null, createdAt: s.createdAt,
+      }))
   }
 
-  async deprecateActive(bank: string, flowType: FlowType): Promise<void> {
-    const active = await this.findActive(bank, flowType)
+  async deprecateActive(bank: string, flowType: FlowType, accountId: string | null, userId: string | null): Promise<void> {
+    const active = [...this.store.values()].find(
+      (s) => s.bank === bank && s.flowType === flowType && s.status === 'active'
+        && (s.accountId ?? null) === accountId && (s.userId ?? null) === userId
+    )
     if (active) active.deprecate()
   }
 

--- a/tests/integration/script-engine/PromoteScriptUseCase.integration.test.ts
+++ b/tests/integration/script-engine/PromoteScriptUseCase.integration.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest'
 import crypto from 'crypto'
 import { getTestPool, truncateAll, closeTestPool } from '../helpers/testDb.js'
-import { getMiDineroBank } from '../helpers/seed.js'
+import { getMiDineroBank, seedUser } from '../helpers/seed.js'
 import { BankScriptRepository } from '../../../src/contexts/script-engine/infrastructure/BankScriptRepository.js'
 import { executorFromPool } from '../../../src/contexts/script-engine/infrastructure/Executor.js'
 import { PromoteScriptUseCase } from '../../../src/contexts/script-engine/application/PromoteScriptUseCase.js'
 import { PgUnitOfWork } from '../../../src/shared/persistence/PgUnitOfWork.js'
 import { InMemoryEventBus } from '../../../src/shared/events/InMemoryEventBus.js'
-import { ConflictError, NotFoundError } from '../../../src/shared/errors/index.js'
+import { ConflictError, ForbiddenError, NotFoundError } from '../../../src/shared/errors/index.js'
 
 async function clearNonSeededScripts(): Promise<void> {
   await getTestPool().query(
@@ -18,15 +18,16 @@ async function clearNonSeededScripts(): Promise<void> {
 async function insertReviewScript(opts: {
   id: string
   bankId: string
+  userId: string
   flowType?: 'login' | 'extract_transactions' | 'verify_payment'
   version?: string
   status?: 'review' | 'active' | 'deprecated'
 }): Promise<void> {
   await getTestPool().query(
     `INSERT INTO bank_scripts
-       (id, bank, flow_type, version, status, origin, selector_map, bank_id, created_at)
-     VALUES ($1, 'mi-dinero', $2, $3, $4, 'user', '{}', $5, now())`,
-    [opts.id, opts.flowType ?? 'extract_transactions', opts.version ?? '3.0.0', opts.status ?? 'review', opts.bankId]
+       (id, bank, flow_type, version, status, origin, selector_map, bank_id, user_id, created_at)
+     VALUES ($1, 'mi-dinero', $2, $3, $4, 'user', '{}', $5, $6, now())`,
+    [opts.id, opts.flowType ?? 'extract_transactions', opts.version ?? '3.0.0', opts.status ?? 'review', opts.bankId, opts.userId]
   )
 }
 
@@ -55,18 +56,14 @@ describe('PromoteScriptUseCase (integration)', () => {
     await closeTestPool()
   })
 
-  it('promotes a review script and deprecates the previously active one atomically', async () => {
+  it("promotes the owner's review script and deprecates their own previously active one atomically", async () => {
+    const owner = await seedUser()
+    const previousId = crypto.randomUUID()
     const candidateId = crypto.randomUUID()
-    await insertReviewScript({ id: candidateId, bankId, version: '3.0.0', status: 'review' })
+    await insertReviewScript({ id: previousId, bankId, userId: owner.id, version: '2.9.0', status: 'active' })
+    await insertReviewScript({ id: candidateId, bankId, userId: owner.id, version: '3.0.0', status: 'review' })
 
-    // Identify the seeded active script for mi-dinero/extract_transactions
-    const { rows: beforeRows } = await getTestPool().query(
-      `SELECT id FROM bank_scripts WHERE bank='mi-dinero' AND flow_type='extract_transactions' AND status='active'`
-    )
-    expect(beforeRows.length).toBe(1)
-    const previousActiveId = beforeRows[0].id
-
-    await useCase.execute({ scriptId: candidateId })
+    await useCase.execute({ scriptId: candidateId, callerId: owner.id })
 
     const { rows: candidateRow } = await getTestPool().query(
       `SELECT status FROM bank_scripts WHERE id = $1`,
@@ -76,26 +73,26 @@ describe('PromoteScriptUseCase (integration)', () => {
 
     const { rows: previousRow } = await getTestPool().query(
       `SELECT status FROM bank_scripts WHERE id = $1`,
-      [previousActiveId]
+      [previousId]
     )
     expect(previousRow[0].status).toBe('deprecated')
 
-    // Invariant: exactly one active row for (mi-dinero, extract_transactions)
-    const { rows: activeRows } = await getTestPool().query(
-      `SELECT id FROM bank_scripts WHERE bank='mi-dinero' AND flow_type='extract_transactions' AND status='active'`
+    // The official system script for mi-dinero/extract_transactions is untouched.
+    const { rows: systemRows } = await getTestPool().query(
+      `SELECT id FROM bank_scripts WHERE bank='mi-dinero' AND flow_type='extract_transactions' AND status='active' AND user_id IS NULL`
     )
-    expect(activeRows.length).toBe(1)
-    expect(activeRows[0].id).toBe(candidateId)
+    expect(systemRows.length).toBe(1)
   })
 
   it('publishes a ScriptPromoted event', async () => {
+    const owner = await seedUser()
     const candidateId = crypto.randomUUID()
-    await insertReviewScript({ id: candidateId, bankId, version: '3.0.1', status: 'review' })
+    await insertReviewScript({ id: candidateId, bankId, userId: owner.id, version: '3.0.1', status: 'review' })
 
     const handler = vi.fn().mockResolvedValue(undefined)
     bus.subscribe('ScriptPromoted', handler)
 
-    await useCase.execute({ scriptId: candidateId })
+    await useCase.execute({ scriptId: candidateId, callerId: owner.id })
 
     expect(handler).toHaveBeenCalledTimes(1)
     const event = handler.mock.calls[0][0]
@@ -107,30 +104,46 @@ describe('PromoteScriptUseCase (integration)', () => {
   })
 
   it('throws ConflictError when the script is already active and leaves DB unchanged', async () => {
-    const { rows: beforeRows } = await getTestPool().query(
-      `SELECT id, status FROM bank_scripts WHERE bank='mi-dinero' AND status='active' LIMIT 1`
-    )
-    const activeId = beforeRows[0].id
+    const owner = await seedUser()
+    const activeId = crypto.randomUUID()
+    await insertReviewScript({ id: activeId, bankId, userId: owner.id, version: '3.0.2', status: 'active' })
 
-    await expect(useCase.execute({ scriptId: activeId })).rejects.toBeInstanceOf(ConflictError)
+    await expect(useCase.execute({ scriptId: activeId, callerId: owner.id })).rejects.toBeInstanceOf(ConflictError)
 
     const { rows: afterRows } = await getTestPool().query(
       `SELECT id, status FROM bank_scripts WHERE id = $1`,
       [activeId]
     )
     expect(afterRows[0].status).toBe('active')
-
-    // Only one active row should still exist for that (bank, flow)
-    const { rows: activeRows } = await getTestPool().query(
-      `SELECT id FROM bank_scripts WHERE bank='mi-dinero' AND flow_type='extract_transactions' AND status='active'`
-    )
-    expect(activeRows.length).toBe(1)
-    expect(activeRows[0].id).toBe(activeId)
   })
 
   it('throws NotFoundError when the scriptId does not exist', async () => {
+    const owner = await seedUser()
     await expect(
-      useCase.execute({ scriptId: crypto.randomUUID() })
+      useCase.execute({ scriptId: crypto.randomUUID(), callerId: owner.id })
     ).rejects.toBeInstanceOf(NotFoundError)
+  })
+
+  it('throws NotFoundError (masking existence) when the script is privately owned by someone else', async () => {
+    const owner = await seedUser()
+    const other = await seedUser()
+    const candidateId = crypto.randomUUID()
+    await insertReviewScript({ id: candidateId, bankId, userId: owner.id, version: '3.0.3', status: 'review' })
+
+    await expect(
+      useCase.execute({ scriptId: candidateId, callerId: other.id })
+    ).rejects.toBeInstanceOf(NotFoundError)
+  })
+
+  it('throws ForbiddenError when a regular caller tries to promote the official system script', async () => {
+    const caller = await seedUser()
+    const { rows: beforeRows } = await getTestPool().query(
+      `SELECT id FROM bank_scripts WHERE bank='mi-dinero' AND status='active' AND user_id IS NULL LIMIT 1`
+    )
+    const systemScriptId = beforeRows[0].id
+
+    await expect(
+      useCase.execute({ scriptId: systemScriptId, callerId: caller.id })
+    ).rejects.toBeInstanceOf(ForbiddenError)
   })
 })


### PR DESCRIPTION
This pull request implements the runtime chain wiring, use cases, routes, and CLI publishing mechanism for bank script ownership, on top of the repository/loader changes merged in #150 and #151.

## Why one PR for five tasks

These layers are tightly coupled at the type level — `IScriptEnginePort` through `ScriptEngineAdapter` through `RunBankScrapeUseCase`, and the use cases through the routes they're wired into. Splitting them further reproduces the same red-CI cycle already seen twice on this feature (a signature change landing before its callers).

## Changes

**Runtime chain**
- `IScriptEnginePort.loadActiveScript` gains `accountId`/`userId` params.
- `ScriptEngineAdapter.loadActiveScript` threads them into `ScriptLoader.loadActive`.
- `RunBankScrapeUseCase` passes `account.id, account.userId`.
- `bankingModule.ts`'s persistent-session `startFn` closure passes the same through its direct `ScriptLoader.loadActive` call.

**Use cases**
- `PromoteScriptUseCase` — owner self-activates their own script; attempting to promote someone else's private script or a system script is rejected (`NotFoundError`/`ForbiddenError`). No more role/admin dependency.
- `DeprecateScriptUseCase` (new) — standalone owner-scoped deactivation lever, independent of having a replacement ready.
- `PublishOfficialScriptUseCase` (new, CLI-only) — registers a git-committed script file as the new official version for a bank/flow and deprecates whatever was previously active in that scope. No `callerId`/role check; trust comes from shell/DB access, the same level hand-writing a migration required.
- `ListScriptsUseCase`/`GetScriptDetailUseCase` scope to the caller (system rows plus the caller's own private tiers); no admin-sees-all branch.

**Routes and CLI**
- `scripts.routes.ts` drops `requireAdmin` entirely, threads `callerId` through every handler, adds `POST /:scriptId/deprecate`.
- `bindRoutes.ts` drops the `requireAdmin` arg from `buildScriptsRouter`.
- New `publish-script` CLI (`src/shared/infrastructure/cli/publishScript.ts`), following `migrate.ts`'s pattern; wired into `package.json`.
- `scriptEngineModule.ts` wires `deprecateScript` and `publishOfficialScript`.

## Testing

- `npx vitest run src/contexts/banking/infrastructure/ScriptEngineAdapter.test.ts src/contexts/banking/application/RunBankScrapeUseCase.test.ts src/composition/bankingModule.test.ts` — 29 passed.
- `npm run typecheck` — clean, 0 errors (this is what CI failed on twice before; confirmed clean before opening this PR).
- `npx vitest run --project unit` — 1121 passed.
- `npx vitest run --project integration` — 189 passed, 35 files, against local Postgres.

Part of the bank script isolation work tracked in #147.
