### PR TITLE
Prune old scrape runs on the scheduler interval (#161)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ SCRAPE_INTERVAL_SECONDS=1200
 EXPIRE_STALE_REQUESTS_INTERVAL_SECONDS=3600
 # How long bank_scrape_runs (and their cascaded step rows) are kept before pruning.
 SCRAPE_RUN_RETENTION_DAYS=90
+SCRAPE_RUN_PRUNE_INTERVAL_SECONDS=86400
 BANK_SCRAPE_CONCURRENCY=2
 
 # Per-phase timeouts (ms) bounding a single scrape so a hung browser can't wedge

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ NODE_ENV=development
 POLLING_INTERVAL_SECONDS=600
 SCRAPE_INTERVAL_SECONDS=1200
 EXPIRE_STALE_REQUESTS_INTERVAL_SECONDS=3600
+# How long bank_scrape_runs (and their cascaded step rows) are kept before pruning.
+SCRAPE_RUN_RETENTION_DAYS=90
 BANK_SCRAPE_CONCURRENCY=2
 
 # Per-phase timeouts (ms) bounding a single scrape so a hung browser can't wedge

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -109,6 +109,8 @@ If you need to override the frontend API base URL, define `VITE_API_BASE_URL` in
 | `NODE_ENV` | No | `development` | Set to `production` to disable stack traces in error responses |
 | `POLLING_INTERVAL_SECONDS` | No | `600` | Interval for polling customer order endpoints |
 | `SCRAPE_INTERVAL_SECONDS` | No | `1200` | Interval for running bank scraping jobs |
+| `SCRAPE_RUN_RETENTION_DAYS` | No | `90` | Age at which `bank_scrape_runs` rows are pruned (step rows cascade) |
+| `SCRAPE_RUN_PRUNE_INTERVAL_SECONDS` | No | `86400` | How often the prune job runs |
 | `EXPIRE_STALE_REQUESTS_INTERVAL_SECONDS` | No | `3600` | Interval for expiring stale conciliation requests |
 | `BANK_SCRAPE_CONCURRENCY` | No | `2` | Maximum number of bank scraping jobs, and Playwright browsers, to run at the same time |
 | `PLAYWRIGHT_PROFILES_DIR` | No | `./playwright-profiles` | Directory where persistent bank sessions store per-account browser profiles (gitignored) |

--- a/src/contexts/banking/domain/IScrapeRunRepository.ts
+++ b/src/contexts/banking/domain/IScrapeRunRepository.ts
@@ -10,4 +10,6 @@ export interface IScrapeRunRepository {
    * definition. Returns how many were reconciled.
    */
   markOrphaned(): Promise<number>
+  /** Deletes runs older than `days`; step rows follow via cascade. Returns the count. */
+  pruneOlderThan(days: number): Promise<number>
 }

--- a/src/contexts/banking/infrastructure/ScrapeRunRepository.ts
+++ b/src/contexts/banking/infrastructure/ScrapeRunRepository.ts
@@ -59,4 +59,14 @@ export class ScrapeRunRepository implements IScrapeRunRepository {
     )
     return rowCount ?? 0
   }
+
+  // Step rows go with them via the ON DELETE CASCADE that has been on
+  // bank_scrape_steps.run_id since 010, so this stays a single statement.
+  async pruneOlderThan(days: number): Promise<number> {
+    const { rowCount } = await this.executor.query(
+      `DELETE FROM bank_scrape_runs WHERE started_at < now() - make_interval(days => $1)`,
+      [days]
+    )
+    return rowCount ?? 0
+  }
 }

--- a/src/shared/infrastructure/queues/Scheduler.test.ts
+++ b/src/shared/infrastructure/queues/Scheduler.test.ts
@@ -37,15 +37,17 @@ function makeContainer(overrides: { isRunning?: (id: string) => boolean; expire?
   const { child: log } = makeLogger()
   const expireExecute = vi.fn(overrides.expire ?? (async () => {}))
   const isRunning = vi.fn(overrides.isRunning ?? (() => false))
+  const pruneRuns = vi.fn(async () => 0)
   return {
     container: {
       logger: { child: vi.fn(() => log) },
-      banking: { sessionManager: { isRunning } },
+      banking: { sessionManager: { isRunning }, scrapeRunRepo: { pruneOlderThan: pruneRuns } },
       conciliation: { expireStaleRequests: { execute: expireExecute } },
     } as never,
     log,
     expireExecute,
     isRunning,
+    pruneRuns,
   }
 }
 
@@ -60,6 +62,30 @@ describe('Scheduler', () => {
   afterEach(() => {
     vi.useRealTimers()
     vi.unstubAllEnvs()
+  })
+
+  it('prunes old scrape runs on start and on its own interval, using the configured retention', async () => {
+    dbQuery.mockResolvedValue({ rows: [] })
+    vi.stubEnv('SCRAPE_RUN_RETENTION_DAYS', '30')
+    vi.stubEnv('SCRAPE_RUN_PRUNE_INTERVAL_SECONDS', '3600')
+    const { container, pruneRuns } = makeContainer()
+    const scheduler = new Scheduler(container)
+
+    await scheduler.start()
+    expect(pruneRuns).toHaveBeenCalledWith(30)
+
+    await vi.advanceTimersByTimeAsync(3600 * 1000)
+    expect(pruneRuns).toHaveBeenCalledTimes(2)
+    scheduler.stop()
+  })
+
+  it('defaults scrape run retention to 90 days', async () => {
+    dbQuery.mockResolvedValue({ rows: [] })
+    const { container, pruneRuns } = makeContainer()
+    const scheduler = new Scheduler(container)
+    await scheduler.start()
+    expect(pruneRuns).toHaveBeenCalledWith(90)
+    scheduler.stop()
   })
 
   it('runs initial pass for polling, scraping, persistent sessions, and expire', async () => {

--- a/src/shared/infrastructure/queues/Scheduler.ts
+++ b/src/shared/infrastructure/queues/Scheduler.ts
@@ -20,17 +20,20 @@ export class Scheduler {
     const scrapeInterval  = Number(process.env.SCRAPE_INTERVAL_SECONDS ?? 1200) * 1000
     const expireInterval  = Number(process.env.EXPIRE_STALE_REQUESTS_INTERVAL_SECONDS ?? 3600) * 1000
     const sessionCheckInterval = Number(process.env.SESSION_HEALTHCHECK_SECONDS ?? 75) * 1000
+    const pruneInterval = Number(process.env.SCRAPE_RUN_PRUNE_INTERVAL_SECONDS ?? 86400) * 1000
 
     await this.enqueuePolling()
     await this.enqueueScraping()
     await this.ensurePersistentSessions()
     await this.expireStaleRequests()
+    await this.pruneScrapeRuns()
 
     this.timers.push(
       setInterval(() => this.runSafely('enqueuePolling', () => this.enqueuePolling()),  pollingInterval),
       setInterval(() => this.runSafely('enqueueScraping', () => this.enqueueScraping()), scrapeInterval),
       setInterval(() => this.runSafely('ensurePersistentSessions', () => this.ensurePersistentSessions()), sessionCheckInterval),
       setInterval(() => this.runSafely('expireStaleRequests', () => this.expireStaleRequests()), expireInterval),
+      setInterval(() => this.runSafely('pruneScrapeRuns', () => this.pruneScrapeRuns()), pruneInterval),
     )
 
     this.log.info('started', {
@@ -108,5 +111,14 @@ export class Scheduler {
 
   private async expireStaleRequests(): Promise<void> {
     await this.container.conciliation.expireStaleRequests.execute()
+  }
+
+  // Neither bank_scrape_runs nor bank_scrape_steps was ever pruned — rows only ever
+  // disappeared when an account was deleted. Survivable while almost nothing was
+  // written; unbounded now that every execution records a run and its failing stages.
+  private async pruneScrapeRuns(): Promise<void> {
+    const days = Number(process.env.SCRAPE_RUN_RETENTION_DAYS ?? 90)
+    const deleted = await this.container.banking.scrapeRunRepo.pruneOlderThan(days)
+    if (deleted > 0) this.log.info('pruned old scrape runs', { deleted, retentionDays: days })
   }
 }

--- a/src/shared/infrastructure/queues/Scheduler.ts
+++ b/src/shared/infrastructure/queues/Scheduler.ts
@@ -21,19 +21,20 @@ export class Scheduler {
     const expireInterval  = Number(process.env.EXPIRE_STALE_REQUESTS_INTERVAL_SECONDS ?? 3600) * 1000
     const sessionCheckInterval = Number(process.env.SESSION_HEALTHCHECK_SECONDS ?? 75) * 1000
     const pruneInterval = Number(process.env.SCRAPE_RUN_PRUNE_INTERVAL_SECONDS ?? 86400) * 1000
+    const retentionDays = Number(process.env.SCRAPE_RUN_RETENTION_DAYS ?? 90)
 
     await this.enqueuePolling()
     await this.enqueueScraping()
     await this.ensurePersistentSessions()
     await this.expireStaleRequests()
-    await this.pruneScrapeRuns()
+    await this.pruneScrapeRuns(retentionDays)
 
     this.timers.push(
       setInterval(() => this.runSafely('enqueuePolling', () => this.enqueuePolling()),  pollingInterval),
       setInterval(() => this.runSafely('enqueueScraping', () => this.enqueueScraping()), scrapeInterval),
       setInterval(() => this.runSafely('ensurePersistentSessions', () => this.ensurePersistentSessions()), sessionCheckInterval),
       setInterval(() => this.runSafely('expireStaleRequests', () => this.expireStaleRequests()), expireInterval),
-      setInterval(() => this.runSafely('pruneScrapeRuns', () => this.pruneScrapeRuns()), pruneInterval),
+      setInterval(() => this.runSafely('pruneScrapeRuns', () => this.pruneScrapeRuns(retentionDays)), pruneInterval),
     )
 
     this.log.info('started', {
@@ -116,8 +117,7 @@ export class Scheduler {
   // Neither bank_scrape_runs nor bank_scrape_steps was ever pruned — rows only ever
   // disappeared when an account was deleted. Survivable while almost nothing was
   // written; unbounded now that every execution records a run and its failing stages.
-  private async pruneScrapeRuns(): Promise<void> {
-    const days = Number(process.env.SCRAPE_RUN_RETENTION_DAYS ?? 90)
+  private async pruneScrapeRuns(days: number): Promise<void> {
     const deleted = await this.container.banking.scrapeRunRepo.pruneOlderThan(days)
     if (deleted > 0) this.log.info('pruned old scrape runs', { deleted, retentionDays: days })
   }

--- a/tests/helpers/inMemoryBankRepos.ts
+++ b/tests/helpers/inMemoryBankRepos.ts
@@ -55,6 +55,9 @@ export class InMemoryScrapeRunRepository implements IScrapeRunRepository {
     const r = this.runs.find((x) => x.runId === runId)
     if (r) { r.status = 'failed'; r.error = error; r.failureType = failureType; r.stopReason = stopReason }
   }
+  async pruneOlderThan(_days: number): Promise<number> {
+    return 0 // no clock in the fake; retention is covered by the integration test
+  }
   async markOrphaned(): Promise<number> {
     const stuck = this.runs.filter((x) => x.status === 'running')
     for (const r of stuck) { r.status = 'failed'; r.failureType = 'orphaned' }

--- a/tests/integration/banking/ScrapeRunRepository.integration.test.ts
+++ b/tests/integration/banking/ScrapeRunRepository.integration.test.ts
@@ -74,6 +74,27 @@ describe('ScrapeRunRepository (integration)', () => {
     expect(byId[alreadyDone].status).toBe('success')
   })
 
+  it('pruneOlderThan deletes aged runs and cascades to their step rows', async () => {
+    const old = crypto.randomUUID()
+    const recent = crypto.randomUUID()
+    await repo.create(old, account.id, scriptId)
+    await repo.create(recent, account.id, scriptId)
+    await getTestPool().query(
+      `INSERT INTO bank_scrape_steps (run_id, step_index, step, status) VALUES ($1,0,'login','failed')`, [old]
+    )
+    await getTestPool().query(
+      `UPDATE bank_scrape_runs SET started_at = now() - interval '120 days' WHERE id=$1`, [old]
+    )
+
+    expect(await repo.pruneOlderThan(90)).toBe(1)
+
+    const runs = await getTestPool().query('SELECT id FROM bank_scrape_runs')
+    expect(runs.rows.map((r) => r.id)).toEqual([recent])
+    // The FK cascade from 010 is what keeps this a single statement.
+    const steps = await getTestPool().query('SELECT id FROM bank_scrape_steps WHERE run_id=$1', [old])
+    expect(steps.rows).toHaveLength(0)
+  })
+
   it('markOrphaned reports zero when nothing was in progress', async () => {
     expect(await repo.markOrphaned()).toBe(0)
   })


### PR DESCRIPTION
Closes #161. Part of #153. **Stacked on the #158 PR — merge that first.**

## What changed

Neither `bank_scrape_runs` nor `bank_scrape_steps` had ever been pruned — rows only disappeared when an account was deleted outright, via cascade. That was survivable while almost nothing was written; it stops being survivable now that every execution records a run and its failing stages.

One `DELETE` on the scheduler's existing interval pattern. Step rows follow via the `ON DELETE CASCADE` that has been on `bank_scrape_steps.run_id` since migration 010, so retention stays a single statement.

`SCRAPE_RUN_RETENTION_DAYS` defaults to 90 and `SCRAPE_RUN_PRUNE_INTERVAL_SECONDS` to 86400; both are documented in `.env.example` and the `getting-started.md` env reference.

## Verification

Scheduler tests cover registration on its own interval, the configured window and the default. An integration test proves the cascade actually removes step rows.

1134 unit + 212 integration green, both tsconfigs clean.