### PR TITLE
Capture the pre-failure event trail (#159)

### DIFF
--- a/src/contexts/banking/application/ScrapeRunRecorder.ts
+++ b/src/contexts/banking/application/ScrapeRunRecorder.ts
@@ -1,8 +1,10 @@
 import type { ILogger } from '../../../shared/logger/ILogger.js'
+import type { IFailureTrail, TrailEntry } from '../../../shared/domain/failureTrail.js'
 import { IScrapeRunRepository } from '../domain/IScrapeRunRepository.js'
 import { IScrapeStepRepository, StepOutcome } from '../domain/IScrapeStepRepository.js'
 import { categorizeFailure } from '../domain/scrapeFailure.js'
 import { ScrapeStage, stageFromFailureCategory } from '../domain/scrapeStage.js'
+import { TrailBuffer } from './TrailBuffer.js'
 
 export interface FailOptions {
   /** The page the browser was on when it broke — the cheapest field for reproducing it. */
@@ -14,12 +16,25 @@ export interface FailOptions {
   stopReason?: string
 }
 
+/**
+ * What the run was judged to be. Stamped on the flushed trail line so that reading the
+ * trail and reading the conclusion do not require two lookups.
+ */
+interface FailureVerdict {
+  stage?: ScrapeStage
+  failureType: string
+  stopReason?: string
+  url?: string
+}
+
 export interface ScrapeRunRecorderDeps {
   runId: string
   runRepo: IScrapeRunRepository
   stepRepo: IScrapeStepRepository
   logger?: ILogger
   now?: () => number
+  /** Defaults to a fresh TrailBuffer; injectable so a caller can inspect what was buffered. */
+  trail?: IFailureTrail
 }
 
 // A failure in the harness around the script body is not "unknown" — it names its own
@@ -44,8 +59,11 @@ export class ScrapeRunRecorder {
   private closed = false
   private lastUrl?: string
   private failedStage?: ScrapeStage
+  private readonly trail: IFailureTrail
 
-  constructor(private readonly deps: ScrapeRunRecorderDeps) {}
+  constructor(private readonly deps: ScrapeRunRecorderDeps) {
+    this.trail = deps.trail ?? new TrailBuffer()
+  }
 
   get runId(): string {
     return this.deps.runId
@@ -53,6 +71,11 @@ export class ScrapeRunRecorder {
 
   observeUrl(url: string): void {
     if (url) this.lastUrl = url
+  }
+
+  /** Buffers one event. No I/O — this runs on every line a script emits. */
+  event(entry: TrailEntry): void {
+    this.trail.event(entry)
   }
 
   private get clock(): () => number {
@@ -116,6 +139,8 @@ export class ScrapeRunRecorder {
   async succeed(transactionsFound: number, stopReason?: string): Promise<void> {
     if (this.closed) return
     this.closed = true
+    // A run that worked explains nothing, so the trail is dropped rather than written.
+    this.trail.drain()
     await this.bestEffort('markSuccess', () =>
       this.deps.runRepo.markSuccess(this.deps.runId, transactionsFound, stopReason)
     )
@@ -142,6 +167,12 @@ export class ScrapeRunRecorder {
       ?? (category === 'unknown' && stage ? HARNESS_FAILURE_TYPE[stage] ?? category : category)
 
     const detail = describe(err)
+
+    // Flushed before the database writes: the trail is the one artifact that exists
+    // only in memory, so it is the one worth getting out first.
+    this.flushTrail({ stage, failureType, stopReason: opts.stopReason, url })
+
+
     // stage() already wrote a row for a stage it wrapped; don't duplicate it.
     if (stage && stage !== this.failedStage) {
       await this.note(stage, 'failed', { ...detail, failureType, url })
@@ -150,6 +181,32 @@ export class ScrapeRunRecorder {
     await this.bestEffort('markFailed', () =>
       this.deps.runRepo.markFailed(this.deps.runId, detail.errorMessage ?? '', failureType, opts.stopReason)
     )
+  }
+
+  /**
+   * Writes the buffered trail as exactly one `error` entry.
+   *
+   * One entry, not one per event: it lands atomically so it cannot interleave with a
+   * concurrent account's output, it is retrievable by run id alone
+   * (`grep <runId> logs/error-*.log`), and one failure costs one line against the
+   * existing 14-day rotation. The log file rather than a database column, because the
+   * trail carries counterparty names and account numbers — rotating that exposure out
+   * beats storing it forever in a table nothing prunes on the same schedule.
+   */
+  private flushTrail(verdict: FailureVerdict): void {
+    // Guarded like every other write here, and for a sharper reason: this runs *before*
+    // markFailed, and `closed` is already set. A throw escaping here would abort fail()
+    // and leave the run stuck in `running` until the next boot reconciliation — losing
+    // the failure record itself in order to report a logging problem.
+    try {
+      const trail = this.trail.drain()
+      if (!trail.length) return
+      this.deps.logger?.error('failure_trail', {
+        runId: this.deps.runId, ...verdict, events: trail.length, trail,
+      })
+    } catch {
+      // Nowhere left to report it: the logger is what just failed.
+    }
   }
 }
 

--- a/src/contexts/banking/application/TrailBuffer.ts
+++ b/src/contexts/banking/application/TrailBuffer.ts
@@ -1,0 +1,106 @@
+import { MAX_LOG_LINE_CHARS, type IFailureTrail, type TrailEntry } from '../../../shared/domain/failureTrail.js'
+
+// A pinned head plus a rolling tail, not one flat window.
+//
+// A persistent monitor emits roughly two events per minute in steady state and can
+// run for days, so a flat window of any practical size ends up holding nothing but
+// the most recent poll cycles — it evicts the unique login phase in order to keep
+// more near-identical copies of the repetitive one. And an authentication failure at
+// hour six is usually explained by what happened at hour zero.
+//
+// 50 pinned covers launch through authentication on both contracts (the assisted
+// auth wait is the longest, and it reports on entry and exit only, not per poll).
+// The persistent contract reaches this buffer once #157 hands the monitor a recorder;
+// the window is sized for it now because it is the demanding case.
+const PINNED = 50
+const ROLLING = 150
+
+// Per-entry budget, derived from the one line-size limit rather than restated, so the
+// two cannot drift. Halved to leave room for the wrapper fields on the flush line.
+const MAX_ENTRY_CHARS = Math.floor(MAX_LOG_LINE_CHARS / (2 * (PINNED + ROLLING)))
+const MAX_STRING_CHARS = 120
+
+/**
+ * The in-memory event trail for one run. Filled by the debug-log sink on every line a
+ * script emits, drained by ScrapeRunRecorder — flushed to the log on failure,
+ * discarded on success.
+ *
+ * In-process only, so a hard crash loses the trail; boot reconciliation can then
+ * report only that the run was orphaned. That is inherent to flushing on failure, and
+ * the alternative — writing every checkpoint to disk as it happens — is the volume
+ * problem this buffer exists to avoid.
+ */
+export class TrailBuffer implements IFailureTrail {
+  private readonly head: TrailEntry[] = []
+  private readonly tail: TrailEntry[] = []
+  private dropped = 0
+
+  event(entry: TrailEntry): void {
+    const clamped = clampEntry(entry)
+    if (this.head.length < PINNED) {
+      this.head.push(clamped)
+      return
+    }
+    this.tail.push(clamped)
+    // shift() on a 150-element array, at ~2 events per minute, is not worth a ring index.
+    if (this.tail.length > ROLLING) {
+      this.tail.shift()
+      this.dropped += 1
+    }
+  }
+
+  /**
+   * The pinned head, then a marker for whatever the window evicted, then the tail.
+   * The marker matters: without it the trail looks continuous, and a reader would
+   * wrongly conclude that authentication was immediately followed by the failure.
+   */
+  drain(): TrailEntry[] {
+    const drained = [
+      ...this.head,
+      ...(this.dropped > 0 ? [{ event: 'trail_truncated', dropped: this.dropped }] : []),
+      ...this.tail,
+    ]
+    this.head.length = 0
+    this.tail.length = 0
+    this.dropped = 0
+    return drained
+  }
+}
+
+// Clamps one entry so no single event can blow the flushed line's budget — a script
+// is free to log a whole page's text as an error message. Truncates the long values
+// first and keeps the field names, since which fields were present is itself a clue.
+function clampEntry(entry: TrailEntry): TrailEntry {
+  if (serializedSize(entry) <= MAX_ENTRY_CHARS) return entry
+
+  const trimmed: TrailEntry = {}
+  for (const [key, value] of Object.entries(entry)) trimmed[key] = truncate(value)
+  trimmed.trail_entry_truncated = true
+  if (serializedSize(trimmed) <= MAX_ENTRY_CHARS) return trimmed
+
+  // Still oversized: the entry has too many fields, not just long ones. Keep the
+  // identity — when it happened and what it was — and drop the payload.
+  return { at: identity(entry.at), event: identity(entry.event), trail_entry_truncated: true }
+}
+
+const truncate = (value: unknown): unknown =>
+  typeof value === 'string' && value.length > MAX_STRING_CHARS
+    ? `${value.slice(0, MAX_STRING_CHARS)}…`
+    : value
+
+// The last resort has to be bounded unconditionally, so it cannot pass a value of
+// unknown size through. `at` and `event` come straight from a script's JSON and are only
+// conventionally strings — the sink does not check `at` at all — so an object or array
+// here would defeat the whole clamp.
+const identity = (value: unknown): unknown =>
+  typeof value === 'object' && value !== null ? '[dropped: not a scalar]' : truncate(value)
+
+// Entries come from JSON.parse so they are always serializable, but the trail must
+// never be the thing that breaks a run: treat an unserializable entry as oversized.
+function serializedSize(entry: TrailEntry): number {
+  try {
+    return JSON.stringify(entry)?.length ?? MAX_ENTRY_CHARS + 1
+  } catch {
+    return MAX_ENTRY_CHARS + 1
+  }
+}

--- a/src/contexts/script-engine/infrastructure/PlaywrightRunner.test.ts
+++ b/src/contexts/script-engine/infrastructure/PlaywrightRunner.test.ts
@@ -218,6 +218,33 @@ describe('PlaywrightRunner', () => {
     }))
   })
 
+  it('feeds every line a script emits into the recorder, which owns the failure trail', async () => {
+    // The two halves are tested separately — the sink pushes to whatever trail it is given,
+    // and the recorder buffers and flushes — so this asserts the one thing neither can:
+    // that the runner actually connects them.
+    dbQueryMock.mockResolvedValueOnce({ rows: [{ username: 'u', encrypted_password: 'p' }] })
+    buildBrowserChain('')
+    const child: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() }
+    const logger: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn(() => child) }
+
+    const buffered: Array<Record<string, unknown>> = []
+    const recorder = {
+      stage: <T,>(_step: string, fn: () => Promise<T>) => fn(),
+      observeUrl: vi.fn(),
+      event: (entry: Record<string, unknown>) => { buffered.push(entry) },
+    }
+
+    const runner = new PlaywrightRunner(logger)
+    await runner.execute(
+      { id: 's', codeSnapshot: 'context.debugLog(JSON.stringify({ event: "login_submit_start" })); return []' } as any,
+      { accountId: 'acc-42', lastExternalId: null, runId: 'run-abc', recorder: recorder as any },
+    )
+
+    // Classified debug, so it never reaches a file — and is exactly what the trail is for.
+    expect(child.debug).toHaveBeenCalledWith('login_submit_start', expect.any(Object))
+    expect(buffered).toEqual([{ event: 'login_submit_start', level: 'debug' }])
+  })
+
   it('overrides a script-invented runId with the real one', async () => {
     // mi-dinero builds its own `${Date.now()}-${random}` under this exact key; baseMeta
     // is spread last so the real UUID wins rather than two values competing.

--- a/src/contexts/script-engine/infrastructure/PlaywrightRunner.ts
+++ b/src/contexts/script-engine/infrastructure/PlaywrightRunner.ts
@@ -100,10 +100,16 @@ export class PlaywrightRunner {
       password: credentialsCipher().decrypt(creds.encrypted_password),
       lastExternalId: context.lastExternalId,
       debugLog: this.logger
-        ? makeDebugLogSink(this.logger.child('[bank-scrape-script]'), {
-            accountId: context.accountId,
-            ...(context.runId ? { runId: context.runId } : {}),
-          })
+        ? makeDebugLogSink(
+            this.logger.child('[bank-scrape-script]'),
+            {
+              accountId: context.accountId,
+              ...(context.runId ? { runId: context.runId } : {}),
+            },
+            // The recorder is the trail's owner: it buffers what the script reports and
+            // writes it out only if the run fails.
+            context.recorder,
+          )
         : undefined,
     }
 

--- a/src/contexts/script-engine/infrastructure/debugLogSink.test.ts
+++ b/src/contexts/script-engine/infrastructure/debugLogSink.test.ts
@@ -237,6 +237,81 @@ describe('makeDebugLogSink', () => {
     })
   })
 
+  describe('failure trail', () => {
+    const fakeTrail = () => {
+      const entries: Array<Record<string, unknown>> = []
+      return { entries, event: (e: Record<string, unknown>) => { entries.push(e) }, names: () => entries.map((e) => e.event) }
+    }
+
+    it('captures debug-classified events, which are exactly the ones the log level drops', () => {
+      // LOG_LEVEL is unset in production => 'info', so these three never reach a file.
+      // They are also the entire happy-path story of how far a run got.
+      const log = fakeLogger()
+      const trail = fakeTrail()
+      const sink = makeDebugLogSink(log, { accountId: 'a' }, trail)
+
+      sink(emit('login_submit_start'))
+      sink(emit('pagination_done'))
+      sink(emit('movements_table_visible'))
+
+      expect(log.debug).toHaveBeenCalledTimes(3)
+      expect(trail.names()).toEqual(['login_submit_start', 'pagination_done', 'movements_table_visible'])
+      expect(trail.entries[0]).toMatchObject({ level: 'debug', at: '2026-06-09T00:00:00.000Z' })
+    })
+
+    it('captures the cleaned entry, so redaction and the collision prefix apply to the trail too', () => {
+      const log = fakeLogger()
+      const trail = fakeTrail()
+      makeDebugLogSink(log, {}, trail)(
+        emit('login_failed', { message: 'locator timeout', password: 'hunter2' })
+      )
+
+      expect(trail.entries[0]).toMatchObject({
+        event: 'login_failed',
+        detail_message: 'locator timeout',
+        password: '[REDACTED]',
+      })
+      expect(trail.entries[0]).not.toHaveProperty('message')
+    })
+
+    it('leaves baseMeta off trail entries — the flush line carries it once', () => {
+      const log = fakeLogger()
+      const trail = fakeTrail()
+      makeDebugLogSink(log, { accountId: 'acc-1', runId: 'run-1', bank: 'mi-dinero' }, trail)(
+        emit('poll_summary', { incoming: 2 })
+      )
+
+      expect(trail.entries[0]).toEqual({
+        at: '2026-06-09T00:00:00.000Z', event: 'poll_summary', level: 'info', incoming: 2,
+      })
+    })
+
+    it('captures lines it could not parse, and oversized ones, rather than losing them', () => {
+      const log = fakeLogger()
+      const trail = fakeTrail()
+      const sink = makeDebugLogSink(log, {}, trail)
+
+      sink('not json at all')
+      sink('[1,2,3]')
+      sink('x'.repeat(1_000_001))
+
+      expect(trail.names()).toEqual(['unparsed_log_line', 'unparsed_log_line', 'oversized_log_entry'])
+      expect(trail.entries[2]).toMatchObject({ size: 1_000_001 })
+    })
+
+    it('ignores non-string input without touching the trail', () => {
+      const trail = fakeTrail()
+      makeDebugLogSink(fakeLogger(), {}, trail)(undefined as unknown as string)
+      expect(trail.entries).toHaveLength(0)
+    })
+
+    it('works with no trail supplied, since the runner can execute without diagnostics wired', () => {
+      const log = fakeLogger()
+      expect(() => makeDebugLogSink(log)(emit('poll_summary'))).not.toThrow()
+      expect(log.info).toHaveBeenCalled()
+    })
+  })
+
   describe('guards', () => {
     it('falls back to debug for non-JSON lines', () => {
       const log = fakeLogger()

--- a/src/contexts/script-engine/infrastructure/debugLogSink.ts
+++ b/src/contexts/script-engine/infrastructure/debugLogSink.ts
@@ -1,4 +1,5 @@
 import type { ILogger } from '../../../shared/logger/ILogger.js'
+import { MAX_LOG_LINE_CHARS, type ITrailSink } from '../../../shared/domain/failureTrail.js'
 
 type Level = 'debug' | 'info' | 'warn' | 'error'
 
@@ -6,7 +7,8 @@ const LEVELS = new Set<Level>(['debug', 'info', 'warn', 'error'])
 
 // Largest debugLog line we'll parse. A persistent monitor can accumulate large
 // in-memory state; refuse to JSON.parse a multi-MB line (OOM risk) and surface it.
-const MAX_LINE_SIZE = 1_000_000
+// Shared with the failure trail, which sizes its flush against the same limit.
+const MAX_LINE_SIZE = MAX_LOG_LINE_CHARS
 
 // Keys the sink consumes itself: `level` is destructured out as the level hint, and
 // `at` is re-attached below as the script's emit time. Forwarding either from the
@@ -71,29 +73,45 @@ function classify(event: string, explicit?: unknown): Level {
  * Scripts emit one JSON object per event (`{ at, event, ...data }`); this parses
  * it, assigns a Winston level by event name, strips colliding/secret fields, and
  * forwards it to `logger` with `baseMeta` (e.g. accountId, bank) on every line.
+ *
+ * `trail`, when supplied, receives every line the sink handles — *before* Winston's
+ * level filter, which is the whole point: the events that explain how far a run got
+ * are the `debug`-classified ones that never reach a file. It gets the cleaned entry
+ * rather than the raw line, so redaction applies to the trail too, and it gets no
+ * baseMeta, which would repeat accountId and runId on all 200 entries when the flush
+ * line already carries both.
  */
 export function makeDebugLogSink(
   logger: ILogger,
-  baseMeta: Record<string, unknown> = {}
+  baseMeta: Record<string, unknown> = {},
+  trail?: ITrailSink
 ): (line: string) => void {
   return (line: string) => {
     if (typeof line !== 'string') return
 
     if (line.length > MAX_LINE_SIZE) {
       logger.warn('oversized_log_entry', { ...baseMeta, size: line.length })
+      // Recorded rather than skipped: that a script emitted something too big to read
+      // is itself a diagnostic, and the buffer clamps the size.
+      trail?.event({ event: 'oversized_log_entry', size: line.length })
       return
+    }
+
+    // Not an event object: either unparseable, or valid JSON that isn't a record
+    // (a bare number, null, an array). Both are forwarded verbatim.
+    const unstructured = () => {
+      logger.debug(line, baseMeta)
+      trail?.event({ event: 'unparsed_log_line', line })
     }
 
     let parsed: unknown
     try {
       parsed = JSON.parse(line)
     } catch {
-      logger.debug(line, baseMeta)
-      return
+      return unstructured()
     }
     if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-      logger.debug(line, baseMeta)
-      return
+      return unstructured()
     }
 
     const { event, level, ...rest } = parsed as Record<string, unknown>
@@ -109,6 +127,9 @@ export function makeDebugLogSink(
 
     const lvl = classify(typeof event === 'string' ? event : '', level)
     const name = typeof event === 'string' && event ? event : 'monitor_event'
+    // The level is kept on the trail entry: reading a trail, the events that were
+    // already warn-worthy on their own are where you start.
+    trail?.event({ ...(at !== undefined ? { at } : {}), event: name, level: lvl, ...cleaned })
     // `at` is the event-emit time from the script; Winston adds its own log-write
     // `timestamp` in transports.ts. Both are kept on purpose — they're distinct.
     // baseMeta (system-supplied accountId/bank) wins: a script must not be able to

--- a/src/shared/domain/failureTrail.ts
+++ b/src/shared/domain/failureTrail.ts
@@ -1,0 +1,38 @@
+/**
+ * The pre-failure event trail.
+ *
+ * Most of what a bank script reports never reaches disk: the debug-log sink
+ * classifies any event that does not match its warn-pattern as `debug`, and the
+ * effective log level is `info`. So the entire happy path leading up to a failure —
+ * exactly the part that explains how far the run got — is dropped.
+ *
+ * The fix is not to raise the log level (a persistent monitor emits ~2 events a
+ * minute, forever, per account) but to keep a bounded in-memory buffer and write it
+ * out only when a run actually fails.
+ *
+ * Lives in the shared kernel because the two ends are in different contexts:
+ * `script-engine`'s sink fills the buffer, `banking`'s recorder drains it.
+ */
+export type TrailEntry = Record<string, unknown>
+
+/**
+ * The largest log line this system will produce or parse.
+ *
+ * Shared because both ends depend on it: the sink refuses to `JSON.parse` a line above
+ * this size (a persistent monitor can accumulate large in-memory state, and a multi-MB
+ * line is an OOM risk), and the trail sizes its own flush to stay underneath. Keeping
+ * one constant means raising the cap cannot silently invalidate the other end's budget.
+ */
+export const MAX_LOG_LINE_CHARS = 1_000_000
+
+/** The fill end, which is all the sink is given. */
+export interface ITrailSink {
+  /** Records one event. Must never throw and never do I/O — it runs on every log line. */
+  event(entry: TrailEntry): void
+}
+
+/** The drain end, held by whoever decides a run has ended. */
+export interface IFailureTrail extends ITrailSink {
+  /** Returns the buffered events in order and empties the buffer. */
+  drain(): TrailEntry[]
+}

--- a/src/shared/domain/scrapeStage.ts
+++ b/src/shared/domain/scrapeStage.ts
@@ -1,3 +1,5 @@
+import type { ITrailSink } from './failureTrail.js'
+
 /**
  * The stages a bank script run can be recorded at, mirroring the CHECK constraint on
  * bank_scrape_steps.step.
@@ -28,8 +30,11 @@ export type StepStatus = 'started' | 'success' | 'failed'
  * What the harness needs in order to record a stage, expressed as the narrowest
  * possible surface so `script-engine` depends on a capability rather than on
  * `banking`'s recorder. ScrapeRunRecorder satisfies this.
+ *
+ * Extends ITrailSink because the harness owns the debug-log sink: the sink is where
+ * every event a script emits passes through, so that is where the trail is filled.
  */
-export interface IStageRecorder {
+export interface IStageRecorder extends ITrailSink {
   stage<T>(step: ScrapeStage, fn: () => Promise<T>): Promise<T>
   /**
    * Reports the page the browser is on. Synchronous and I/O-free — the harness calls

--- a/tests/integration/banking/ScrapeRunRecorder.integration.test.ts
+++ b/tests/integration/banking/ScrapeRunRecorder.integration.test.ts
@@ -6,6 +6,8 @@ import { ScrapeRunRepository } from '../../../src/contexts/banking/infrastructur
 import { ScrapeStepRepository } from '../../../src/contexts/banking/infrastructure/ScrapeStepRepository.js'
 import { executorFromPool } from '../../../src/contexts/banking/infrastructure/Executor.js'
 import { ScrapeRunRecorder } from '../../../src/contexts/banking/application/ScrapeRunRecorder.js'
+import { TrailBuffer } from '../../../src/contexts/banking/application/TrailBuffer.js'
+import { MAX_LOG_LINE_CHARS } from '../../../src/shared/domain/failureTrail.js'
 import { SCRAPE_STAGES } from '../../../src/contexts/banking/domain/scrapeStage.js'
 import { TimeoutError } from '../../../src/shared/errors/index.js'
 
@@ -271,6 +273,180 @@ describe('ScrapeRunRecorder (integration)', () => {
       await expect(rec.stage('load_script', async () => { throw err })).rejects.toThrow()
       await rec.fail(err)
       expect((await run(runId)).failure_type).toBe('login_failed')
+    })
+  })
+
+  describe('the failure trail', () => {
+    // A logger that keeps what it was handed, so the flushed entry can be inspected as
+    // the shape that actually lands in logs/error-*.log.
+    function capturingLogger() {
+      const errors: Array<{ message: string; meta: Record<string, unknown> }> = []
+      const logger: any = {
+        debug() {}, info() {}, warn() {},
+        error(message: string, meta: Record<string, unknown>) { errors.push({ message, meta }) },
+        child() { return logger },
+      }
+      return { logger, errors, trails: () => errors.filter((e) => e.message === 'failure_trail') }
+    }
+
+    it('flushes exactly one entry, carrying the run id and the events in order', async () => {
+      const runId = await newRun()
+      const { logger, errors, trails } = capturingLogger()
+      const rec = build(runId, logger)
+
+      rec.event({ event: 'login_submit_start', level: 'debug' })
+      rec.event({ event: 'authenticated', level: 'info' })
+      rec.event({ event: 'movements_fetch_failed', detail_message: 'table never rendered' })
+
+      await rec.fail(new Error('movements_fetch_failed: table never rendered'))
+
+      expect(trails()).toHaveLength(1)
+      const { meta } = trails()[0]
+      expect(meta.runId).toBe(runId)
+      expect(meta.stage).toBe('movements_fetch')
+      expect(meta.failureType).toBe('movements_fetch_failed')
+      const trail = meta.trail as Array<Record<string, unknown>>
+      expect(trail.map((e) => e.event)).toEqual([
+        'login_submit_start', 'authenticated', 'movements_fetch_failed',
+      ])
+      // One line, so it cannot interleave with a concurrent account's output.
+      expect(errors).toHaveLength(1)
+    })
+
+    it('keeps the earliest events alongside the most recent when the window overflows', async () => {
+      const runId = await newRun()
+      const { logger, trails } = capturingLogger()
+      const rec = build(runId, logger)
+
+      // Well past 50 pinned + 150 rolling: an eight-hour session at a 60s poll interval
+      // emits roughly this many events.
+      for (let i = 0; i < 1_000; i++) rec.event({ event: `checkpoint_${i}` })
+      await rec.fail(new Error('login_failed: session lost at hour six'))
+
+      const trail = (trails()[0].meta.trail as Array<Record<string, unknown>>)
+      const names = trail.map((e) => e.event)
+
+      // The login phase survives — that is what explains an auth failure hours later.
+      expect(names.slice(0, 3)).toEqual(['checkpoint_0', 'checkpoint_1', 'checkpoint_2'])
+      // ...and so does the run-up to the failure.
+      expect(names.at(-1)).toBe('checkpoint_999')
+      // The gap between them is declared rather than left to look continuous.
+      expect(trail.find((e) => e.event === 'trail_truncated')).toMatchObject({ dropped: 800 })
+      expect(trail).toHaveLength(50 + 1 + 150)
+    })
+
+    it('stays inside the sink line-size cap even when every event is oversized', async () => {
+      const runId = await newRun()
+      const { logger, trails } = capturingLogger()
+      const rec = build(runId, logger)
+
+      // A script is free to log a whole page of text as an error message.
+      for (let i = 0; i < 400; i++) rec.event({ event: `dump_${i}`, blob: 'x'.repeat(20_000) })
+      await rec.fail(new Error('boom'))
+
+      const trail = trails()[0].meta.trail as Array<Record<string, unknown>>
+      expect(JSON.stringify(trail).length).toBeLessThan(MAX_LOG_LINE_CHARS)
+      // Truncated, not dropped: which fields an event carried is itself a clue.
+      expect(trail[0]).toMatchObject({ event: 'dump_0', trail_entry_truncated: true })
+      expect(String(trail[0].blob)).toHaveLength(121) // 120 chars + the ellipsis
+    })
+
+    it('keeps only the identity of an event with too many fields to trim', async () => {
+      const runId = await newRun()
+      const { logger, trails } = capturingLogger()
+      const rec = build(runId, logger)
+
+      // Truncating values cannot shrink this one — there are simply too many of them —
+      // so the entry falls back to when it happened and what it was.
+      const wide: Record<string, unknown> = { at: '2026-08-13T00:00:00.000Z', event: 'wide' }
+      for (let i = 0; i < 2_000; i++) wide[`field_${i}`] = i
+      rec.event(wide)
+      await rec.fail(new Error('boom'))
+
+      const trail = trails()[0].meta.trail as Array<Record<string, unknown>>
+      expect(trail[0]).toEqual({
+        at: '2026-08-13T00:00:00.000Z', event: 'wide', trail_entry_truncated: true,
+      })
+    })
+
+    it('stays inside the cap when the field it falls back to is not a scalar', async () => {
+      // The sink copies `at` verbatim from a script's JSON without checking its type, so
+      // the last-resort clamp cannot assume the fields it keeps are small.
+      const runId = await newRun()
+      const { logger, trails } = capturingLogger()
+      const rec = build(runId, logger)
+
+      for (let i = 0; i < 250; i++) {
+        const wide: Record<string, unknown> = { at: { nested: 'y'.repeat(10_000) }, event: `wide_${i}` }
+        for (let f = 0; f < 2_000; f++) wide[`field_${f}`] = f
+        rec.event(wide)
+      }
+      await rec.fail(new Error('boom'))
+
+      const trail = trails()[0].meta.trail as Array<Record<string, unknown>>
+      expect(JSON.stringify(trail).length).toBeLessThan(MAX_LOG_LINE_CHARS)
+      expect(trail[0].at).toBe('[dropped: not a scalar]')
+    })
+
+    it('still marks the run failed when writing the trail throws', async () => {
+      // flushTrail runs before markFailed, so an unguarded throw here would lose the
+      // failure record in order to report a logging problem.
+      const runId = await newRun()
+      const exploding: any = {
+        debug() {}, info() {}, warn() {},
+        error() { throw new Error('log transport down') },
+        child() { return exploding },
+      }
+      const rec = build(runId, exploding)
+      rec.event({ event: 'something_happened' })
+
+      await expect(rec.fail(new Error('login_failed: rejected'))).resolves.toBeUndefined()
+
+      const r = await run(runId)
+      expect(r.status).toBe('failed')
+      expect(r.failure_type).toBe('login_failed')
+    })
+
+    it('does not let an unserializable event break the run it was diagnosing', async () => {
+      const runId = await newRun()
+      const { logger, trails } = capturingLogger()
+      const rec = build(runId, logger)
+
+      // Entries come from JSON.parse today, so this cannot arise from a script — but the
+      // trail must never be the thing that breaks a scrape.
+      const circular: Record<string, unknown> = { event: 'self_referential' }
+      circular.self = circular
+
+      expect(() => rec.event(circular)).not.toThrow()
+      rec.event({ event: 'after' })
+      await rec.fail(new Error('boom'))
+
+      const trail = trails()[0].meta.trail as Array<Record<string, unknown>>
+      expect(trail.map((e) => e.event)).toEqual(['self_referential', 'after'])
+      expect(trail[0]).toMatchObject({ trail_entry_truncated: true })
+      expect(() => JSON.stringify(trail)).not.toThrow()
+    })
+
+    it('emits no trail for a run that succeeded, and keeps nothing buffered', async () => {
+      const runId = await newRun()
+      const { logger, trails } = capturingLogger()
+      const trail = new TrailBuffer()
+      const rec = new ScrapeRunRecorder({ runId, runRepo, stepRepo, logger, trail })
+
+      rec.event({ event: 'poll_summary', incoming: 3 })
+      await rec.succeed(3)
+
+      expect(trails()).toHaveLength(0)
+      // Emptied, not merely left unwritten — the buffer holds counterparty names and
+      // account numbers, so a successful run should not leave them in memory.
+      expect(trail.drain()).toEqual([])
+    })
+
+    it('writes no trail entry when there was nothing to report', async () => {
+      const runId = await newRun()
+      const { logger, errors } = capturingLogger()
+      await new ScrapeRunRecorder({ runId, runRepo, stepRepo, logger }).fail(new Error('boom'))
+      expect(errors).toHaveLength(0)
     })
   })
 


### PR DESCRIPTION
Closes #159. Part of #153.

## The problem

A failing bank script left no record of how far it got. The debug-log sink classifies any
event not matching its warn-pattern as `debug`, the effective log level is `info`, and so
the entire happy-path trail leading up to a failure was dropped before it reached a file.

Raising the log level is not the fix — a persistent monitor emits ~2 events a minute per
account, forever.

## The shape

A bounded in-memory buffer, filled by the sink on every line, drained by the recorder:
**discarded on success, flushed as one `error` entry on failure.**

- `shared/domain/failureTrail.ts` — `ITrailSink` (fill end, all the sink is given) and
  `IFailureTrail` (drain end, held by whoever decides a run has ended), plus the one
  shared `MAX_LOG_LINE_CHARS`.
- `banking/application/TrailBuffer.ts` — 50 pinned + 150 rolling, with a
  `trail_truncated` marker for whatever the window evicted.
- `debugLogSink.ts` — optional `trail`; pushes the cleaned entry pre-level-filter.
- `ScrapeRunRecorder.ts` — `event()`, drains on `succeed()`, flushes on `fail()`.

**Pinned head, not a flat window.** Any practical flat window evicts the unique login
phase to retain more copies of the repetitive poll phase — and an auth failure at hour
six is usually explained by what happened at hour zero.

**Log file, not a database column.** One line per failure against the existing 14-day
rotation, retrievable by run id alone, and it keeps the counterparty account numbers the
trail carries on a rotating exposure rather than a permanent one.

## Acceptance criteria

| Criterion | Where |
|---|---|
| One entry, run id + ordered events | `flushes exactly one entry…` (integration) |
| Events the log level would drop are present | `captures debug-classified events…` (sink) |
| Earliest survive alongside most recent | `keeps the earliest events alongside…` (integration) |
| Success emits no trail, retains no buffer | `emits no trail for a run that succeeded…` |
| Stays within the line-size limit | two tests: long strings, and non-scalar fallback |
| Extractable by run id, cannot interleave | one `logger.error` call, asserted |
| Extends existing sink + recorder seams | both files extended; no new test seam |

## Review notes

Two defects found by review and fixed here, both with regression tests:

1. **`flushTrail` was the one unguarded write** in a class built on `bestEffort`, and it
   runs *before* `markFailed` with the run already latched closed — a throwing logger
   would have aborted `fail()` and stranded the run in `running`.
2. **The clamp had a hole.** Truncation only shortens strings, and the last-resort clamp
   kept `at`/`event` verbatim. The sink copies `at` from script JSON without a type check,
   so a non-scalar `at` produced entries the clamp could not shrink (verified: 201 such
   entries exceeded 1MB).

Deliberately slightly beyond the letter of the ticket, both cheap and in its spirit:

- The sink also trails `unparsed_log_line` / `oversized_log_entry`. Lines the sink cannot
  parse are the ones most likely to precede a crash, and losing lines is the failure mode
  this ticket exists to fix.
- The flush line carries `stage` / `failureType` / `stopReason` / `url` alongside the
  events, so reading a trail from the log does not require a database lookup to learn the
  verdict.

**The persistent path is not wired here** — `bankingModule`'s monitor sink gets no trail,
because no recorder exists on that path until #157. The buffer is nonetheless sized for
the persistent contract, since it is the demanding case; `TrailBuffer.ts` says so in a
comment. #157 is stacked on this branch.

## Verification

- `pnpm typecheck` clean
- `pnpm test` — 1141 passed (153 files)
- `pnpm test:integration` — 221 passed (36 files)

Integration suites share one Postgres and must run serially; running two at once produces
spurious FK and gating failures.
