### PR TITLE
Stamp the recorded runId on one-shot script log lines (#155)

### DIFF
--- a/src/contexts/banking/application/RunBankScrapeUseCase.test.ts
+++ b/src/contexts/banking/application/RunBankScrapeUseCase.test.ts
@@ -41,6 +41,33 @@ const sample = (externalId: string): ScrapedTransaction => ({
 })
 
 describe('RunBankScrapeUseCase', () => {
+  it('hands the script engine the same runId it recorded, so log lines correlate to the run row', async () => {
+    const txRepo = new InMemoryBankTransactionRepository()
+    const scrapeRunRepo = new InMemoryScrapeRunRepository()
+    const eventBus = new InMemoryEventBus()
+    const runScript = vi.fn().mockResolvedValue([])
+    const useCase = new RunBankScrapeUseCase({
+      accountReader: {
+        findById: async (accountId: string) => ({
+          id: accountId, userId: 'user-1', bank: 'test-bank',
+          sessionType: 'one-shot' as const, loginMode: 'simple' as const,
+        }),
+      },
+      txRepo,
+      scrapeRunRepo,
+      scriptEngine: { loadActiveScript: async () => ({ id: 's1', codeSnapshot: '' }), runScript },
+      ingest: new IngestTransactionsUseCase({ txRepo, eventBus }),
+    })
+
+    await useCase.execute({ accountId: 'acc-1' })
+
+    expect(scrapeRunRepo.runs).toHaveLength(1)
+    expect(runScript).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ runId: scrapeRunRepo.runs[0].runId }),
+    )
+  })
+
   it('persists new transactions and publishes ingested events', async () => {
     const { useCase, txRepo, scrapeRunRepo, eventBus } = buildSut([sample('ext-1'), sample('ext-2')])
     const handler = vi.fn().mockResolvedValue(undefined)

--- a/src/contexts/banking/application/RunBankScrapeUseCase.ts
+++ b/src/contexts/banking/application/RunBankScrapeUseCase.ts
@@ -51,7 +51,7 @@ export class RunBankScrapeUseCase {
 
     try {
       const transactions = await withTimeout(
-        scriptEngine.runScript(script, { accountId, lastExternalId }),
+        scriptEngine.runScript(script, { accountId, lastExternalId, runId }),
         this.deps.runTimeoutMs ?? DEFAULT_RUN_TIMEOUT_MS,
         `bank scrape ${account.bank}`,
       )

--- a/src/contexts/banking/domain/IScriptEnginePort.ts
+++ b/src/contexts/banking/domain/IScriptEnginePort.ts
@@ -13,7 +13,16 @@ export interface ActiveScript {
   codeSnapshot: string
 }
 
+// `runId` is the bank_scrape_runs id the caller has already recorded. Required here
+// (the use case always has one) so every line a script emits can be tied back to its
+// run row without inventing a second identifier.
+export interface RunScriptContext {
+  accountId: string
+  lastExternalId: string | null
+  runId: string
+}
+
 export interface IScriptEnginePort {
   loadActiveScript(bank: string, flowType: string, accountId: string, userId: string): Promise<ActiveScript | null>
-  runScript(script: ActiveScript, context: { accountId: string; lastExternalId: string | null }): Promise<ScrapedTransaction[]>
+  runScript(script: ActiveScript, context: RunScriptContext): Promise<ScrapedTransaction[]>
 }

--- a/src/contexts/banking/infrastructure/ScriptEngineAdapter.test.ts
+++ b/src/contexts/banking/infrastructure/ScriptEngineAdapter.test.ts
@@ -62,12 +62,12 @@ describe('ScriptEngineAdapter', () => {
       const adapter = new ScriptEngineAdapter()
       const result = await adapter.runScript(
         { id: 'script-1', codeSnapshot: 'return []' },
-        { accountId: 'acc-1', lastExternalId: null },
+        { accountId: 'acc-1', lastExternalId: null, runId: 'run-1' },
       )
       expect(result).toBe(txs)
       expect(executeMock).toHaveBeenCalledWith(
         { id: 'script-1', codeSnapshot: 'return []' },
-        { accountId: 'acc-1', lastExternalId: null },
+        { accountId: 'acc-1', lastExternalId: null, runId: 'run-1' },
       )
     })
 
@@ -75,7 +75,7 @@ describe('ScriptEngineAdapter', () => {
       executeMock.mockResolvedValue([])
       const logger = { debug() {}, info() {}, warn() {}, error() {}, child() { return logger } } as any
       const adapter = new ScriptEngineAdapter(logger)
-      await adapter.runScript({ id: 's', codeSnapshot: 'return []' }, { accountId: 'a', lastExternalId: null })
+      await adapter.runScript({ id: 's', codeSnapshot: 'return []' }, { accountId: 'a', lastExternalId: null, runId: 'run-1' })
       expect(ctorArgs).toHaveLength(1)
       expect(ctorArgs[0][0]).toBe(logger)
     })
@@ -83,7 +83,7 @@ describe('ScriptEngineAdapter', () => {
     it('constructs the runner with undefined when no logger is provided', async () => {
       executeMock.mockResolvedValue([])
       const adapter = new ScriptEngineAdapter()
-      await adapter.runScript({ id: 's', codeSnapshot: 'return []' }, { accountId: 'a', lastExternalId: null })
+      await adapter.runScript({ id: 's', codeSnapshot: 'return []' }, { accountId: 'a', lastExternalId: null, runId: 'run-1' })
       expect(ctorArgs[0][0]).toBeUndefined()
     })
 
@@ -93,7 +93,7 @@ describe('ScriptEngineAdapter', () => {
       await expect(
         adapter.runScript(
           { id: 'script-1', codeSnapshot: 'return []' },
-          { accountId: 'acc-1', lastExternalId: 'x' },
+          { accountId: 'acc-1', lastExternalId: 'x', runId: 'run-1' },
         ),
       ).rejects.toThrow('runner exploded')
     })

--- a/src/contexts/banking/infrastructure/ScriptEngineAdapter.ts
+++ b/src/contexts/banking/infrastructure/ScriptEngineAdapter.ts
@@ -1,6 +1,6 @@
 import { ScriptLoader } from '../../script-engine/infrastructure/ScriptLoader.js'
 import { PlaywrightRunner } from '../../script-engine/infrastructure/PlaywrightRunner.js'
-import { ActiveScript, IScriptEnginePort, ScrapedTransaction } from '../domain/IScriptEnginePort.js'
+import { ActiveScript, IScriptEnginePort, RunScriptContext, ScrapedTransaction } from '../domain/IScriptEnginePort.js'
 import type { ILogger } from '../../../shared/logger/ILogger.js'
 
 export class ScriptEngineAdapter implements IScriptEnginePort {
@@ -14,7 +14,7 @@ export class ScriptEngineAdapter implements IScriptEnginePort {
 
   async runScript(
     script: ActiveScript,
-    context: { accountId: string; lastExternalId: string | null }
+    context: RunScriptContext
   ): Promise<ScrapedTransaction[]> {
     // PlaywrightRunner expects a BankScript-like object with codeSnapshot and id
     const runner = new PlaywrightRunner(this.logger)

--- a/src/contexts/script-engine/infrastructure/PlaywrightRunner.test.ts
+++ b/src/contexts/script-engine/infrastructure/PlaywrightRunner.test.ts
@@ -202,6 +202,54 @@ describe('PlaywrightRunner', () => {
     }))
   })
 
+  it('stamps the runId on every line a script emits through debugLog', async () => {
+    dbQueryMock.mockResolvedValueOnce({ rows: [{ username: 'u', encrypted_password: 'p' }] })
+    buildBrowserChain('')
+    const child: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() }
+    const logger: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn(() => child) }
+
+    const runner = new PlaywrightRunner(logger)
+    await runner.execute(
+      { id: 's', codeSnapshot: 'context.debugLog(JSON.stringify({ event: "poll_summary", incoming: 3 })); return []' } as any,
+      { accountId: 'acc-42', lastExternalId: null, runId: 'run-abc' },
+    )
+    expect(child.info).toHaveBeenCalledWith('poll_summary', expect.objectContaining({
+      accountId: 'acc-42', runId: 'run-abc',
+    }))
+  })
+
+  it('overrides a script-invented runId with the real one', async () => {
+    // mi-dinero builds its own `${Date.now()}-${random}` under this exact key; baseMeta
+    // is spread last so the real UUID wins rather than two values competing.
+    dbQueryMock.mockResolvedValueOnce({ rows: [{ username: 'u', encrypted_password: 'p' }] })
+    buildBrowserChain('')
+    const child: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() }
+    const logger: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn(() => child) }
+
+    const runner = new PlaywrightRunner(logger)
+    await runner.execute(
+      { id: 's', codeSnapshot: 'context.debugLog(JSON.stringify({ event: "poll_summary", runId: "1786556926403-behi6e" })); return []' } as any,
+      { accountId: 'acc-42', lastExternalId: null, runId: 'run-abc' },
+    )
+    const meta = child.info.mock.calls[0][1] as Record<string, unknown>
+    expect(meta.runId).toBe('run-abc')
+  })
+
+  it('omits runId from script log lines when the caller supplied none', async () => {
+    dbQueryMock.mockResolvedValueOnce({ rows: [{ username: 'u', encrypted_password: 'p' }] })
+    buildBrowserChain('')
+    const child: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() }
+    const logger: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn(() => child) }
+
+    const runner = new PlaywrightRunner(logger)
+    await runner.execute(
+      { id: 's', codeSnapshot: 'context.debugLog(JSON.stringify({ event: "poll_summary" })); return []' } as any,
+      { accountId: 'acc-42', lastExternalId: null },
+    )
+    const meta = child.info.mock.calls[0][1] as Record<string, unknown>
+    expect(meta).not.toHaveProperty('runId')
+  })
+
   it('rejects when the script takes longer than the configured timeout', async () => {
     vi.useFakeTimers()
     dbQueryMock.mockResolvedValueOnce({ rows: [{ username: 'u', encrypted_password: 'p' }] })

--- a/src/contexts/script-engine/infrastructure/PlaywrightRunner.ts
+++ b/src/contexts/script-engine/infrastructure/PlaywrightRunner.ts
@@ -23,6 +23,9 @@ interface ScrapedTransaction {
 interface RunContext {
   accountId: string
   lastExternalId: string | null
+  // Optional for the same reason `logger` is: the runner can execute a script without
+  // correlation wired up. The scrape use case always supplies it.
+  runId?: string
 }
 
 export class PlaywrightRunner {
@@ -76,7 +79,10 @@ export class PlaywrightRunner {
       password: credentialsCipher().decrypt(creds.encrypted_password),
       lastExternalId: context.lastExternalId,
       debugLog: this.logger
-        ? makeDebugLogSink(this.logger.child('[bank-scrape-script]'), { accountId: context.accountId })
+        ? makeDebugLogSink(this.logger.child('[bank-scrape-script]'), {
+            accountId: context.accountId,
+            ...(context.runId ? { runId: context.runId } : {}),
+          })
         : undefined,
     }
 

--- a/src/contexts/script-engine/infrastructure/debugLogSink.test.ts
+++ b/src/contexts/script-engine/infrastructure/debugLogSink.test.ts
@@ -218,6 +218,16 @@ describe('makeDebugLogSink', () => {
       expect(meta.incoming).toBe(1)
     })
 
+    it('carries a runId supplied in baseMeta, and a script cannot spoof it', () => {
+      const log = fakeLogger()
+      makeDebugLogSink(log, { accountId: 'acc-1', runId: 'run-real' })(
+        emit('poll_summary', { runId: '1786556926403-behi6e', incoming: 1 })
+      )
+      const meta = log.info.mock.calls[0][1] as Record<string, unknown>
+      expect(meta.runId).toBe('run-real')
+      expect(meta.incoming).toBe(1)
+    })
+
     it('omits at when the payload has none', () => {
       const log = fakeLogger()
       makeDebugLogSink(log)(JSON.stringify({ event: 'poll_summary', incoming: 2 }))


### PR DESCRIPTION
Closes #155. Part of #153. **Stacked on #163 — merge that first.**

## What changed

A log line and a run row could not be connected. The run id existed in the database but appeared on exactly one warn line, and never reached the script's own logging at all. Meanwhile mi-dinero invents its own `\${Date.now()}-\${random}` under the same `runId` key, so the field was actively misleading.

The existing `bank_scrape_runs` id is now threaded through `RunScriptContext` into the sink's `baseMeta`. Because `baseMeta` is spread last, the real UUID overrides anything a script emits under that key rather than competing with it. No new identifier is introduced.

## Design note

`runId` is **required** on the port context — the use case always has one — and **optional** on the runner's `RunContext`, matching the existing optional-logger idiom: the runner can execute a script without correlation wired up. Making it required at the port caught four call sites at compile time.

Scoped to one-shot deliberately: persistent accounts have no run row to reference until #157.

## Verification

Extends the existing scrape use case, one-shot runner, adapter and sink tests. Full unit suite green, both tsconfigs clean.