### PR TITLE
Recover the discarded bank script error text (#154)

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,35 @@
+# Issue tracker
+
+## Where issues live
+
+**GitHub Issues** on `ignaciogarcia-dev/reconbanker`, via the `gh` CLI.
+
+- Create: `gh issue create --title <title> --body-file <file> --label <label>`
+- List: `gh issue list --label <label>`
+- Read: `gh issue view <number>`
+
+## PRs as a request surface
+
+**Off.** Pull requests are not part of the triage queue — only issues are.
+
+## Triage labels
+
+The five canonical triage roles, each label string equal to its name:
+
+| Role | Label |
+|---|---|
+| Needs triage | `needs-triage` |
+| Needs info | `needs-info` |
+| Ready for agent | `ready-for-agent` |
+| Ready for human | `ready-for-human` |
+| Won't fix | `wontfix` |
+
+Present in the repository so far: `wontfix` (GitHub default) and `ready-for-agent` (created
+2026-08-13). The remaining three are created on first use.
+
+## Domain docs
+
+Single-context layout: `CONTEXT.md` and `docs/adr/` at the repository root. Neither exists yet —
+`docs/architecture.md` is currently the de facto domain reference, and its vocabulary (bounded
+contexts, ports and adapters, one-shot vs persistent session types, simple vs assisted login modes,
+failure categories, monitor stop reasons) should be used until a `CONTEXT.md` is written.

--- a/src/contexts/banking/application/RunBankScrapeUseCase.test.ts
+++ b/src/contexts/banking/application/RunBankScrapeUseCase.test.ts
@@ -41,6 +41,33 @@ const sample = (externalId: string): ScrapedTransaction => ({
 })
 
 describe('RunBankScrapeUseCase', () => {
+  it('hands the script engine the same runId it recorded, so log lines correlate to the run row', async () => {
+    const txRepo = new InMemoryBankTransactionRepository()
+    const scrapeRunRepo = new InMemoryScrapeRunRepository()
+    const eventBus = new InMemoryEventBus()
+    const runScript = vi.fn().mockResolvedValue([])
+    const useCase = new RunBankScrapeUseCase({
+      accountReader: {
+        findById: async (accountId: string) => ({
+          id: accountId, userId: 'user-1', bank: 'test-bank',
+          sessionType: 'one-shot' as const, loginMode: 'simple' as const,
+        }),
+      },
+      txRepo,
+      scrapeRunRepo,
+      scriptEngine: { loadActiveScript: async () => ({ id: 's1', codeSnapshot: '' }), runScript },
+      ingest: new IngestTransactionsUseCase({ txRepo, eventBus }),
+    })
+
+    await useCase.execute({ accountId: 'acc-1' })
+
+    expect(scrapeRunRepo.runs).toHaveLength(1)
+    expect(runScript).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ runId: scrapeRunRepo.runs[0].runId }),
+    )
+  })
+
   it('persists new transactions and publishes ingested events', async () => {
     const { useCase, txRepo, scrapeRunRepo, eventBus } = buildSut([sample('ext-1'), sample('ext-2')])
     const handler = vi.fn().mockResolvedValue(undefined)

--- a/src/contexts/banking/application/RunBankScrapeUseCase.ts
+++ b/src/contexts/banking/application/RunBankScrapeUseCase.ts
@@ -51,7 +51,7 @@ export class RunBankScrapeUseCase {
 
     try {
       const transactions = await withTimeout(
-        scriptEngine.runScript(script, { accountId, lastExternalId }),
+        scriptEngine.runScript(script, { accountId, lastExternalId, runId }),
         this.deps.runTimeoutMs ?? DEFAULT_RUN_TIMEOUT_MS,
         `bank scrape ${account.bank}`,
       )

--- a/src/contexts/banking/domain/IScriptEnginePort.ts
+++ b/src/contexts/banking/domain/IScriptEnginePort.ts
@@ -13,7 +13,16 @@ export interface ActiveScript {
   codeSnapshot: string
 }
 
+// `runId` is the bank_scrape_runs id the caller has already recorded. Required here
+// (the use case always has one) so every line a script emits can be tied back to its
+// run row without inventing a second identifier.
+export interface RunScriptContext {
+  accountId: string
+  lastExternalId: string | null
+  runId: string
+}
+
 export interface IScriptEnginePort {
   loadActiveScript(bank: string, flowType: string, accountId: string, userId: string): Promise<ActiveScript | null>
-  runScript(script: ActiveScript, context: { accountId: string; lastExternalId: string | null }): Promise<ScrapedTransaction[]>
+  runScript(script: ActiveScript, context: RunScriptContext): Promise<ScrapedTransaction[]>
 }

--- a/src/contexts/banking/infrastructure/ScriptEngineAdapter.test.ts
+++ b/src/contexts/banking/infrastructure/ScriptEngineAdapter.test.ts
@@ -62,12 +62,12 @@ describe('ScriptEngineAdapter', () => {
       const adapter = new ScriptEngineAdapter()
       const result = await adapter.runScript(
         { id: 'script-1', codeSnapshot: 'return []' },
-        { accountId: 'acc-1', lastExternalId: null },
+        { accountId: 'acc-1', lastExternalId: null, runId: 'run-1' },
       )
       expect(result).toBe(txs)
       expect(executeMock).toHaveBeenCalledWith(
         { id: 'script-1', codeSnapshot: 'return []' },
-        { accountId: 'acc-1', lastExternalId: null },
+        { accountId: 'acc-1', lastExternalId: null, runId: 'run-1' },
       )
     })
 
@@ -75,7 +75,7 @@ describe('ScriptEngineAdapter', () => {
       executeMock.mockResolvedValue([])
       const logger = { debug() {}, info() {}, warn() {}, error() {}, child() { return logger } } as any
       const adapter = new ScriptEngineAdapter(logger)
-      await adapter.runScript({ id: 's', codeSnapshot: 'return []' }, { accountId: 'a', lastExternalId: null })
+      await adapter.runScript({ id: 's', codeSnapshot: 'return []' }, { accountId: 'a', lastExternalId: null, runId: 'run-1' })
       expect(ctorArgs).toHaveLength(1)
       expect(ctorArgs[0][0]).toBe(logger)
     })
@@ -83,7 +83,7 @@ describe('ScriptEngineAdapter', () => {
     it('constructs the runner with undefined when no logger is provided', async () => {
       executeMock.mockResolvedValue([])
       const adapter = new ScriptEngineAdapter()
-      await adapter.runScript({ id: 's', codeSnapshot: 'return []' }, { accountId: 'a', lastExternalId: null })
+      await adapter.runScript({ id: 's', codeSnapshot: 'return []' }, { accountId: 'a', lastExternalId: null, runId: 'run-1' })
       expect(ctorArgs[0][0]).toBeUndefined()
     })
 
@@ -93,7 +93,7 @@ describe('ScriptEngineAdapter', () => {
       await expect(
         adapter.runScript(
           { id: 'script-1', codeSnapshot: 'return []' },
-          { accountId: 'acc-1', lastExternalId: 'x' },
+          { accountId: 'acc-1', lastExternalId: 'x', runId: 'run-1' },
         ),
       ).rejects.toThrow('runner exploded')
     })

--- a/src/contexts/banking/infrastructure/ScriptEngineAdapter.ts
+++ b/src/contexts/banking/infrastructure/ScriptEngineAdapter.ts
@@ -1,6 +1,6 @@
 import { ScriptLoader } from '../../script-engine/infrastructure/ScriptLoader.js'
 import { PlaywrightRunner } from '../../script-engine/infrastructure/PlaywrightRunner.js'
-import { ActiveScript, IScriptEnginePort, ScrapedTransaction } from '../domain/IScriptEnginePort.js'
+import { ActiveScript, IScriptEnginePort, RunScriptContext, ScrapedTransaction } from '../domain/IScriptEnginePort.js'
 import type { ILogger } from '../../../shared/logger/ILogger.js'
 
 export class ScriptEngineAdapter implements IScriptEnginePort {
@@ -14,7 +14,7 @@ export class ScriptEngineAdapter implements IScriptEnginePort {
 
   async runScript(
     script: ActiveScript,
-    context: { accountId: string; lastExternalId: string | null }
+    context: RunScriptContext
   ): Promise<ScrapedTransaction[]> {
     // PlaywrightRunner expects a BankScript-like object with codeSnapshot and id
     const runner = new PlaywrightRunner(this.logger)

--- a/src/contexts/script-engine/infrastructure/PlaywrightRunner.test.ts
+++ b/src/contexts/script-engine/infrastructure/PlaywrightRunner.test.ts
@@ -202,6 +202,54 @@ describe('PlaywrightRunner', () => {
     }))
   })
 
+  it('stamps the runId on every line a script emits through debugLog', async () => {
+    dbQueryMock.mockResolvedValueOnce({ rows: [{ username: 'u', encrypted_password: 'p' }] })
+    buildBrowserChain('')
+    const child: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() }
+    const logger: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn(() => child) }
+
+    const runner = new PlaywrightRunner(logger)
+    await runner.execute(
+      { id: 's', codeSnapshot: 'context.debugLog(JSON.stringify({ event: "poll_summary", incoming: 3 })); return []' } as any,
+      { accountId: 'acc-42', lastExternalId: null, runId: 'run-abc' },
+    )
+    expect(child.info).toHaveBeenCalledWith('poll_summary', expect.objectContaining({
+      accountId: 'acc-42', runId: 'run-abc',
+    }))
+  })
+
+  it('overrides a script-invented runId with the real one', async () => {
+    // mi-dinero builds its own `${Date.now()}-${random}` under this exact key; baseMeta
+    // is spread last so the real UUID wins rather than two values competing.
+    dbQueryMock.mockResolvedValueOnce({ rows: [{ username: 'u', encrypted_password: 'p' }] })
+    buildBrowserChain('')
+    const child: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() }
+    const logger: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn(() => child) }
+
+    const runner = new PlaywrightRunner(logger)
+    await runner.execute(
+      { id: 's', codeSnapshot: 'context.debugLog(JSON.stringify({ event: "poll_summary", runId: "1786556926403-behi6e" })); return []' } as any,
+      { accountId: 'acc-42', lastExternalId: null, runId: 'run-abc' },
+    )
+    const meta = child.info.mock.calls[0][1] as Record<string, unknown>
+    expect(meta.runId).toBe('run-abc')
+  })
+
+  it('omits runId from script log lines when the caller supplied none', async () => {
+    dbQueryMock.mockResolvedValueOnce({ rows: [{ username: 'u', encrypted_password: 'p' }] })
+    buildBrowserChain('')
+    const child: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() }
+    const logger: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn(() => child) }
+
+    const runner = new PlaywrightRunner(logger)
+    await runner.execute(
+      { id: 's', codeSnapshot: 'context.debugLog(JSON.stringify({ event: "poll_summary" })); return []' } as any,
+      { accountId: 'acc-42', lastExternalId: null },
+    )
+    const meta = child.info.mock.calls[0][1] as Record<string, unknown>
+    expect(meta).not.toHaveProperty('runId')
+  })
+
   it('rejects when the script takes longer than the configured timeout', async () => {
     vi.useFakeTimers()
     dbQueryMock.mockResolvedValueOnce({ rows: [{ username: 'u', encrypted_password: 'p' }] })

--- a/src/contexts/script-engine/infrastructure/PlaywrightRunner.ts
+++ b/src/contexts/script-engine/infrastructure/PlaywrightRunner.ts
@@ -23,6 +23,9 @@ interface ScrapedTransaction {
 interface RunContext {
   accountId: string
   lastExternalId: string | null
+  // Optional for the same reason `logger` is: the runner can execute a script without
+  // correlation wired up. The scrape use case always supplies it.
+  runId?: string
 }
 
 export class PlaywrightRunner {
@@ -76,7 +79,10 @@ export class PlaywrightRunner {
       password: credentialsCipher().decrypt(creds.encrypted_password),
       lastExternalId: context.lastExternalId,
       debugLog: this.logger
-        ? makeDebugLogSink(this.logger.child('[bank-scrape-script]'), { accountId: context.accountId })
+        ? makeDebugLogSink(this.logger.child('[bank-scrape-script]'), {
+            accountId: context.accountId,
+            ...(context.runId ? { runId: context.runId } : {}),
+          })
         : undefined,
     }
 

--- a/src/contexts/script-engine/infrastructure/debugLogSink.test.ts
+++ b/src/contexts/script-engine/infrastructure/debugLogSink.test.ts
@@ -105,7 +105,7 @@ describe('makeDebugLogSink', () => {
       })
     })
 
-    it('strips reserved/colliding keys from the payload', () => {
+    it('keeps colliding keys off the entry root but preserves their values under a prefix', () => {
       const log = fakeLogger()
       makeDebugLogSink(log)(
         emit('poll_summary', { message: 'x', level: 'error', timestamp: 'y', context: 'z', keep: 1 })
@@ -117,7 +117,43 @@ describe('makeDebugLogSink', () => {
       expect(meta).not.toHaveProperty('timestamp')
       expect(meta).not.toHaveProperty('context')
       expect(meta).not.toHaveProperty('level')
+      expect(meta.detail_message).toBe('x')
+      expect(meta.detail_timestamp).toBe('y')
+      expect(meta.detail_context).toBe('z')
       expect(meta.keep).toBe(1)
+    })
+
+    it('preserves the error text scripts emit under a message key', () => {
+      // Nine call sites across the live bank scripts do exactly this — e.g.
+      // debug("login_or_account_selection_failed", { message: e.message }) — and the
+      // text was previously discarded, leaving only the event name to debug from.
+      const log = fakeLogger()
+      makeDebugLogSink(log)(
+        emit('login_or_account_selection_failed', { message: 'locator timeout on #submit' })
+      )
+      const meta = log.warn.mock.calls[0][1] as Record<string, unknown>
+      expect(meta.detail_message).toBe('locator timeout on #submit')
+      expect(log.warn).toHaveBeenCalledWith('login_or_account_selection_failed', expect.any(Object))
+    })
+
+    it('consumes at and level rather than prefixing them', () => {
+      const log = fakeLogger()
+      makeDebugLogSink(log)(emit('poll_summary', { level: 'info' }))
+      const meta = log.info.mock.calls[0][1] as Record<string, unknown>
+      // `at` stays under its own name (the script's emit time, distinct from Winston's
+      // write timestamp); `level` is consumed as the level hint and never forwarded.
+      expect(meta.at).toBe('2026-06-09T00:00:00.000Z')
+      expect(meta).not.toHaveProperty('detail_at')
+      expect(meta).not.toHaveProperty('detail_level')
+      expect(meta).not.toHaveProperty('level')
+    })
+
+    it('redacts a colliding key by its original name, not its prefixed one', () => {
+      const log = fakeLogger()
+      makeDebugLogSink(log)(emit('poll_summary', { message: 'x', password: 'hunter2' }))
+      const meta = log.info.mock.calls[0][1] as Record<string, unknown>
+      expect(meta.detail_message).toBe('x')
+      expect(meta.password).toBe('[REDACTED]')
     })
 
     it('redacts credential-like keys', () => {

--- a/src/contexts/script-engine/infrastructure/debugLogSink.test.ts
+++ b/src/contexts/script-engine/infrastructure/debugLogSink.test.ts
@@ -218,6 +218,16 @@ describe('makeDebugLogSink', () => {
       expect(meta.incoming).toBe(1)
     })
 
+    it('carries a runId supplied in baseMeta, and a script cannot spoof it', () => {
+      const log = fakeLogger()
+      makeDebugLogSink(log, { accountId: 'acc-1', runId: 'run-real' })(
+        emit('poll_summary', { runId: '1786556926403-behi6e', incoming: 1 })
+      )
+      const meta = log.info.mock.calls[0][1] as Record<string, unknown>
+      expect(meta.runId).toBe('run-real')
+      expect(meta.incoming).toBe(1)
+    })
+
     it('omits at when the payload has none', () => {
       const log = fakeLogger()
       makeDebugLogSink(log)(JSON.stringify({ event: 'poll_summary', incoming: 2 }))

--- a/src/contexts/script-engine/infrastructure/debugLogSink.ts
+++ b/src/contexts/script-engine/infrastructure/debugLogSink.ts
@@ -8,8 +8,18 @@ const LEVELS = new Set<Level>(['debug', 'info', 'warn', 'error'])
 // in-memory state; refuse to JSON.parse a multi-MB line (OOM risk) and surface it.
 const MAX_LINE_SIZE = 1_000_000
 
-// Winston/printf reserve these; `context` would override the child-logger context.
-const RESERVED_KEYS = ['message', 'level', 'timestamp', 'context', 'at']
+// Keys the sink consumes itself: `level` is destructured out as the level hint, and
+// `at` is re-attached below as the script's emit time. Forwarding either from the
+// payload loop would duplicate them.
+const CONSUMED_KEYS = ['level', 'at']
+
+// Keys that collide with Winston's own entry fields (`context` would override the
+// child-logger context). These used to be dropped outright, which silently discarded
+// the error text from `debug("...", { message: e.message })` — the single most useful
+// field a failing script emits, and the shape nine live call sites use. Keep them off
+// the entry root, but preserve the value under a prefix so nothing is lost.
+const COLLIDING_KEYS = ['message', 'timestamp', 'context']
+const COLLIDING_PREFIX = 'detail_'
 
 // Defensive masking in case a script ever logs a credential-bearing field
 // (e.g. the full `raw` movement or the context). Scripts don't today, but the
@@ -91,8 +101,10 @@ export function makeDebugLogSink(
 
     const cleaned: Record<string, unknown> = {}
     for (const [k, v] of Object.entries(rest)) {
-      if (RESERVED_KEYS.includes(k)) continue
-      cleaned[k] = isSecretKey(k) ? '[REDACTED]' : v
+      if (CONSUMED_KEYS.includes(k)) continue
+      // Secrecy is decided by the name the script used, before any prefixing.
+      const value = isSecretKey(k) ? '[REDACTED]' : v
+      cleaned[COLLIDING_KEYS.includes(k) ? `${COLLIDING_PREFIX}${k}` : k] = value
     }
 
     const lvl = classify(typeof event === 'string' ? event : '', level)


### PR DESCRIPTION
Closes #154. Part of #153.

## What changed

When a bank script catches an error and logs it, the text was silently discarded. The debug-log sink treated `message` as reserved and skipped it wholesale, so the emitted entry carried only the event name. Nine call sites across the live scripts use exactly that shape.

Reserved keys are now split by what the sink actually does with them:

- **Consumed** — `level` (destructured as the level hint) and `at` (re-attached as the script's emit time). These stay out of the payload loop.
- **Colliding** — `message`, `timestamp`, `context` merely clash with Winston's entry fields. Preserved under a `detail_` prefix instead of dropped.

Redaction still keys off the name the script used, before prefixing.

## Note on the ticket

The ticket said `at` was being dropped. It wasn't — it's skipped in the loop and re-attached afterwards, so only three keys were ever lost. The test asserting `at` survives passed before any change and is now a regression guard.

No bank script is edited, so no republish or promotion is needed.

## Verification

Extends the existing sink tests; no new test file. Full unit suite green, both tsconfigs clean.

Also carries one unrelated commit recording the repo's issue-tracker configuration — `docs/agents/` existed but was empty.