### PR TITLE
Persistent bank sessions get a run record (#157)

### DIFF
--- a/src/composition/bankingModule.test.ts
+++ b/src/composition/bankingModule.test.ts
@@ -70,6 +70,24 @@ function makeContainer() {
   }
 }
 
+// The run row is written through the pool executor, unlike credentials which go through
+// the shared db client — so the two are separable in assertions.
+const runInserts = (c: ReturnType<typeof makeContainer>) =>
+  (c.pool.query as ReturnType<typeof vi.fn>).mock.calls
+    .filter(([sql]) => typeof sql === 'string' && sql.includes('INSERT INTO bank_scrape_runs'))
+
+// A persistent account whose launch reaches the runner.
+function persistentAccount(c: ReturnType<typeof makeContainer>) {
+  c.account.accountRepository.findById.mockResolvedValue({
+    id: 'acc-1', userId: 'owner-1', bank: 'TEST',
+  })
+  c.account.accountConfigRepository.findByAccountId.mockResolvedValue({
+    sessionType: 'persistent', loginMode: 'simple',
+  })
+  scriptLoaderMock.loadActive.mockResolvedValue({ id: 'script-7', codeSnapshot: 'return {}' })
+  dbMock.query.mockResolvedValue({ rows: [{ username: 'u', encrypted_password: 'p' }] })
+}
+
 describe('buildBankingModule', () => {
   beforeEach(() => {
     dbMock.query.mockReset()
@@ -134,6 +152,9 @@ describe('buildBankingModule', () => {
       c.account.accountConfigRepository.findByAccountId.mockResolvedValue({
         sessionType: 'persistent', loginMode: 'simple',
       })
+      // The script is resolved first now — it identifies the run row that the recorded
+      // credentials stage writes to — so a credentials test has to get past it.
+      scriptLoaderMock.loadActive.mockResolvedValue({ id: 's', codeSnapshot: 'return {}' })
       dbMock.query.mockResolvedValueOnce({ rows: [] })
       const mod = buildBankingModule(c)
       await expect(mod.sessionManager.ensureRunning('acc-1')).rejects.toThrow('No valid credentials for account acc-1')
@@ -147,10 +168,27 @@ describe('buildBankingModule', () => {
       c.account.accountConfigRepository.findByAccountId.mockResolvedValue({
         sessionType: 'persistent', loginMode: 'simple',
       })
-      dbMock.query.mockResolvedValueOnce({ rows: [{ username: 'u', encrypted_password: 'p' }] })
       scriptLoaderMock.loadActive.mockResolvedValue(null)
       const mod = buildBankingModule(c)
       await expect(mod.sessionManager.ensureRunning('acc-1')).rejects.toThrow('No active script for TEST')
+    })
+
+    it('opens no run row when there is no script to attribute it to', async () => {
+      // A missing active script is misconfiguration rather than a failed execution, and
+      // the row needs the script id — so this throws before any row exists, exactly as
+      // the one-shot use case throws NotFoundError before create().
+      const c = makeContainer()
+      c.account.accountRepository.findById.mockResolvedValue({
+        id: 'acc-1', userId: 'u', bank: 'TEST',
+      })
+      c.account.accountConfigRepository.findByAccountId.mockResolvedValue({
+        sessionType: 'persistent', loginMode: 'simple',
+      })
+      scriptLoaderMock.loadActive.mockResolvedValue(null)
+      const mod = buildBankingModule(c)
+      await expect(mod.sessionManager.ensureRunning('acc-1')).rejects.toThrow()
+
+      expect(runInserts(c)).toHaveLength(0)
     })
 
     it('throws when the active script has no codeSnapshot', async () => {
@@ -161,10 +199,59 @@ describe('buildBankingModule', () => {
       c.account.accountConfigRepository.findByAccountId.mockResolvedValue({
         sessionType: 'persistent', loginMode: 'simple',
       })
-      dbMock.query.mockResolvedValueOnce({ rows: [{ username: 'u', encrypted_password: 'p' }] })
       scriptLoaderMock.loadActive.mockResolvedValue({ id: 's', codeSnapshot: '' })
       const mod = buildBankingModule(c)
       await expect(mod.sessionManager.ensureRunning('acc-1')).rejects.toThrow('No active script for TEST')
+    })
+
+    it('opens exactly one run row per session lifetime, attributed to the active script', async () => {
+      const c = makeContainer()
+      persistentAccount(c)
+      runnerStartMock.mockResolvedValue({ stop: vi.fn(), done: new Promise(() => {}) })
+      const mod = buildBankingModule(c)
+
+      await mod.sessionManager.ensureRunning('acc-1')
+      // Stand in for the ~75s persistent-session health-check, which calls the idempotent
+      // ensureRunning on every tick for the lifetime of the session.
+      for (let tick = 0; tick < 5; tick++) await mod.sessionManager.ensureRunning('acc-1')
+
+      const inserts = runInserts(c)
+      expect(inserts).toHaveLength(1)
+      const [, params] = inserts[0]
+      expect(params[1]).toBe('acc-1')
+      expect(params[2]).toBe('script-7')
+    })
+
+    it('ties the lines a persistent script emits to its run row', async () => {
+      // Correlation is the whole point of reusing the run id rather than inventing a
+      // tracking number: one identifier moves you between the log file and the database.
+      const c = makeContainer()
+      persistentAccount(c)
+      runnerStartMock.mockResolvedValue({ stop: vi.fn(), done: new Promise(() => {}) })
+      const mod = buildBankingModule(c)
+      await mod.sessionManager.ensureRunning('acc-1')
+
+      const runId = runInserts(c)[0][1][0]
+      const monitorLog = (c.logger.child as ReturnType<typeof vi.fn>).mock.results[0].value
+
+      runnerStartMock.mock.calls[0][0].context.debugLog(
+        JSON.stringify({ event: 'poll_summary', incoming: 2 }),
+      )
+
+      expect(monitorLog.info).toHaveBeenCalledWith('poll_summary', expect.objectContaining({
+        accountId: 'acc-1', bank: 'TEST', runId,
+      }))
+    })
+
+    it('hands the runner the same recorder that owns the run row', async () => {
+      const c = makeContainer()
+      persistentAccount(c)
+      runnerStartMock.mockResolvedValue({ stop: vi.fn(), done: new Promise(() => {}) })
+      const mod = buildBankingModule(c)
+      await mod.sessionManager.ensureRunning('acc-1')
+
+      const runId = runInserts(c)[0][1][0]
+      expect(runnerStartMock.mock.calls[0][0].recorder.runId).toBe(runId)
     })
 
     it('resolves the active script scoped to the account and its owning user', async () => {

--- a/src/composition/bankingModule.ts
+++ b/src/composition/bankingModule.ts
@@ -16,6 +16,7 @@ import { UserOperationModeReaderAdapter } from '../contexts/banking/infrastructu
 import type { AccountModule } from './accountModule.js'
 import type { UserModule } from './userModule.js'
 import { RunBankScrapeUseCase } from '../contexts/banking/application/RunBankScrapeUseCase.js'
+import { RecordedSessionLauncher } from '../contexts/banking/application/RecordedSessionLauncher.js'
 import { IngestTransactionsUseCase } from '../contexts/banking/application/IngestTransactionsUseCase.js'
 import { BankSessionRepository } from '../contexts/banking/infrastructure/BankSessionRepository.js'
 import { AssistanceRequestRepository } from '../contexts/banking/infrastructure/AssistanceRequestRepository.js'
@@ -102,55 +103,83 @@ export function buildBankingModule(container: ContainerBase): BankingModule {
 
   const monitorLog = container.logger.child('[bank-monitor]')
 
+  // Owns run identity for a persistent session: opens the row on launch and closes it from
+  // the monitor's stop reason. Invoked from inside startFn, which SessionManager calls only
+  // on a real launch — creating the row any further upstream would orphan one every time
+  // the ~75s health-check called the idempotent ensureRunning.
+  const recordedLauncher = new RecordedSessionLauncher({
+    runRepo: scrapeRunRepo,
+    stepRepo: scrapeStepRepo,
+    logger: container.logger.child('[session-run]'),
+  })
+
   const startFn = async (accountId: string) => {
     const account = await accountReader.findById(accountId)
     if (!account) throw new Error(`Account ${accountId} not found`)
 
-    const { rows: [creds] } = await db.query(
-      `SELECT username, encrypted_password FROM bank_credentials
-       WHERE account_id = $1 AND status = 'valid'`,
-      [accountId]
-    )
-    if (!creds) throw new Error(`No valid credentials for account ${accountId}`)
-
+    // Resolved before the run row exists, and deliberately so: a missing active script is
+    // misconfiguration rather than a failed execution, and the row needs its id. This
+    // mirrors the one-shot use case, which throws NotFoundError before create().
     const script = await ScriptLoader.loadActive(account.bank, 'extract_transactions', accountId, account.userId)
     if (!script || !script.codeSnapshot) throw new Error(`No active script for ${account.bank}`)
+    const scriptCode = script.codeSnapshot
 
-    const lastExternalId = await bankTxRepo.findLatestExternalId(accountId)
+    return recordedLauncher.launch({ accountId, scriptId: script.id }, async (recorder) => {
+      // Credential resolution is a recorded stage: a bad decryption key or a revoked
+      // credential is a specific, actionable cause, not an "unknown" failure.
+      const creds = await recorder.stage('credentials', async () => {
+        const { rows: [row] } = await db.query(
+          `SELECT username, encrypted_password FROM bank_credentials
+           WHERE account_id = $1 AND status = 'valid'`,
+          [accountId]
+        )
+        if (!row) throw new Error(`No valid credentials for account ${accountId}`)
+        return { username: row.username as string, password: credentialsCipher().decrypt(row.encrypted_password) }
+      })
 
-    const requestOtp = otpCoordinator.forSession({ accountId, userId: account.userId })
+      const lastExternalId = await bankTxRepo.findLatestExternalId(accountId)
 
-    const handle = await persistentRunner.start({
-      scriptCode: script.codeSnapshot,
-      loginMode: account.loginMode,
-      pollIntervalMs: Number(process.env.PERSISTENT_POLL_INTERVAL_MS ?? 60_000),
-      context: {
-        accountId,
-        username: creds.username,
-        password: credentialsCipher().decrypt(creds.encrypted_password),
-        lastExternalId,
-        debugLog: makeDebugLogSink(monitorLog, { accountId, bank: account.bank }),
-        requestOtp,
-      },
-      onTransactions: async (batch) => { await ingest.execute(accountId, script.id, batch) },
-      shouldStop: () => false,
-      // Bank-local day key whose change clears runMonitor's dedup set so it stays bounded over multi-day sessions
-      getBankDay: () =>
-        new Intl.DateTimeFormat('en-GB', {
-          timeZone: 'America/Guayaquil', year: 'numeric', month: '2-digit', day: '2-digit',
-        }).format(new Date()),
+      const requestOtp = otpCoordinator.forSession({ accountId, userId: account.userId })
+
+      const handle = await persistentRunner.start({
+        scriptCode,
+        loginMode: account.loginMode,
+        pollIntervalMs: Number(process.env.PERSISTENT_POLL_INTERVAL_MS ?? 60_000),
+        recorder,
+        context: {
+          accountId,
+          username: creds.username,
+          password: creds.password,
+          lastExternalId,
+          // The recorder doubles as the trail: it buffers everything the script reports and
+          // writes it out only if the session fails. runId ties those lines to the run row.
+          debugLog: makeDebugLogSink(
+            monitorLog,
+            { accountId, bank: account.bank, runId: recorder.runId },
+            recorder,
+          ),
+          requestOtp,
+        },
+        onTransactions: async (batch) => { await ingest.execute(accountId, script.id, batch) },
+        shouldStop: () => false,
+        // Bank-local day key whose change clears runMonitor's dedup set so it stays bounded over multi-day sessions
+        getBankDay: () =>
+          new Intl.DateTimeFormat('en-GB', {
+            timeZone: 'America/Guayaquil', year: 'numeric', month: '2-digit', day: '2-digit',
+          }).format(new Date()),
+      })
+
+      // Clear the pending assistance request on session end so the dashboard alert never dangles
+      void handle.done.catch(() => {}).finally(() => {
+        void otpCoordinator.cancel(accountId, account.userId).catch(() => {})
+      })
+
+      // Stamp lifecycle metadata so SessionManager can emit the dashboard light events and
+      // route an assisted-persistent login loss to needs_attention instead of a silent relaunch.
+      // Object.assign (not a fresh literal) preserves handle.stop's binding to the runner.
+      const assistedPersistent = account.loginMode === 'assisted' && account.sessionType === 'persistent'
+      return Object.assign(handle, { userId: account.userId, assistedPersistent })
     })
-
-    // Clear the pending assistance request on session end so the dashboard alert never dangles
-    void handle.done.catch(() => {}).finally(() => {
-      void otpCoordinator.cancel(accountId, account.userId).catch(() => {})
-    })
-
-    // Stamp lifecycle metadata so SessionManager can emit the dashboard light events and
-    // route an assisted-persistent login loss to needs_attention instead of a silent relaunch.
-    // Object.assign (not a fresh literal) preserves handle.stop's binding to the runner.
-    const assistedPersistent = account.loginMode === 'assisted' && account.sessionType === 'persistent'
-    return Object.assign(handle, { userId: account.userId, assistedPersistent })
   }
 
   const sessionManager = new SessionManager(

--- a/src/contexts/banking/application/RecordedSessionLauncher.test.ts
+++ b/src/contexts/banking/application/RecordedSessionLauncher.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi } from 'vitest'
+import { RecordedSessionLauncher, type RecordedSessionLauncherDeps } from './RecordedSessionLauncher.js'
+
+function deferred<T>() {
+  let resolve!: (v: T) => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej })
+  return { promise, resolve, reject }
+}
+
+const runRepo = () => ({
+  create: vi.fn().mockResolvedValue(undefined),
+  markSuccess: vi.fn().mockResolvedValue(undefined),
+  markFailed: vi.fn().mockResolvedValue(undefined),
+  markOrphaned: vi.fn().mockResolvedValue(0),
+  pruneOlderThan: vi.fn().mockResolvedValue(0),
+})
+
+const stepRepo = () => ({
+  start: vi.fn().mockResolvedValue(undefined),
+  finish: vi.fn().mockResolvedValue(undefined),
+  record: vi.fn().mockResolvedValue(undefined),
+})
+
+const fakeLogger = () => {
+  const l: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: () => l }
+  return l
+}
+
+function build(overrides: Partial<RecordedSessionLauncherDeps> = {}) {
+  const runs = runRepo()
+  const steps = stepRepo()
+  const logger = fakeLogger()
+  const launcher = new RecordedSessionLauncher({
+    runRepo: runs, stepRepo: steps, logger, newRunId: () => 'run-1', ...overrides,
+  })
+  return { launcher, runs, steps, logger }
+}
+
+// Lets the assertions run after the `done` handlers have settled.
+const flush = () => new Promise((r) => setTimeout(r, 0))
+
+const target = { accountId: 'acc-1', scriptId: 'script-1' }
+
+describe('RecordedSessionLauncher', () => {
+  it('opens exactly one run row for the session and hands the recorder to the launch', async () => {
+    const { launcher, runs } = build()
+    const done = deferred<string>()
+    let seenRunId: string | undefined
+
+    await launcher.launch(target, async (recorder) => {
+      seenRunId = recorder.runId
+      return { done: done.promise }
+    })
+
+    expect(runs.create).toHaveBeenCalledTimes(1)
+    expect(runs.create).toHaveBeenCalledWith('run-1', 'acc-1', 'script-1')
+    expect(seenRunId).toBe('run-1')
+  })
+
+  it('returns the caller’s own handle, so session lifecycle metadata survives', async () => {
+    // SessionManager reads userId and assistedPersistent off the handle to drive the
+    // dashboard light and route an assisted login loss to needs_attention.
+    const { launcher } = build()
+    const stop = vi.fn()
+    const handle = await launcher.launch(target, async () => ({
+      done: new Promise<string>(() => {}), stop, userId: 'user-9', assistedPersistent: true,
+    }))
+
+    expect(handle.userId).toBe('user-9')
+    expect(handle.assistedPersistent).toBe(true)
+    handle.stop()
+    expect(stop).toHaveBeenCalled()
+  })
+
+  describe('closing the row from the way the session ended', () => {
+    it.each([
+      ['stop_requested'],
+      ['max_runtime'],
+    ])('records %s as a success, so restarts and shutdowns stay out of the failure list', async (reason) => {
+      const { launcher, runs } = build()
+      const done = deferred<string>()
+      await launcher.launch(target, async () => ({ done: done.promise }))
+
+      done.resolve(reason)
+      await flush()
+
+      expect(runs.markSuccess).toHaveBeenCalledWith('run-1', null, reason)
+      expect(runs.markFailed).not.toHaveBeenCalled()
+    })
+
+    it.each([
+      ['auth_timeout'],
+      ['logged_out'],
+      ['watchdog_timeout'],
+    ])('records the %s stop reason as a failure of the matching category', async (reason) => {
+      const { launcher, runs } = build()
+      const done = deferred<string>()
+      await launcher.launch(target, async () => ({ done: done.promise }))
+
+      done.resolve(reason)
+      await flush()
+
+      expect(runs.markFailed).toHaveBeenCalledWith('run-1', reason, reason, reason)
+      expect(runs.markSuccess).not.toHaveBeenCalled()
+    })
+
+    it.each([
+      ['browser_closed'],
+      ['session_killed'],
+    ])('records a rejected done carrying %s as that failure category', async (reason) => {
+      // These arrive as thrown errors rather than returned stop reasons: the runner races
+      // an explicit close/kill against the monitor.
+      const { launcher, runs } = build()
+      const done = deferred<string>()
+      await launcher.launch(target, async () => ({ done: done.promise }))
+
+      done.reject(new Error(reason))
+      await flush()
+
+      expect(runs.markFailed).toHaveBeenCalledWith('run-1', reason, reason, reason)
+    })
+
+    it('leaves an unrecognised crash to be categorised from the error, with no stop reason', async () => {
+      // stop_reason stays a closed vocabulary; an arbitrary message belongs in error_message.
+      const { launcher, runs } = build()
+      const done = deferred<string>()
+      await launcher.launch(target, async () => ({ done: done.promise }))
+
+      done.reject(new Error('login_failed: bank rejected the credentials'))
+      await flush()
+
+      expect(runs.markFailed).toHaveBeenCalledWith(
+        'run-1', 'login_failed: bank rejected the credentials', 'login_failed', undefined,
+      )
+    })
+
+    it('records a stage row for the failing stage a crash names', async () => {
+      const { launcher, steps } = build()
+      const done = deferred<string>()
+      await launcher.launch(target, async () => ({ done: done.promise }))
+
+      done.reject(new Error('movements_fetch_failed: table never rendered'))
+      await flush()
+
+      expect(steps.record).toHaveBeenCalledWith(
+        'run-1', 0, 'movements_fetch', 'failed',
+        expect.objectContaining({ failureType: 'movements_fetch_failed' }),
+      )
+    })
+
+    it('closes the row once, even though SessionManager also observes the same promise', async () => {
+      const { launcher, runs } = build()
+      const done = deferred<string>()
+      const handle = await launcher.launch(target, async () => ({ done: done.promise }))
+      handle.done.catch(() => {}) // stand in for SessionManager's own handlers
+
+      done.resolve('stop_requested')
+      await flush()
+      await flush()
+
+      expect(runs.markSuccess).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('a launch that never gets a session', () => {
+    it('records the harness cause when a pre-script stage failed, and rethrows', async () => {
+      const { launcher, runs } = build()
+      const boom = new Error('bad decryption key')
+
+      await expect(
+        launcher.launch(target, async (recorder) => {
+          await recorder.stage('credentials', async () => { throw boom })
+          return { done: Promise.resolve('never') }
+        }),
+      ).rejects.toThrow(boom)
+
+      // Rethrown so SessionManager still marks the session stopped and the job fails.
+      expect(runs.markFailed).toHaveBeenCalledWith('run-1', 'bad decryption key', 'credentials_failed', undefined)
+    })
+
+    it.each([
+      ['launch', 'launch_failed'],
+      ['load_script', 'script_load_failed'],
+    ] as const)('records a failing %s stage as %s', async (stage, expected) => {
+      const { launcher, runs } = build()
+
+      await expect(
+        launcher.launch(target, async (recorder) => {
+          await recorder.stage(stage, async () => { throw new Error('chromium would not start') })
+          return { done: Promise.resolve('never') }
+        }),
+      ).rejects.toThrow()
+
+      expect(runs.markFailed).toHaveBeenCalledWith('run-1', 'chromium would not start', expected, undefined)
+    })
+  })
+
+  describe('diagnostics never change monitoring behaviour', () => {
+    it('launches the session even when the run row cannot be opened', async () => {
+      const runs = runRepo()
+      runs.create.mockRejectedValue(new Error('db down'))
+      const { launcher, logger } = build({ runRepo: runs })
+
+      const handle = await launcher.launch(target, async () => ({ done: new Promise<string>(() => {}) }))
+
+      expect(handle).toBeDefined()
+      expect(logger.warn).toHaveBeenCalledWith(
+        'could not open a scrape run row',
+        expect.objectContaining({ accountId: 'acc-1', error: 'db down' }),
+      )
+    })
+
+    it('does not leave an unhandled rejection when closing the row fails', async () => {
+      const runs = runRepo()
+      runs.markSuccess.mockRejectedValue(new Error('db down'))
+      const { launcher, logger } = build({ runRepo: runs })
+      const done = deferred<string>()
+      await launcher.launch(target, async () => ({ done: done.promise }))
+
+      done.resolve('stop_requested')
+      await flush()
+
+      // Swallowed by the recorder's own best-effort write, so it is logged there.
+      expect(logger.warn).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/contexts/banking/application/RecordedSessionLauncher.ts
+++ b/src/contexts/banking/application/RecordedSessionLauncher.ts
@@ -1,0 +1,110 @@
+import crypto from 'crypto'
+import type { ILogger } from '../../../shared/logger/ILogger.js'
+import { IScrapeRunRepository } from '../domain/IScrapeRunRepository.js'
+import { IScrapeStepRepository } from '../domain/IScrapeStepRepository.js'
+import { outcomeFromStopReason } from '../domain/monitorStopOutcome.js'
+import { ScrapeRunRecorder } from './ScrapeRunRecorder.js'
+
+export interface RecordedSessionLauncherDeps {
+  runRepo: IScrapeRunRepository
+  stepRepo: IScrapeStepRepository
+  logger?: ILogger
+  /** Injectable so a test can assert on a known run id. */
+  newRunId?: () => string
+}
+
+/**
+ * All the launcher needs of a session handle: how to learn that it ended. Declared
+ * structurally rather than importing SessionManager's SessionHandle, which would point
+ * an application-layer module at infrastructure — and the generic below hands the
+ * caller's own handle type straight back, so nothing is lost by narrowing here.
+ */
+export interface EndingSession {
+  /** Resolves with a MonitorStopReason; rejects with a thrown error. */
+  done: Promise<string>
+}
+
+/**
+ * Gives a persistent monitor session a run record.
+ *
+ * Persistent accounts had no execution history at all: the scrape use case returns
+ * early for them before creating a row, and both live bank scripts run this way — so
+ * the accounts that matter most were the ones with no record.
+ *
+ * One row per **session lifetime**, not per poll cycle. The monitor authenticates once
+ * and then polls indefinitely, so the session *is* the execution; a row per poll would
+ * bury the table in near-identical rows.
+ *
+ * Opened here, on the launch path, and nowhere upstream of it: `ensureRunning` no-ops
+ * on a live session and the persistent-session health-check calls it roughly every 75
+ * seconds, so a row created there would orphan a row a minute.
+ */
+export class RecordedSessionLauncher {
+  constructor(private readonly deps: RecordedSessionLauncherDeps) {}
+
+  async launch<H extends EndingSession>(
+    input: { accountId: string; scriptId: string },
+    start: (recorder: ScrapeRunRecorder) => Promise<H>,
+  ): Promise<H> {
+    const runId = (this.deps.newRunId ?? (() => crypto.randomUUID()))()
+    const recorder = new ScrapeRunRecorder({
+      runId,
+      runRepo: this.deps.runRepo,
+      stepRepo: this.deps.stepRepo,
+      logger: this.deps.logger,
+    })
+
+    // Best-effort like every other write here: failing to record a run must never be
+    // the reason an account stops being monitored.
+    try {
+      await this.deps.runRepo.create(runId, input.accountId, input.scriptId)
+    } catch (err) {
+      this.warn('could not open a scrape run row', input.accountId, err)
+    }
+
+    let handle: H
+    try {
+      handle = await start(recorder)
+    } catch (err) {
+      // Everything before the monitor loop: credential resolution, browser launch,
+      // script evaluation. The recorder already knows which stage threw, so this
+      // records launch_failed / script_load_failed / credentials_failed rather than
+      // a bare "unknown".
+      await recorder.fail(err)
+      throw err
+    }
+
+    // `done` resolves with a MonitorStopReason and rejects with a thrown error. Both
+    // close the row. SessionManager attaches its own handlers to the same promise for
+    // bank_sessions; these two are independent on purpose, so a diagnostics write
+    // cannot interfere with per-account attention state.
+    void handle.done
+      .then((reason) => this.close(recorder, reason))
+      .catch((err) => this.close(recorder, message(err), err))
+      .catch((err) => this.warn('could not close the scrape run row', input.accountId, err))
+
+    return handle
+  }
+
+  private async close(recorder: ScrapeRunRecorder, reason: string, error?: unknown): Promise<void> {
+    const outcome = outcomeFromStopReason(reason)
+    if (outcome.status === 'success') {
+      // No transaction count: a persistent session ingests continuously over a lifetime
+      // that can span days, so any single number here would be a lie. NULL reads as
+      // "not counted", which is the truth; the transactions themselves are in
+      // bank_transactions, tied to the account.
+      await recorder.succeed(null, outcome.stopReason)
+      return
+    }
+    await recorder.fail(error ?? new Error(reason), {
+      failureType: outcome.failureType,
+      stopReason: outcome.stopReason,
+    })
+  }
+
+  private warn(what: string, accountId: string, err: unknown): void {
+    this.deps.logger?.warn(what, { accountId, error: message(err) })
+  }
+}
+
+const message = (err: unknown): string => (err instanceof Error ? err.message : String(err))

--- a/src/contexts/banking/application/ScrapeRunRecorder.ts
+++ b/src/contexts/banking/application/ScrapeRunRecorder.ts
@@ -1,5 +1,6 @@
 import type { ILogger } from '../../../shared/logger/ILogger.js'
 import type { IFailureTrail, TrailEntry } from '../../../shared/domain/failureTrail.js'
+import type { OpenStage } from '../../../shared/domain/scrapeStage.js'
 import { IScrapeRunRepository } from '../domain/IScrapeRunRepository.js'
 import { IScrapeStepRepository, StepOutcome } from '../domain/IScrapeStepRepository.js'
 import { categorizeFailure } from '../domain/scrapeFailure.js'
@@ -103,28 +104,53 @@ export class ScrapeRunRecorder {
    * `fn`, the row stays `started` and names the stage it died in.
    */
   async stage<T>(step: ScrapeStage, fn: () => Promise<T>): Promise<T> {
-    const index = this.stepIndex++
-    const startedAt = this.clock()
-    await this.bestEffort(`start:${step}`, () => this.deps.stepRepo.start(this.deps.runId, index, step))
+    const open = this.open(step)
+    await open.opened
 
     try {
       const result = await fn()
-      await this.bestEffort(`finish:${step}`, () =>
-        this.deps.stepRepo.finish(this.deps.runId, index, 'success', { durationMs: this.clock() - startedAt })
-      )
+      await open.finish('success')
       return result
     } catch (err) {
-      // Remember the harness stage so fail() can name the cause when the error itself
-      // carries no category — a browser that would not launch is not an "unknown" failure.
-      this.failedStage ??= step
-      await this.bestEffort(`finish:${step}`, () =>
-        this.deps.stepRepo.finish(this.deps.runId, index, 'failed', {
-          ...describe(err),
-          url: this.lastUrl,
-          durationMs: this.clock() - startedAt,
-        })
-      )
+      await open.finish('failed', describe(err))
       throw err
+    }
+  }
+
+  /**
+   * Opens a stage for a caller that will close it itself — the monitor's authentication
+   * wait, whose failure is a timed-out loop rather than a thrown error.
+   *
+   * Returns synchronously: the caller is about to enter a wait, not await a write. The
+   * insert is awaited inside `finish` instead, since the in-place update is keyed by
+   * (runId, stepIndex) and would otherwise update nothing.
+   */
+  beginStage(step: ScrapeStage): OpenStage {
+    return this.open(step)
+  }
+
+  private open(step: ScrapeStage): OpenStage & { opened: Promise<void> } {
+    const index = this.stepIndex++
+    const startedAt = this.clock()
+    const opened = this.bestEffort(`start:${step}`, () =>
+      this.deps.stepRepo.start(this.deps.runId, index, step)
+    )
+
+    return {
+      opened,
+      finish: async (status, outcome: StepOutcome = {}) => {
+        await opened
+        // Remember the harness stage so fail() can name the cause when the error itself
+        // carries no category — a browser that would not launch is not an "unknown" failure.
+        if (status === 'failed') this.failedStage ??= step
+        await this.bestEffort(`finish:${step}`, () =>
+          this.deps.stepRepo.finish(this.deps.runId, index, status, {
+            ...outcome,
+            url: outcome.url ?? this.lastUrl,
+            durationMs: this.clock() - startedAt,
+          })
+        )
+      },
     }
   }
 
@@ -132,11 +158,18 @@ export class ScrapeRunRecorder {
   async note(step: ScrapeStage, status: 'success' | 'failed', outcome: StepOutcome = {}): Promise<void> {
     const index = this.stepIndex++
     await this.bestEffort(`record:${step}`, () =>
-      this.deps.stepRepo.record(this.deps.runId, index, step, status, outcome)
+      this.deps.stepRepo.record(this.deps.runId, index, step, status, {
+        ...outcome,
+        url: outcome.url ?? this.lastUrl,
+      })
     )
   }
 
-  async succeed(transactionsFound: number, stopReason?: string): Promise<void> {
+  /**
+   * `transactionsFound` is null for a persistent session: it ingests continuously over a
+   * lifetime that can span days, so no single number describes the run.
+   */
+  async succeed(transactionsFound: number | null, stopReason?: string): Promise<void> {
     if (this.closed) return
     this.closed = true
     // A run that worked explains nothing, so the trail is dropped rather than written.

--- a/src/contexts/banking/domain/IScrapeRunRepository.ts
+++ b/src/contexts/banking/domain/IScrapeRunRepository.ts
@@ -2,7 +2,9 @@ export interface IScrapeRunRepository {
   create(runId: string, accountId: string, scriptId: string): Promise<void>
   // stopReason carries the nuance (which MonitorStopReason, which harness cause) that
   // the three-valued status deliberately does not, mirroring bank_sessions.stop_reason.
-  markSuccess(runId: string, transactionCount: number, stopReason?: string): Promise<void>
+  // A null count means "not counted": a persistent session ingests over a lifetime that
+  // can span days, so no single number describes the run.
+  markSuccess(runId: string, transactionCount: number | null, stopReason?: string): Promise<void>
   markFailed(runId: string, errorMessage: string, failureType?: string, stopReason?: string): Promise<void>
   /**
    * Closes every run still marked running. Correct only at boot: live sessions are

--- a/src/contexts/banking/domain/monitorStopOutcome.ts
+++ b/src/contexts/banking/domain/monitorStopOutcome.ts
@@ -1,0 +1,43 @@
+/**
+ * How a persistent monitor's exit becomes a run outcome.
+ *
+ * The run status stays three-valued (running / success / failed) so it remains a clean
+ * answer to "did this work". The nuance goes in `stop_reason`, mirroring how
+ * `bank_sessions.stop_reason` already works — and `bank_sessions` keeps sole ownership
+ * of per-account attention state, so the two records can never disagree about whether
+ * an account needs a human.
+ */
+export interface MonitorOutcome {
+  status: 'success' | 'failed'
+  /** Constrained to the vocabulary below, so the column stays queryable. */
+  stopReason?: string
+  /** Left undefined when the error itself should name the category. */
+  failureType?: string
+}
+
+// A restart or a shutdown is not a broken script. Recording these as failures would
+// mean every deploy showed up in the failure list.
+const CLEAN_STOPS = new Set(['stop_requested', 'max_runtime'])
+
+// Stop reasons that are genuine failures. Each doubles as its own failure category —
+// deliberately, so a stage, a stop reason and a failure category describe one event in
+// one vocabulary rather than three.
+const FAILURE_STOPS = new Set([
+  'auth_timeout',
+  'logged_out',
+  'watchdog_timeout',
+  'browser_closed',
+  'session_killed',
+])
+
+/**
+ * `reason` is either a MonitorStopReason (the monitor returned) or a thrown error's
+ * message (the session crashed). An unrecognised value is a crash: it is recorded as a
+ * failure with no stop reason, leaving the category to be derived from the error, so an
+ * arbitrary error message never lands in a column meant for a closed vocabulary.
+ */
+export function outcomeFromStopReason(reason: string): MonitorOutcome {
+  if (CLEAN_STOPS.has(reason)) return { status: 'success', stopReason: reason }
+  if (FAILURE_STOPS.has(reason)) return { status: 'failed', stopReason: reason, failureType: reason }
+  return { status: 'failed' }
+}

--- a/src/contexts/banking/infrastructure/ScrapeRunRepository.ts
+++ b/src/contexts/banking/infrastructure/ScrapeRunRepository.ts
@@ -21,7 +21,7 @@ export class ScrapeRunRepository implements IScrapeRunRepository {
   }
 
   // duration_ms existed since 009 and was null on every row ever written.
-  async markSuccess(runId: string, transactionCount: number, stopReason?: string): Promise<void> {
+  async markSuccess(runId: string, transactionCount: number | null, stopReason?: string): Promise<void> {
     await this.executor.query(
       `UPDATE bank_scrape_runs
           SET status='success', transactions_found=$1, stop_reason=$2, finished_at=now(),

--- a/src/contexts/banking/infrastructure/SessionManager.test.ts
+++ b/src/contexts/banking/infrastructure/SessionManager.test.ts
@@ -31,6 +31,31 @@ describe('SessionManager', () => {
     expect(mgr.isRunning('acc-1')).toBe(true)
   })
 
+  it('opens no further run rows while a session is alive, however often the health-check fires', async () => {
+    // The run row is opened inside startFn, which is reached only on a real launch. The
+    // persistent-session health-check calls ensureRunning roughly every 75 seconds, so a
+    // row created anywhere upstream of this guard would orphan a row a minute.
+    const repo = sessionRepo()
+    const d = deferred<string>()
+    let rowsOpened = 0
+    const startFn = vi.fn().mockImplementation(async () => {
+      rowsOpened += 1
+      return { stop: vi.fn(), done: d.promise } as SessionHandle
+    })
+    const mgr = new SessionManager(startFn, repo)
+
+    await mgr.ensureRunning('acc-1')
+    for (let tick = 0; tick < 10; tick++) await mgr.ensureRunning('acc-1')
+
+    expect(rowsOpened).toBe(1)
+
+    // ...and once the session really ends, the next launch opens a new one.
+    d.resolve('logged_out')
+    await new Promise((r) => setTimeout(r, 0))
+    await mgr.ensureRunning('acc-1')
+    expect(rowsOpened).toBe(2)
+  })
+
   it('marks stopped and frees the slot when the session ends', async () => {
     const repo = sessionRepo()
     const d = deferred<string>()

--- a/src/contexts/script-engine/infrastructure/PersistentPlaywrightRunner.test.ts
+++ b/src/contexts/script-engine/infrastructure/PersistentPlaywrightRunner.test.ts
@@ -248,6 +248,96 @@ describe('PersistentPlaywrightRunner', () => {
     await expect(handle.done).rejects.toThrow('browser_closed')
   })
 
+  describe('harness stage recording', () => {
+    // Records which stages the runner reports, so a failure before the script body ever
+    // runs is attributable rather than landing as "unknown".
+    function fakeRecorder() {
+      const stages: string[] = []
+      const failed: string[] = []
+      return {
+        stages,
+        failed,
+        recorder: {
+          stage: async <T,>(step: string, fn: () => Promise<T>) => {
+            stages.push(step)
+            try {
+              return await fn()
+            } catch (err) {
+              failed.push(step)
+              throw err
+            }
+          },
+          beginStage: () => ({ finish: async () => {} }),
+          note: async () => {},
+          observeUrl: vi.fn(),
+          event: vi.fn(),
+        },
+      }
+    }
+
+    it('reports the browser launch and the script load, and forwards the recorder to the monitor', async () => {
+      buildContext()
+      runMonitorMock.mockResolvedValue('stop_requested')
+      const { recorder, stages } = fakeRecorder()
+
+      await (await new PersistentPlaywrightRunner().start({ ...baseInput(), recorder: recorder as any })).done
+
+      expect(stages).toEqual(['launch', 'load_script'])
+      expect(runMonitorMock).toHaveBeenCalledWith(expect.objectContaining({ recorder }))
+    })
+
+    it('attributes a browser that will not start to the launch stage', async () => {
+      launchPersistentContextMock.mockRejectedValue(new Error('chromium refused to start'))
+      const { recorder, failed } = fakeRecorder()
+
+      await expect(
+        new PersistentPlaywrightRunner().start({ ...baseInput(), recorder: recorder as any }),
+      ).rejects.toThrow('chromium refused to start')
+      expect(failed).toEqual(['launch'])
+    })
+
+    it('attributes a script body that throws to the script-load stage, and still closes the context', async () => {
+      const { close } = buildContext()
+      const { recorder, failed } = fakeRecorder()
+
+      await expect(
+        new PersistentPlaywrightRunner().start({
+          ...baseInput(), scriptCode: 'throw new Error("script boom")', recorder: recorder as any,
+        }),
+      ).rejects.toThrow('script boom')
+      expect(failed).toEqual(['load_script'])
+      expect(close).toHaveBeenCalled()
+    })
+
+    it('attributes a script returning the wrong shape to the script-load stage', async () => {
+      buildContext()
+      const { recorder, failed } = fakeRecorder()
+
+      await expect(
+        new PersistentPlaywrightRunner().start({
+          ...baseInput(), scriptCode: 'return null', recorder: recorder as any,
+        }),
+      ).rejects.toThrow(/hooks object/i)
+      expect(failed).toEqual(['load_script'])
+    })
+
+    it('closes the browser context when page setup fails inside the launch stage', async () => {
+      // The outer cleanup does not cover this scope, so the launch stage owns it.
+      const close = vi.fn().mockResolvedValue(undefined)
+      const page = { addInitScript: vi.fn().mockRejectedValue(new Error('page setup failed')) }
+      launchPersistentContextMock.mockResolvedValue({
+        pages: () => [page], newPage: vi.fn(), close, on: vi.fn(), browser: () => ({ on: vi.fn() }),
+      })
+      const { recorder, failed } = fakeRecorder()
+
+      await expect(
+        new PersistentPlaywrightRunner().start({ ...baseInput(), recorder: recorder as any }),
+      ).rejects.toThrow('page setup failed')
+      expect(failed).toEqual(['launch'])
+      expect(close).toHaveBeenCalled()
+    })
+  })
+
   it('exercises the addInitScript navigator.webdriver guard', async () => {
     const { page } = buildContext()
     runMonitorMock.mockResolvedValue('stop_requested')

--- a/src/contexts/script-engine/infrastructure/PersistentPlaywrightRunner.ts
+++ b/src/contexts/script-engine/infrastructure/PersistentPlaywrightRunner.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import { ScriptHooks, MonitorScriptContext, MonitorTransaction, runMonitor, MonitorStopReason } from './runMonitor.js'
 import { CHROMIUM_ARGS, USER_AGENT, VIEWPORT, isHeadless, applyAntiWebdriver } from './playwrightLaunch.js'
+import type { IStageRecorder, ScrapeStage } from '../../../shared/domain/scrapeStage.js'
 
 export interface PersistentRunnerInput {
   scriptCode: string
@@ -10,6 +11,9 @@ export interface PersistentRunnerInput {
   onTransactions(batch: MonitorTransaction[]): Promise<void>
   shouldStop(): boolean
   getBankDay?(): string
+  // Records the harness stages around the script body — the failures that happen before a
+  // script ever runs, which no amount of script-side logging can report.
+  recorder?: IStageRecorder
 }
 
 export interface PersistentSessionHandle {
@@ -23,6 +27,14 @@ export interface PersistentSessionHandle {
 
 const PROFILES_DIR = process.env.PLAYWRIGHT_PROFILES_DIR ?? path.resolve(process.cwd(), 'playwright-profiles')
 
+// Records the stage if a recorder was supplied, otherwise just runs it — mirroring
+// PlaywrightRunner, so the happy path is identical whether diagnostics are wired in.
+const withStage = <T>(
+  recorder: IStageRecorder | undefined,
+  step: ScrapeStage,
+  fn: () => Promise<T>,
+): Promise<T> => (recorder ? recorder.stage(step, fn) : fn())
+
 /**
  * Loads a hook-based script, launches a persistent-profile headful browser, and
  * runs the monitor loop. Returns a handle whose `done` promise resolves with the
@@ -30,31 +42,46 @@ const PROFILES_DIR = process.env.PLAYWRIGHT_PROFILES_DIR ?? path.resolve(process
  */
 export class PersistentPlaywrightRunner {
   async start(input: PersistentRunnerInput): Promise<PersistentSessionHandle> {
-    const { chromium } = await import('playwright')
-
+    const rec = input.recorder
     const userDataDir = path.join(PROFILES_DIR, input.context.accountId)
-    const browserContext = await chromium.launchPersistentContext(userDataDir, {
-      headless: isHeadless(),
-      viewport: VIEWPORT,
-      locale: 'es-EC',
-      userAgent: USER_AGENT,
-      args: CHROMIUM_ARGS,
+
+    // Browser launch and page setup are one stage: both are "getting a usable page", and a
+    // failure in either is a launch failure rather than a broken script. The context is
+    // closed here on failure because the outer cleanup below does not cover this scope.
+    const { browserContext, page } = await withStage(rec, 'launch', async () => {
+      const { chromium } = await import('playwright')
+      const ctx = await chromium.launchPersistentContext(userDataDir, {
+        headless: isHeadless(),
+        viewport: VIEWPORT,
+        locale: 'es-EC',
+        userAgent: USER_AGENT,
+        args: CHROMIUM_ARGS,
+      })
+      try {
+        const firstPage = ctx.pages()[0] ?? (await ctx.newPage())
+        await applyAntiWebdriver(firstPage)
+        return { browserContext: ctx, page: firstPage }
+      } catch (err) {
+        await ctx.close().catch(() => {})
+        throw err
+      }
     })
 
     // Once the monitor starts its .finally closes the context. Until then any
-    // failure (page setup, the script body throwing, or missing hooks) must
-    // close it here, or the browser process + on-disk profile leak.
+    // failure (the script body throwing, or missing hooks) must close it here,
+    // or the browser process + on-disk profile leak.
     try {
-      const page = browserContext.pages()[0] ?? (await browserContext.newPage())
-      await applyAntiWebdriver(page)
-
-      // Execute the script body; a hook-based script returns the hooks object.
-      const fn = new Function('page', 'context', `return (async function(page, context){\n${input.scriptCode}\n})(page, context)`)
-      const result = await fn(page, input.context)
-      if (!result || typeof result.poll !== 'function') {
-        throw new Error('persistent script did not return a hooks object with a poll() function')
-      }
-      const hooks = result as ScriptHooks
+      // Evaluating the script body is its own stage: a syntax error or a script that
+      // returns the wrong shape is a broken script, not a broken bank, and the two should
+      // not land under one category.
+      const hooks = await withStage(rec, 'load_script', async () => {
+        const fn = new Function('page', 'context', `return (async function(page, context){\n${input.scriptCode}\n})(page, context)`)
+        const result = await fn(page, input.context)
+        if (!result || typeof result.poll !== 'function') {
+          throw new Error('persistent script did not return a hooks object with a poll() function')
+        }
+        return result as ScriptHooks
+      })
 
       let stopped = false
       let markAuthed!: (ok: boolean) => void
@@ -74,6 +101,7 @@ export class PersistentPlaywrightRunner {
         pollIntervalMs: input.pollIntervalMs,
         authTimeoutMs: input.loginMode === 'assisted' ? 300_000 : 30_000,
         onAuthenticated: () => markAuthed(true),
+        recorder: rec,
       })
       // The monitor only notices a closed browser lazily (next poll, up to a minute later) and some
       // scripts never report it at all. Race an explicit close/disconnect so the session ends at once,

--- a/src/contexts/script-engine/infrastructure/runMonitor.test.ts
+++ b/src/contexts/script-engine/infrastructure/runMonitor.test.ts
@@ -342,6 +342,241 @@ describe('runMonitor', () => {
   })
 })
 
+// The recorder is a collaborator boundary — a port the harness calls — so asserting
+// which stages the monitor reports through it is asserting a contract, not an
+// implementation detail. A fake records the calls in order.
+function fakeRecorder() {
+  const calls: string[] = []
+  const notes: Array<{ step: string; status: string; outcome?: Record<string, unknown> }> = []
+  const open: Array<{ step: string; status?: string; outcome?: Record<string, unknown> }> = []
+  const recorder = {
+    stage: async <T,>(step: string, fn: () => Promise<T>) => {
+      calls.push(`stage:${step}`)
+      return fn()
+    },
+    beginStage: (step: string) => {
+      calls.push(`begin:${step}`)
+      const entry: { step: string; status?: string; outcome?: Record<string, unknown> } = { step }
+      open.push(entry)
+      return {
+        finish: async (status: string, outcome?: Record<string, unknown>) => {
+          calls.push(`finish:${step}:${status}`)
+          entry.status = status
+          entry.outcome = outcome
+        },
+      }
+    },
+    note: async (step: string, status: string, outcome?: Record<string, unknown>) => {
+      calls.push(`note:${step}:${status}`)
+      notes.push({ step, status, outcome })
+    },
+    observeUrl: vi.fn(),
+    event: vi.fn(),
+  }
+  return { recorder, calls, notes, open }
+}
+
+describe('runMonitor stage recording', () => {
+  it('reports login, then the auth wait, then the first poll that worked', async () => {
+    const { recorder, calls } = fakeRecorder()
+    const h = hooks({ poll: vi.fn().mockResolvedValue([]) })
+    let n = 0
+    const reason = await runMonitor({
+      hooks: h, page: {}, context: baseContext, sleep: noSleep, recorder: recorder as any,
+      onTransactions: async () => {},
+      shouldStop: () => { n += 1; return n > 2 },
+    })
+
+    expect(reason).toBe('stop_requested')
+    expect(calls).toEqual([
+      'stage:login', 'begin:auth_wait', 'finish:auth_wait:success', 'note:poll:success',
+    ])
+  })
+
+  it('reports the auth wait on entry and exit only, however many times it polls', async () => {
+    // An assisted login polls up to 200 times; a checkpoint per iteration would flood
+    // the trail with nothing.
+    const { recorder, calls } = fakeRecorder()
+    let checks = 0
+    const h = hooks({
+      isAuthenticated: vi.fn().mockImplementation(async () => { checks += 1; return checks > 5 }),
+    })
+    let n = 0
+    await runMonitor({
+      hooks: h, page: {}, context: baseContext, sleep: noSleep, recorder: recorder as any,
+      onTransactions: async () => {},
+      shouldStop: () => { n += 1; return n > 1 },
+    })
+
+    expect(checks).toBeGreaterThan(5)
+    expect(calls.filter((c) => c.includes('auth_wait'))).toEqual([
+      'begin:auth_wait', 'finish:auth_wait:success',
+    ])
+  })
+
+  it('closes the auth wait as failed when authentication never arrives', async () => {
+    const { recorder, open } = fakeRecorder()
+    const h = hooks({ isAuthenticated: vi.fn().mockResolvedValue(false) })
+    const reason = await runMonitor({
+      hooks: h, page: {}, context: baseContext, sleep: noSleep, authTimeoutMs: 5,
+      recorder: recorder as any, onTransactions: async () => {},
+    })
+
+    expect(reason).toBe('auth_timeout')
+    expect(open).toEqual([{
+      step: 'auth_wait',
+      status: 'failed',
+      outcome: { failureType: 'auth_timeout', errorMessage: 'not authenticated within 5ms' },
+    }])
+  })
+
+  it('closes the auth wait rather than leaving it open when the auth check throws fatally', async () => {
+    // Left open, the row would read as a hang in the wait rather than an abort.
+    const { recorder, open } = fakeRecorder()
+    const h = hooks({ isAuthenticated: vi.fn().mockRejectedValue(new Error('fatal auth')) })
+
+    await expect(runMonitor({
+      hooks: h, page: {}, context: baseContext, sleep: noSleep,
+      recorder: recorder as any, onTransactions: async () => {},
+    })).rejects.toThrow('fatal auth')
+
+    expect(open[0]).toMatchObject({ step: 'auth_wait', status: 'failed' })
+  })
+
+  it('reports a failing login as a failed stage and does not reach the wait', async () => {
+    const { recorder, calls } = fakeRecorder()
+    const h = hooks({ login: vi.fn().mockRejectedValue(new Error('login_failed: bad password')) })
+
+    await expect(runMonitor({
+      hooks: h, page: {}, context: baseContext, sleep: noSleep,
+      recorder: recorder as any, onTransactions: async () => {},
+    })).rejects.toThrow('login_failed')
+
+    expect(calls).toEqual(['stage:login'])
+  })
+
+  it('writes no step rows for steady-state polls, so a long session does not bury the table', async () => {
+    const { recorder, notes } = fakeRecorder()
+    const h = hooks({ poll: vi.fn().mockResolvedValue([]) })
+    let n = 0
+    await runMonitor({
+      hooks: h, page: {}, context: baseContext, sleep: noSleep, recorder: recorder as any,
+      onTransactions: async () => {},
+      shouldStop: () => { n += 1; return n > 20 },
+    })
+
+    expect(h.poll).toHaveBeenCalledTimes(20)
+    expect(notes).toEqual([{ step: 'poll', status: 'success', outcome: undefined }])
+  })
+
+  it('records a recovered poll failure once, however often it repeats', async () => {
+    // A script failing every poll for hours would otherwise write a row a minute; the
+    // repetition is visible in the trail, which is bounded by design.
+    const { recorder, notes } = fakeRecorder()
+    const h = hooks({ poll: vi.fn().mockRejectedValue(new Error('selector not found')) })
+    let n = 0
+    await runMonitor({
+      hooks: h, page: {}, context: baseContext, sleep: noSleep, recorder: recorder as any,
+      onTransactions: async () => {},
+      shouldStop: () => { n += 1; return n > 10 },
+    })
+
+    expect(h.poll).toHaveBeenCalledTimes(10)
+    expect(notes).toEqual([
+      { step: 'poll', status: 'failed', outcome: { errorMessage: 'selector not found' } },
+    ])
+  })
+
+  it('records a failed poll step when the watchdog cuts off a hung poll', async () => {
+    const { recorder, notes } = fakeRecorder()
+    const h = hooks({ poll: vi.fn().mockReturnValue(new Promise<never>(() => {})) })
+    const reason = await runMonitor({
+      hooks: h, page: {}, context: baseContext, sleep: noSleep, pollIntervalMs: 10,
+      recorder: recorder as any, onTransactions: async () => {},
+    })
+
+    expect(reason).toBe('watchdog_timeout')
+    expect(notes).toEqual([
+      { step: 'poll', status: 'failed', outcome: expect.objectContaining({ failureType: 'watchdog_timeout' }) },
+    ])
+  })
+
+  it('attributes a hung keepAlive to the keep_alive stage, not the poll', async () => {
+    const { recorder, notes } = fakeRecorder()
+    const h = hooks({
+      poll: vi.fn().mockResolvedValue([]),
+      keepAlive: vi.fn().mockReturnValue(new Promise<never>(() => {})),
+    })
+    const reason = await runMonitor({
+      hooks: h, page: {}, context: baseContext, sleep: noSleep, pollIntervalMs: 10,
+      recorder: recorder as any, onTransactions: async () => {},
+    })
+
+    expect(reason).toBe('watchdog_timeout')
+    expect(notes.at(-1)).toMatchObject({
+      step: 'keep_alive', status: 'failed', outcome: { failureType: 'watchdog_timeout' },
+    })
+  })
+
+  it('records a lost session as a failed poll step', async () => {
+    const { recorder, notes } = fakeRecorder()
+    let auth = 0
+    const h = hooks({
+      isAuthenticated: vi.fn().mockImplementation(async () => { auth += 1; return auth <= 1 }),
+    })
+    const reason = await runMonitor({
+      hooks: h, page: {}, context: baseContext, sleep: noSleep,
+      recorder: recorder as any, onTransactions: async () => {},
+    })
+
+    expect(reason).toBe('logged_out')
+    expect(notes).toEqual([
+      { step: 'poll', status: 'failed', outcome: expect.objectContaining({ failureType: 'logged_out' }) },
+    ])
+  })
+
+  it('captures the page url at the moment a stage fails', async () => {
+    const { recorder } = fakeRecorder()
+    const page = { url: () => 'https://bank.example/movements' }
+    const h = hooks({ poll: vi.fn().mockRejectedValue(new Error('boom')) })
+    let n = 0
+    await runMonitor({
+      hooks: h, page, context: baseContext, sleep: noSleep, recorder: recorder as any,
+      onTransactions: async () => {},
+      shouldStop: () => { n += 1; return n > 1 },
+    })
+
+    expect(recorder.observeUrl).toHaveBeenCalledWith('https://bank.example/movements')
+  })
+
+  it('survives a page that cannot report its url', async () => {
+    // `page` is `any` here, and a closed page throws on url().
+    const { recorder, notes } = fakeRecorder()
+    const page = { url: () => { throw new Error('page closed') } }
+    const h = hooks({ poll: vi.fn().mockRejectedValue(new Error('boom')) })
+    let n = 0
+    const reason = await runMonitor({
+      hooks: h, page, context: baseContext, sleep: noSleep, recorder: recorder as any,
+      onTransactions: async () => {},
+      shouldStop: () => { n += 1; return n > 1 },
+    })
+
+    expect(reason).toBe('stop_requested')
+    expect(notes).toHaveLength(1)
+  })
+
+  it('behaves identically with no recorder wired', async () => {
+    const h = hooks({ poll: vi.fn().mockResolvedValue([]) })
+    let n = 0
+    const reason = await runMonitor({
+      hooks: h, page: {}, context: baseContext, sleep: noSleep,
+      onTransactions: async () => {},
+      shouldStop: () => { n += 1; return n > 1 },
+    })
+    expect(reason).toBe('stop_requested')
+  })
+})
+
 // The monitor loop bounds each isAuthenticated / poll / keepAlive call with
 // withTimeout(2 * pollIntervalMs). reconbanker's withTimeout REJECTS with a
 // TimeoutError (no sentinel), which runMonitor catches and converts into a

--- a/src/contexts/script-engine/infrastructure/runMonitor.ts
+++ b/src/contexts/script-engine/infrastructure/runMonitor.ts
@@ -1,5 +1,6 @@
 import { withTimeout } from '../../../shared/util/withTimeout.js'
 import { TimeoutError } from '../../../shared/errors/index.js'
+import type { IStageRecorder } from '../../../shared/domain/scrapeStage.js'
 
 // Local copy of banking's ScrapedTransaction so script-engine never depends on the banking context
 export interface MonitorTransaction {
@@ -59,6 +60,9 @@ export interface RunMonitorOptions {
   // Called once immediately after authentication succeeds (before the monitor loop). Used to
   // signal a session that came back from needs_attention has actually re-authenticated.
   onAuthenticated?(): void
+  // Records this session's stages. Optional: the monitor behaves identically without it,
+  // and supplying it is what makes the checkpoint baseline independent of the script author.
+  recorder?: IStageRecorder
 }
 
 export type MonitorStopReason =
@@ -78,32 +82,73 @@ export async function runMonitor(opts: RunMonitorOptions): Promise<MonitorStopRe
     authTimeoutMs = 300_000,
     sleep = (ms: number) => new Promise((r) => setTimeout(r, ms)),
     onAuthenticated,
+    recorder,
   } = opts
 
   const log = (event: string, data?: Record<string, unknown>) =>
     context.debugLog?.(JSON.stringify({ at: new Date().toISOString(), event, ...data }))
 
+  // Reading the URL can throw on a closed page, and a page is `any` here, so this must
+  // never be the thing that breaks a session it was only trying to describe.
+  const observeUrl = () => {
+    try {
+      if (typeof page?.url === 'function') recorder?.observeUrl(page.url())
+    } catch { /* page already gone */ }
+  }
+  // Records a stage only when a recorder was supplied, keeping the happy path identical.
+  const note = async (step: 'poll' | 'keep_alive', status: 'success' | 'failed', outcome?: {
+    failureType?: string; errorMessage?: string
+  }) => {
+    if (!recorder) return
+    observeUrl()
+    await recorder.note(step, status, outcome)
+  }
+
   // Login then wait for authentication with a long timeout for assisted human 2FA
-  await hooks.login(page, context)
+  if (recorder) await recorder.stage('login', () => hooks.login(page, context))
+  else await hooks.login(page, context)
+
+  // The wait is opened rather than wrapped: it ends by falling out of the loop on
+  // timeout, which stage() would record as a success. Reported on entry and exit only —
+  // an assisted login polls up to 200 times, and a checkpoint per iteration would flood
+  // the trail with nothing.
+  const authWait = recorder?.beginStage('auth_wait')
   const authDeadline = Date.now() + authTimeoutMs
   let authed = false
-  while (Date.now() < authDeadline) {
-    // Bound each check by the remaining auth budget so a hang *inside* isAuthenticated can't block
-    // past the deadline. A fatal throw still propagates (rejects the monitor); the void-catch only
-    // guards the losing race arm. A timeout here is just the auth budget running out -> auth_timeout.
-    const check = hooks.isAuthenticated(page)
-    void check.catch(() => {})
-    let res: boolean
-    try {
-      res = await withTimeout(check, Math.max(0, authDeadline - Date.now()), 'auth check')
-    } catch (err) {
-      if (err instanceof TimeoutError) break
-      throw err
+  try {
+    while (Date.now() < authDeadline) {
+      // Bound each check by the remaining auth budget so a hang *inside* isAuthenticated can't block
+      // past the deadline. A fatal throw still propagates (rejects the monitor); the void-catch only
+      // guards the losing race arm. A timeout here is just the auth budget running out -> auth_timeout.
+      const check = hooks.isAuthenticated(page)
+      void check.catch(() => {})
+      let res: boolean
+      try {
+        res = await withTimeout(check, Math.max(0, authDeadline - Date.now()), 'auth check')
+      } catch (err) {
+        if (err instanceof TimeoutError) break
+        throw err
+      }
+      if (res) { authed = true; break }
+      await sleep(1_500)
     }
-    if (res) { authed = true; break }
-    await sleep(1_500)
+  } catch (err) {
+    // A fatal isAuthenticated throw aborts the session; close the wait before it leaves,
+    // or the row would stay `started` and read as a hang.
+    observeUrl()
+    await authWait?.finish('failed', { errorMessage: err instanceof Error ? err.message : String(err) })
+    throw err
   }
-  if (!authed) { log('auth_timeout'); return 'auth_timeout' }
+  if (!authed) {
+    log('auth_timeout')
+    observeUrl()
+    await authWait?.finish('failed', {
+      failureType: 'auth_timeout',
+      errorMessage: `not authenticated within ${authTimeoutMs}ms`,
+    })
+    return 'auth_timeout'
+  }
+  await authWait?.finish('success')
   log('authenticated')
   onAuthenticated?.()
 
@@ -112,6 +157,14 @@ export async function runMonitor(opts: RunMonitorOptions): Promise<MonitorStopRe
   if (context.lastExternalId) seen.add(String(context.lastExternalId))
   let currentDay = getBankDay()
   const runDeadline = maxRuntimeMs > 0 ? Date.now() + maxRuntimeMs : null
+
+  // Transitions only, and only the first of each. A steady-state poll writes no row —
+  // an eight-hour session at a 60s interval would otherwise leave ~480 of them, nearly
+  // all "nothing new", burying the rows worth searching for. A script that fails every
+  // poll for hours would do the same, so a recovered failure is recorded once too; the
+  // repetition is visible in the trail, which is bounded by design.
+  let recordedFirstPollSuccess = false
+  let recordedFirstPollFailure = false
 
   while (true) {
     if (await Promise.resolve(shouldStop())) { log('stop_requested'); return 'stop_requested' }
@@ -128,27 +181,56 @@ export async function runMonitor(opts: RunMonitorOptions): Promise<MonitorStopRe
     try {
       authRes = await withTimeout(authCall, 2 * pollIntervalMs, 'auth check')
     } catch (err) {
-      if (err instanceof TimeoutError) { log('watchdog_timeout'); return 'watchdog_timeout' }
+      if (err instanceof TimeoutError) {
+        log('watchdog_timeout')
+        // Attributed to `poll`: the liveness check is part of the poll cycle, and the
+        // stage vocabulary has no separate session-check stage.
+        await note('poll', 'failed', { failureType: 'watchdog_timeout', errorMessage: err.message })
+        return 'watchdog_timeout'
+      }
       throw err
     }
-    if (!authRes) { log('logged_out'); return 'logged_out' }
+    if (!authRes) {
+      log('logged_out')
+      await note('poll', 'failed', { failureType: 'logged_out', errorMessage: 'session was no longer authenticated' })
+      return 'logged_out'
+    }
 
     let batch: MonitorTransaction[]
     try {
       batch = await withTimeout(hooks.poll(page, context), 2 * pollIntervalMs, 'poll')
     } catch (err) {
-      if (err instanceof TimeoutError) { log('watchdog_timeout'); return 'watchdog_timeout' }
+      if (err instanceof TimeoutError) {
+        log('watchdog_timeout')
+        await note('poll', 'failed', { failureType: 'watchdog_timeout', errorMessage: err.message })
+        return 'watchdog_timeout'
+      }
       log('poll_failed', { error: err instanceof Error ? err.message : String(err) })
+      if (!recordedFirstPollFailure) {
+        recordedFirstPollFailure = true
+        await note('poll', 'failed', { errorMessage: err instanceof Error ? err.message : String(err) })
+      }
       if (hooks.keepAlive) {
         // The inner .catch makes a keepAlive *error* non-fatal (resolves undefined); only a *hang* trips the watchdog.
         try {
           await withTimeout(hooks.keepAlive(page).catch(() => {}), 2 * pollIntervalMs, 'keepAlive')
         } catch (kaErr) {
-          if (kaErr instanceof TimeoutError) { log('watchdog_timeout'); return 'watchdog_timeout' }
+          if (kaErr instanceof TimeoutError) {
+            log('watchdog_timeout')
+            await note('keep_alive', 'failed', { failureType: 'watchdog_timeout', errorMessage: kaErr.message })
+            return 'watchdog_timeout'
+          }
         }
       }
       await sleep(pollIntervalMs)
       continue
+    }
+
+    // One row for the first poll that worked: it is the transition that says the session
+    // reached steady state, which distinguishes "polling normally" from "never got there".
+    if (!recordedFirstPollSuccess) {
+      recordedFirstPollSuccess = true
+      await note('poll', 'success')
     }
 
     const fresh = batch.filter((t) => !seen.has(String(t.externalId)))
@@ -159,7 +241,11 @@ export async function runMonitor(opts: RunMonitorOptions): Promise<MonitorStopRe
       try {
         await withTimeout(hooks.keepAlive(page).catch(() => {}), 2 * pollIntervalMs, 'keepAlive')
       } catch (kaErr) {
-        if (kaErr instanceof TimeoutError) { log('watchdog_timeout'); return 'watchdog_timeout' }
+        if (kaErr instanceof TimeoutError) {
+          log('watchdog_timeout')
+          await note('keep_alive', 'failed', { failureType: 'watchdog_timeout', errorMessage: kaErr.message })
+          return 'watchdog_timeout'
+        }
       }
     }
 

--- a/src/shared/domain/scrapeStage.ts
+++ b/src/shared/domain/scrapeStage.ts
@@ -27,6 +27,27 @@ export type ScrapeStage = (typeof SCRAPE_STAGES)[number]
 export type StepStatus = 'started' | 'success' | 'failed'
 
 /**
+ * A stage that has been opened and not yet closed. Returned by `beginStage` for the one
+ * shape `stage()` cannot express: a stage whose outcome is a *return value* rather than a
+ * thrown error. The monitor's authentication wait is exactly that — it times out by
+ * falling out of a loop, which `stage()` would record as a success.
+ */
+export interface OpenStage {
+  finish(status: Exclude<StepStatus, 'started'>, outcome?: StageOutcome): Promise<void>
+}
+
+/**
+ * The failure detail a harness can attach to a stage it closes itself. Deliberately
+ * narrower than banking's StepOutcome: the harness has no stack for a failure nobody
+ * threw, and the recorder owns the timing.
+ */
+export interface StageOutcome {
+  failureType?: string
+  errorMessage?: string
+  url?: string
+}
+
+/**
  * What the harness needs in order to record a stage, expressed as the narrowest
  * possible surface so `script-engine` depends on a capability rather than on
  * `banking`'s recorder. ScrapeRunRecorder satisfies this.
@@ -36,6 +57,15 @@ export type StepStatus = 'started' | 'success' | 'failed'
  */
 export interface IStageRecorder extends ITrailSink {
   stage<T>(step: ScrapeStage, fn: () => Promise<T>): Promise<T>
+  /** Opens a stage the caller will close itself. See OpenStage. */
+  beginStage(step: ScrapeStage): OpenStage
+  /**
+   * Records a stage with no in-progress phase worth a row — a poll that failed, say.
+   * A poll writes no `started` row because a hung poll already trips the monitor's
+   * watchdog, which writes the failed row itself; two rows a minute per account would
+   * buy nothing.
+   */
+  note(step: ScrapeStage, status: Exclude<StepStatus, 'started'>, outcome?: StageOutcome): Promise<void>
   /**
    * Reports the page the browser is on. Synchronous and I/O-free — the harness calls
    * it at the moment of failure, and the recorder decides whether it ends up on a row.

--- a/tests/integration/banking/ScrapeRunRecorder.integration.test.ts
+++ b/tests/integration/banking/ScrapeRunRecorder.integration.test.ts
@@ -450,6 +450,62 @@ describe('ScrapeRunRecorder (integration)', () => {
     })
   })
 
+  describe('beginStage()', () => {
+    it('closes the row the caller opened, in place, with the outcome the caller decided', async () => {
+      // The monitor's authentication wait times out by falling out of a loop rather than
+      // by throwing, so stage() would record it as a success.
+      const runId = await newRun()
+      const rec = build(runId)
+
+      // beginStage returns synchronously — the caller is entering a wait, not awaiting a
+      // write — so poll for the in-progress row rather than assuming it has landed.
+      const wait = rec.beginStage('auth_wait')
+      for (let i = 0; i < 50 && (await steps(runId)).length === 0; i++) {
+        await new Promise((r) => setTimeout(r, 10))
+      }
+      expect((await steps(runId))[0]).toMatchObject({ step: 'auth_wait', status: 'started' })
+
+      await wait.finish('failed', { failureType: 'auth_timeout', errorMessage: 'not authenticated within 300000ms' })
+
+      const rows = await steps(runId)
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toMatchObject({
+        step: 'auth_wait', status: 'failed', failure_type: 'auth_timeout',
+        error_message: 'not authenticated within 300000ms',
+      })
+      expect(rows[0].duration_ms).not.toBeNull()
+    })
+
+    it('does not add a second row for a stage the caller already closed as failed', async () => {
+      // How a persistent session's authentication failure actually lands: the wait writes
+      // its own failed row, then the stop reason closes the run.
+      const runId = await newRun()
+      const rec = build(runId)
+      await rec.beginStage('auth_wait').finish('failed', { failureType: 'auth_timeout' })
+      await rec.fail(new Error('auth_timeout'), { failureType: 'auth_timeout', stopReason: 'auth_timeout' })
+
+      expect(await steps(runId)).toHaveLength(1)
+      const r = await run(runId)
+      expect(r.failure_type).toBe('auth_timeout')
+      expect(r.stop_reason).toBe('auth_timeout')
+    })
+  })
+
+  describe('a persistent session lifetime', () => {
+    it('records a clean stop as an uncounted success rather than zero transactions', async () => {
+      // A persistent session ingests continuously over a lifetime that can span days, so
+      // any single count would be a lie; NULL reads as "not counted", which is the truth.
+      const runId = await newRun()
+      await build(runId).succeed(null, 'stop_requested')
+
+      const r = await run(runId)
+      expect(r.status).toBe('success')
+      expect(r.transactions_found).toBeNull()
+      expect(r.stop_reason).toBe('stop_requested')
+      expect(r.duration_ms).not.toBeNull()
+    })
+  })
+
   describe('best-effort writes', () => {
     it('never propagates a diagnostics write failure out of stage()', async () => {
       const runId = await newRun()


### PR DESCRIPTION
Closes #157. Part of #153. Builds on #168 (merged).

## The problem

Persistent accounts had no execution history whatsoever — the scrape use case returns early
for them before creating a run row. **Both live bank scripts run this way**, so the accounts
that matter most were the ones with no record.

## The shape

`RecordedSessionLauncher` (new, `banking/application`) owns run identity for a session:
opens the row, hands a recorder to the launch, closes the row from however `done` settled.

**One row per session lifetime.** The monitor authenticates once then polls indefinitely, so
the session *is* the execution.

**Opened on the launch path and nowhere upstream.** `ensureRunning` no-ops on a live session
and the health-check calls it every ~75s — a row opened upstream would orphan a row a minute.

### Terminal mapping (`monitorStopOutcome.ts`)

| Monitor outcome | Status | Recorded as |
|---|---|---|
| `stop_requested`, `max_runtime` | success | stop reason only |
| `auth_timeout`, `logged_out`, `watchdog_timeout` | failed | matching category |
| `browser_closed`, `session_killed` | failed | matching category |
| harness failure before the script ran | failed | `launch_failed` / `script_load_failed` / `credentials_failed` |
| unrecognised crash | failed | no stop reason; category derived from the error |

A clean stop is a **success**, so restarts and shutdowns stay out of the failure list.
`stop_reason` stays a closed vocabulary — an arbitrary crash message belongs in
`error_message`. `bank_sessions` keeps sole ownership of per-account attention state.

### Step rows

- `login` wrapped; `auth_wait` **opened** rather than wrapped, because it ends by falling out
  of a loop on timeout — which `stage()` would record as a success. Entry and exit only, since
  an assisted login polls up to 200 times.
- `credentials` recorded in the composition root; `launch` and `load_script` in the runner.
- Polls bounded to **transitions**: the first that worked, the first that failed. Steady state
  writes nothing (~480 rows/shift otherwise), and a script failing every poll for hours writes
  one row, not one a minute. Session-ending failures write their own row, with a hung
  `keepAlive` attributed to `keep_alive` rather than `poll`.

## Two things worth your attention

1. **A new seam, against the epic's "exactly one new seam".** `RecordedSessionLauncher`
   exists because the alternative was putting run identity and terminal mapping inside
   `bankingModule`'s `startFn` — a composition root — where the stop-reason mapping would
   have been untestable. It moves logic *into* test coverage rather than adding surface;
   17 tests cover the mapping table directly.
2. **An ordering change.** Credentials are now fetched *after* the script is resolved,
   because the run row they record against needs the script id. A missing active script
   therefore throws before any row exists — mirroring the one-shot use case, which throws
   `NotFoundError` before `create()`. This flipped which error an existing composition-root
   test saw; the test was updated and a new one pins the "no row without a script" rule.

`succeed` and `markSuccess` now take `number | null`: a persistent session ingests
continuously over days, so any single count would be a lie. NULL reads as "not counted".

## Verification

- `pnpm typecheck` clean
- `pnpm test` — 1181 passed (154 files), 40 new
- `pnpm test:integration` — 224 passed (36 files)

## Heads-up on CI

CI has been failing on `main` since #164, four merges before any of my work (green at #147;
`test` and `audit` fail, `quality` and CodeQL pass). Not introduced here, and it reproduces
only in CI — all three commands above pass locally. Happy to take it as its own PR.
