### PR TITLE
Reconcile orphaned scrape runs at boot (#158)

### DIFF
--- a/src/composition/bankingModule.ts
+++ b/src/composition/bankingModule.ts
@@ -50,6 +50,8 @@ interface ContainerBase {
 
 export interface BankingModule {
   runBankScrape: RunBankScrapeUseCase
+  // Exposed for the boot-time orphan reconciliation in index.ts.
+  scrapeRunRepo: ScrapeRunRepository
   notifyBankMovement: NotifyBankMovementUseCase
   listBankMovements: ListBankMovementsUseCase
   reNotifyBankMovement: ReNotifyBankMovementUseCase
@@ -188,6 +190,7 @@ export function buildBankingModule(container: ContainerBase): BankingModule {
     }),
     bankTransactionRepository: bankTxRepo,
     sessionManager,
+    scrapeRunRepo,
     assistanceRepo,
     submitAssistanceCode: new SubmitAssistanceCodeUseCase(assistanceRepo, realtimeBus),
     reactivateSession: new ReactivateSessionUseCase(accountReader, (id) => {

--- a/src/contexts/banking/domain/IScrapeRunRepository.ts
+++ b/src/contexts/banking/domain/IScrapeRunRepository.ts
@@ -4,4 +4,10 @@ export interface IScrapeRunRepository {
   // the three-valued status deliberately does not, mirroring bank_sessions.stop_reason.
   markSuccess(runId: string, transactionCount: number, stopReason?: string): Promise<void>
   markFailed(runId: string, errorMessage: string, failureType?: string, stopReason?: string): Promise<void>
+  /**
+   * Closes every run still marked running. Correct only at boot: live sessions are
+   * held in an in-process registry, so a restart invalidates all of them by
+   * definition. Returns how many were reconciled.
+   */
+  markOrphaned(): Promise<number>
 }

--- a/src/contexts/banking/infrastructure/ScrapeRunRepository.ts
+++ b/src/contexts/banking/infrastructure/ScrapeRunRepository.ts
@@ -45,4 +45,18 @@ export class ScrapeRunRepository implements IScrapeRunRepository {
       [failureType, errorMessage, stopReason ?? null, runId]
     )
   }
+
+  // Age proves nothing here — a persistent session legitimately runs for days — so
+  // this is deliberately unconditional and boot-only rather than a periodic sweep.
+  async markOrphaned(): Promise<number> {
+    const { rowCount } = await this.executor.query(
+      `UPDATE bank_scrape_runs
+          SET status='failed', failure_type='orphaned',
+              error_message=COALESCE(error_message, 'run was still in progress when the process restarted'),
+              finished_at=now(),
+              duration_ms=${DURATION_MS}
+        WHERE status='running'`
+    )
+    return rowCount ?? 0
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,14 @@ const notifier = startNotifier(container)
 const httpServer = app.listen(PORT, async () => {
   log.info(`server listening`, { port: PORT })
   await container.banking.sessionManager.resetOrphanedSessions()
+  // Same reasoning as resetOrphanedSessions: a run still marked running cannot have
+  // survived the restart. Best-effort — a reconciliation failure must not stop boot.
+  await container.banking.scrapeRunRepo
+    .markOrphaned()
+    .then((n: number) => { if (n > 0) log.warn('reconciled orphaned scrape runs', { count: n }) })
+    .catch((err: unknown) => log.error('orphaned scrape run reconciliation failed', {
+      error: err instanceof Error ? err.message : String(err),
+    }))
   await scheduler.start()
 })
 realtimeGateway.attach(httpServer)

--- a/tests/helpers/inMemoryBankRepos.ts
+++ b/tests/helpers/inMemoryBankRepos.ts
@@ -55,4 +55,9 @@ export class InMemoryScrapeRunRepository implements IScrapeRunRepository {
     const r = this.runs.find((x) => x.runId === runId)
     if (r) { r.status = 'failed'; r.error = error; r.failureType = failureType; r.stopReason = stopReason }
   }
+  async markOrphaned(): Promise<number> {
+    const stuck = this.runs.filter((x) => x.status === 'running')
+    for (const r of stuck) { r.status = 'failed'; r.failureType = 'orphaned' }
+    return stuck.length
+  }
 }

--- a/tests/integration/banking/ScrapeRunRepository.integration.test.ts
+++ b/tests/integration/banking/ScrapeRunRepository.integration.test.ts
@@ -47,6 +47,46 @@ describe('ScrapeRunRepository (integration)', () => {
     expect(rows[0].finished_at).toBeInstanceOf(Date)
   })
 
+  it('markOrphaned closes every run left in progress by a restart', async () => {
+    const stuckOneShot = crypto.randomUUID()
+    const stuckSession = crypto.randomUUID()
+    const alreadyDone = crypto.randomUUID()
+    await repo.create(stuckOneShot, account.id, scriptId)
+    await repo.create(stuckSession, account.id, scriptId)
+    await repo.create(alreadyDone, account.id, scriptId)
+    await repo.markSuccess(alreadyDone, 1)
+
+    const count = await repo.markOrphaned()
+    expect(count).toBe(2)
+
+    const { rows } = await getTestPool().query(
+      'SELECT id, status, failure_type, finished_at, duration_ms FROM bank_scrape_runs WHERE id = ANY($1)',
+      [[stuckOneShot, stuckSession, alreadyDone]]
+    )
+    const byId = Object.fromEntries(rows.map((r) => [r.id, r]))
+    for (const id of [stuckOneShot, stuckSession]) {
+      expect(byId[id].status).toBe('failed')
+      expect(byId[id].failure_type).toBe('orphaned')
+      expect(byId[id].finished_at).toBeInstanceOf(Date)
+      expect(byId[id].duration_ms).not.toBeNull()
+    }
+    // A run that already finished is untouched — orphaning is not a blanket rewrite.
+    expect(byId[alreadyDone].status).toBe('success')
+  })
+
+  it('markOrphaned reports zero when nothing was in progress', async () => {
+    expect(await repo.markOrphaned()).toBe(0)
+  })
+
+  it('markSuccess records stop_reason and a derived duration', async () => {
+    const runId = crypto.randomUUID()
+    await repo.create(runId, account.id, scriptId)
+    await repo.markSuccess(runId, 3, 'stop_requested')
+    const { rows } = await getTestPool().query('SELECT * FROM bank_scrape_runs WHERE id=$1', [runId])
+    expect(rows[0].stop_reason).toBe('stop_requested')
+    expect(rows[0].duration_ms).not.toBeNull()
+  })
+
   it('markFailed sets status=failed, failure_type and error_message', async () => {
     const runId = crypto.randomUUID()
     await repo.create(runId, account.id, scriptId)


### PR DESCRIPTION
Closes #158. Part of #153. **Stacked on #165 — merge that first.**

## What changed

A run could sit in `running` forever: if the process died mid-run, or the code closing the row itself threw, nothing ever resolved it. There was no reaper — so a hang, one of the two failure classes this work targets, was invisible in the database rather than recorded as a failure.

`markOrphaned` closes every run still marked running, wired best-effort at boot so a reconciliation failure cannot stop startup.

## Why boot-only and unconditional

Live sessions are held in an in-process registry, so a restart invalidates all of them by definition. That makes this **correct rather than heuristic** — and age proves nothing for a persistent session that legitimately runs for days, which is why there is no periodic sweep or age cutoff. It mirrors the existing `resetOrphanedSessions` for `bank_sessions`.

**Known residual gap:** if the process stays up but a session's completion handler itself throws, that row stays in progress until the next restart.

Finished runs are untouched — orphaning is not a blanket rewrite.

## Verification

Integration test against a real database covering both session types, the untouched-finished-run case, and the zero case. Full unit suite green.